### PR TITLE
Missing header to propagate Caliper enablement

### DIFF
--- a/src/coreComponents/common/TimingMacros.hpp
+++ b/src/coreComponents/common/TimingMacros.hpp
@@ -19,6 +19,8 @@
 #ifndef SRC_COMPONENTS_CORE_SRC_COMMON_TIMING_MACROS_HPP_
 #define SRC_COMPONENTS_CORE_SRC_COMMON_TIMING_MACROS_HPP_
 
+#include "common/GeosxConfig.hpp"
+
 #ifdef GEOSX_USE_CALIPER
 #include <caliper/cali.h>
 


### PR DESCRIPTION
We were missing a header for the timer macros. This header should enable us to generate Caliper data across the code. 