### PR TITLE
Wrong target in CMake of Sphinx ?

### DIFF
--- a/src/cmake/geosxOptions.cmake
+++ b/src/cmake/geosxOptions.cmake
@@ -61,10 +61,10 @@ set(ATK_CMAKE "${ATK_DIR}/lib/cmake" CACHE PATH "")
 
 set( GEOSX_TPL_ROOT_DIR "../../thirdPartyLibs/" CACHE PATH "" )
 
-set(SPHINX_EXECUTABLE "sphinx-build" CACHE PATH "")
-include(cmake/blt/cmake/thirdparty/FindSphinx.cmake)
-message( "SPHINX_FOUND = ${SPHINX_FOUND}" )
-message( "SPHINX_EXECUTABLE = ${SPHINX_EXECUTABLE}" )
+#set(SPHINX_EXECUTABLE "sphinx-build" CACHE PATH "")
+#include(cmake/blt/cmake/thirdparty/FindSphinx.cmake)
+#message( "SPHINX_FOUND = ${SPHINX_FOUND}" )
+#message( "SPHINX_EXECUTABLE = ${SPHINX_EXECUTABLE}" )
 
 if(NOT BLT_CXX_STD STREQUAL c++14)
     MESSAGE(FATAL_ERROR "c++14 is NOT enabled. GEOSX requires c++14")

--- a/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
+++ b/src/cmake/thirdparty/SetupGeosxThirdParty.cmake
@@ -402,9 +402,9 @@ set( thirdPartyLibs ${thirdPartyLibs} trilinos )
 
 
 
-if (UNCRUSTIFY_EXECUTABLE)
-  include(cmake/blt/cmake/thirdparty/FindUncrustify.cmake)
-endif()
+#if (UNCRUSTIFY_EXECUTABLE)
+#  include(cmake/blt/cmake/thirdparty/FindUncrustify.cmake)
+#endif()
 message("UNCRUSTIFY_FOUND = ${UNCRUSTIFY_FOUND}")
 if(UNCRUSTIFY_FOUND)
     # targets for verifying formatting

--- a/src/docs/sphinx/CMakeLists.txt
+++ b/src/docs/sphinx/CMakeLists.txt
@@ -1,3 +1,3 @@
 if( ${SPHINX_FOUND} )
-  blt_add_sphinx_target( sphinx_docs )
+  blt_add_sphinx_target( geosx_docs )
 endif()


### PR DESCRIPTION
Hello,

I think the target is wrong in `src/docs/sphinx/CMakeLists.txt`

Indeed, the python script running CMake outputs an error with the default configuration

```
-- Creating sphinx docs target geosx_docs
CMake Error at cmake/blt/cmake/SetupDocs.cmake:152 (add_dependencies):
  Cannot add target-level dependencies to non-existent target "sphinx_docs".

  The add_dependencies works for top-level logical targets created by the
  add_executable, add_library, or add_custom_target commands.  If you want to
  add file-level dependencies see the DEPENDS option of the add_custom_target
  and add_custom_command commands.
Call Stack (most recent call first):
  docs/sphinx/CMakeLists.txt:2 (blt_add_sphinx_target)
```

I had a look on  cmake/blt/cmake/SetupDocs.cmake and found these lines

```
if(SPHINX_FOUND)
    add_custom_target(sphinx_docs)
    add_dependencies(docs sphinx_docs)
endif()
```

I have change the target `geosx_docs` by `sphinx_docs` in `src/docs/sphinx/CMakeLists.txt` and it seems to work.

Tell me if I am wrong !