### PR TITLE
Restore missing timer variables in SolidMechanicsLagrangianFEM

### DIFF
--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
@@ -671,6 +671,9 @@ real64 SolidMechanicsLagrangianFEM::ExplicitStep( real64 const& time_n,
   MPI_Barrier(MPI_COMM_GEOSX);
   GEOSX_MARK_END("MPI_Barrier");
 
+  static real64 minTimes[10] = {1.0e9,1.0e9,1.0e9,1.0e9,1.0e9,1.0e9,1.0e9,1.0e9,1.0e9,1.0e9};
+  static real64 maxTimes[10] = {0.0};
+
   minTimes[0] = std::min( minTimes[0], t2-t1 );
   minTimes[1] = std::min( minTimes[1], t4-t3 );
   minTimes[2] = std::min( minTimes[2], tf-t0 );


### PR DESCRIPTION
In https://github.com/GEOSX/GEOSX/commit/bb9099c58d0477af21c82c4b56b85840c63dd37e#diff-f6af5a6a842e0fa7e3e7268d7f04bf62 some variables were removed as unused, but they are actually used with `-DENABLE_TIMERS=ON`