### PR TITLE
InterObjectRelation method fix. 

### DIFF
--- a/src/coreComponents/mesh/InterObjectRelation.hpp
+++ b/src/coreComponents/mesh/InterObjectRelation.hpp
@@ -48,9 +48,9 @@ public:
 
   InterObjectRelation & operator=(const InterObjectRelation& copiedRelationship);
 
-  operator BASETYPE() const
+  operator BASETYPE*() const
   {
-    return static_cast<BASETYPE>(this);
+    return static_cast<BASETYPE*>(this);
   }
 
   /// equals operator that sets *this to a single value of any type


### PR DESCRIPTION
@rrsettgast , I'm not 100% sure on what this should be. But for the moment it fixes building on Cori. I will run the ATS test next. 

Prior to my changes, here is my error: 
  }In file included from GEOSX/src/coreComponents/fileIO/blueprint/Blueprint.cpp(23):
GEOSX/src/coreComponents/mesh/InterObjectRelation.hpp(52): error #597: "geosx::InterObjectRelation<BASETYPE>::operator geosx::array1d<geosx::set<geosx::localIndex={int_fast32_t={long}}>>() [with BASETYPE=geosx::array1d<geosx::set<geosx::localIndex={int_fast32_t={long}}>>]" will not be called for implicit or explicit conversions
    operator BASETYPE()