### PR TITLE
Periodic event zero timestep bugfix

### DIFF
--- a/src/coreComponents/managers/Events/EventBase.cpp
+++ b/src/coreComponents/managers/Events/EventBase.cpp
@@ -263,7 +263,13 @@ void EventBase::Execute(real64 const time_n,
     Step(time_n, dt, cycleNumber, domain);
   }
 
-  lastTime = time_n;
+  // In some cases, a periodic event controlled by a time-frequency may trigger on a zero-dt step.
+  // This leads to ambiguity as to which cycle the event should execute on.
+  // To resolve this, only increment lastTime if dt=0, and cause the event to trigger on both.
+  if (dt > 0.0)
+  {
+    lastTime = time_n;
+  }
   lastCycle = cycleNumber;
 }
 

--- a/src/coreComponents/managers/Events/PeriodicEvent.cpp
+++ b/src/coreComponents/managers/Events/PeriodicEvent.cpp
@@ -114,7 +114,7 @@ void PeriodicEvent::EstimateEventTiming(real64 const time,
     else
     {
       real64 forecast = (timeFrequency - (time - lastTime)) / dt;
-      SetForecast(static_cast<integer>(std::min(forecast, 1e9)));
+      SetForecast(static_cast<integer>(std::min(std::max(forecast, 0.0), 1e9)));
     }
   }
   else


### PR DESCRIPTION
In some cases, a periodic event controlled by a time-frequency may trigger on a zero-dt step.  This leads to ambiguity as to which cycle the event should execute on.  To resolve this, only increment lastTime if dt=0, and cause the event to trigger on both.