### PR TITLE
CompositionalMultiphaseFlow: fix a bug in flux assembly

### DIFF
--- a/src/coreComponents/physicsSolvers/FiniteVolume/CompositionalMultiphaseFlow.cpp
+++ b/src/coreComponents/physicsSolvers/FiniteVolume/CompositionalMultiphaseFlow.cpp
@@ -1337,7 +1337,7 @@ void CompositionalMultiphaseFlow::AssembleFluxTerms( DomainPartition const * con
       // skip the phase flux if phase not present or immobile upstream
       if (std::fabs(mobility[k_up]) < 1e-20) // TODO better constant
       {
-        break;
+        continue;
       }
 
       // pressure gradient depends on all points in the stencil

--- a/src/coreComponents/physicsSolvers/integratedTests/compositionalMultiphaseFlow/1D_10cell_BO.xml
+++ b/src/coreComponents/physicsSolvers/integratedTests/compositionalMultiphaseFlow/1D_10cell_BO.xml
@@ -145,7 +145,7 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="1"
-               scale="0.3"/>
+               scale="0.399"/>
 
     <FieldSpecification name="initialComposition_water"
                initialCondition="1"
@@ -153,7 +153,7 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="2"
-               scale="0.1"/>
+               scale="0.001"/>
 
     <!-- Injection pressure: ~10 bar -->
 
@@ -208,14 +208,14 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="1"
-               scale="0.3"/>
+               scale="0.399"/>
 
     <FieldSpecification name="sinkTermComposition_water"
                setNames="sink"
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="2"
-               scale="0.1"/>
+               scale="0.001"/>
 
   </FieldSpecifications>
 

--- a/src/coreComponents/physicsSolvers/integratedTests/compositionalMultiphaseFlow/1D_10cell_DO.xml
+++ b/src/coreComponents/physicsSolvers/integratedTests/compositionalMultiphaseFlow/1D_10cell_DO.xml
@@ -145,7 +145,7 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="1"
-               scale="0.3"/>
+               scale="0.399"/>
 
     <FieldSpecification name="initialComposition_water"
                initialCondition="1"
@@ -153,7 +153,7 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="2"
-               scale="0.1"/>
+               scale="0.001"/>
 
     <!-- Injection pressure: ~10 bar -->
 
@@ -208,14 +208,14 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="1"
-               scale="0.3"/>
+               scale="0.399"/>
 
     <FieldSpecification name="sinkTermComposition_water"
                setNames="sink"
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="2"
-               scale="0.1"/>
+               scale="0.001"/>
 
   </FieldSpecifications>
 

--- a/src/coreComponents/physicsSolvers/integratedTests/compositionalMultiphaseFlow/1D_3cell_BO.xml
+++ b/src/coreComponents/physicsSolvers/integratedTests/compositionalMultiphaseFlow/1D_3cell_BO.xml
@@ -146,7 +146,7 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="1"
-               scale="0.3"/>
+               scale="0.399"/>
 
     <FieldSpecification name="initialComposition_water"
                initialCondition="1"
@@ -154,7 +154,7 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="2"
-               scale="0.1"/>
+               scale="0.001"/>
 
     <!-- Injection pressure: ~10 bar -->
 
@@ -209,14 +209,14 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="1"
-               scale="0.3"/>
+               scale="0.399"/>
 
     <FieldSpecification name="sinkTermComposition_water"
                setNames="sink"
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="2"
-               scale="0.1"/>
+               scale="0.001"/>
 
   </FieldSpecifications>
 

--- a/src/coreComponents/physicsSolvers/integratedTests/compositionalMultiphaseFlow/1D_3cell_DO.xml
+++ b/src/coreComponents/physicsSolvers/integratedTests/compositionalMultiphaseFlow/1D_3cell_DO.xml
@@ -146,7 +146,7 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="1"
-               scale="0.3"/>
+               scale="0.399"/>
 
     <FieldSpecification name="initialComposition_water"
                initialCondition="1"
@@ -154,7 +154,7 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="2"
-               scale="0.1"/>
+               scale="0.001"/>
 
     <!-- Injection pressure: ~10 bar -->
 
@@ -209,14 +209,14 @@
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="1"
-               scale="0.3"/>
+               scale="0.399"/>
 
     <FieldSpecification name="sinkTermComposition_water"
                setNames="sink"
                objectPath="ElementRegions/elementRegions/Region2/elementSubRegions/cb1"
                fieldName="globalCompFraction"
                component="2"
-               scale="0.1"/>
+               scale="0.001"/>
 
   </FieldSpecifications>
 


### PR DESCRIPTION
@rrsettgast @yue-2018 It was a pretty stupid bug. It only came up if you had an immobile phase (saturation below a threshold), which was not the case for compositional test. I must have added the `if` statement after I tested the code with black-oil inputs. There isn't an integrated test for them, because I'm not sure they are physically meaningful. I'll try to design one whenever I get time.