### PR TITLE
Enabled colored output when using ninja

### DIFF
--- a/src/cmake/geosxOptions.cmake
+++ b/src/cmake/geosxOptions.cmake
@@ -86,6 +86,16 @@ blt_append_custom_compiler_flag( FLAGS_VAR CMAKE_CXX_FLAGS_DEBUG
                                  CLANG "-fstandalone-debug" 
                                 )
 
+blt_append_custom_compiler_flag(FLAGS_VAR GEOSX_NINJA_FLAGS
+                  DEFAULT     " "
+                  GNU         "-fdiagnostics-color=always"
+                  CLANG       "-fcolor-diagnostics"
+                  )
+
+if( ${CMAKE_MAKE_PROGRAM} STREQUAL "ninja" OR ${CMAKE_MAKE_PROGRAM} MATCHES ".*/ninja$" )
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${GEOSX_NINJA_FLAGS}")
+endif()
+
 if( CMAKE_HOST_APPLE )
     set(GEOSX_LINK_PREPEND_FLAG "-Wl,-force_load" CACHE PATH "" FORCE)
     set(GEOSX_LINK_POSTPEND_FLAG "" CACHE PATH "" FORCE)


### PR DESCRIPTION
When using `ninja` instead of `make` compilers won't write colored output, this fixes that.

https://github.com/ninja-build/ninja/wiki/FAQ 