### PR TITLE
modified cmake config to only compile external components that are present.

### DIFF
--- a/src/cmake/GeosxConfig.cmake
+++ b/src/cmake/GeosxConfig.cmake
@@ -22,8 +22,7 @@ set( PREPROCESSOR_DEFINES ARRAY_BOUNDS_CHECK
                           PYTHON
                           RAJA 
                           TRILINOS
-                          PVT_PACKAGE
-                          PAMELA )
+                          ${externalComponentsList} )
 
 foreach( DEP in ${PREPROCESSOR_DEFINES})
     if( ${DEP}_FOUND OR ENABLE_${DEP} )

--- a/src/cmake/geosxOptions.cmake
+++ b/src/cmake/geosxOptions.cmake
@@ -44,10 +44,6 @@ else()
   option(ENABLE_OPENMP     "Enables OpenMP compiler support" ON)
 endif()
 
-option( ENABLE_PVT_PACKAGE "Enables building with PVTPackage" ON )
-
-option( ENABLE_PAMELA "Enables building with PAMELA" ON )
-
 #set( BUILD_SHARED_LIBS ON CACHE PATH "" FORCE)
 #set( ENABLE_SHARED_LIBS ON CACHE PATH "" FORCE )
 

--- a/src/coreComponents/constitutive/CMakeLists.txt
+++ b/src/coreComponents/constitutive/CMakeLists.txt
@@ -23,7 +23,7 @@ set( constitutive_sources
 
 set( dependencyList dataRepository )
 
-if( ENABLE_PVT_PACKAGE )
+if( ENABLE_PVTPackage )
     set( constitutive_headers ${constitutive_headers} Fluid/CompositionalMultiphaseFluid.hpp )
     set( constitutive_sources ${constitutive_sources} Fluid/CompositionalMultiphaseFluid.cpp )
     set( dependencyList ${dependencyList} PVTPackage )

--- a/src/externalComponents/CMakeLists.txt
+++ b/src/externalComponents/CMakeLists.txt
@@ -2,14 +2,17 @@ message( "Entering /src/externalComponents/CMakeLists.txt")
 
 
 
-set(externalComponentsList "" )
+set(externalComponentsList "" CACHE STRING "" FORCE)
 
 file(GLOB children RELATIVE ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_CURRENT_LIST_DIR}/*)
 foreach(child ${children})
   if(IS_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/${child})
     if( EXISTS "${CMAKE_CURRENT_LIST_DIR}/${child}/CMakeLists.txt" )
       add_subdirectory(${child})
-      set(externalComponentsList ${externalComponentsList} ${child} )
+      set( ENABLE_${child} ON CACHE BOOL "" FORCE )
+      list( APPEND externalComponentsList ${child} )
+    else()
+      set( ENABLE_${child} OFF CACHE BOOL "" FORCE )
     endif()
   endif()
 endforeach()


### PR DESCRIPTION
sets ENABLE_${COMPONENT_NAME} if the component exists in externalComponents. 

This way if the user doesn't want to checkout the submodule, they do not have to.