### PR TITLE
Make DofManager templated on LAI.

### DIFF
--- a/src/coreComponents/linearAlgebra/interfaces/PetscSparseMatrix.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/PetscSparseMatrix.cpp
@@ -746,4 +746,23 @@ Mat PetscSparseMatrix::getMat()
   return m_mat;
 }
 
+localIndex PetscSparseMatrix::localNonzeros() const
+{
+  PetscInt firstrow, lastrow;
+  MatGetOwnershipRange( m_mat, &firstrow, &lastrow );
+
+  PetscInt numEntries;
+  localIndex result = 0;
+
+  // loop over rows
+  for( PetscInt row = firstrow; row < lastrow; ++row )
+  {
+    MatGetRow( m_mat, row, &numEntries, nullptr, nullptr );
+    result += numEntries;
+    MatRestoreRow( m_mat, row, &numEntries, nullptr, nullptr );
+  }
+
+  return result;
+}
+
 } // end geosx namespace

--- a/src/coreComponents/linearAlgebra/interfaces/PetscSparseMatrix.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/PetscSparseMatrix.hpp
@@ -548,6 +548,11 @@ public:
   globalIndex iupper() const;
 
   /**
+   * @brief Returns the number of nonzeros in the local portion of the matrix
+   */
+  localIndex localNonzeros() const;
+
+  /**
    * @brief Returns the infinity norm of the matrix.
    */
   real64 normInf() const;

--- a/src/coreComponents/physicsSolvers/CoupledSolvers/HydrofractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/CoupledSolvers/HydrofractureSolver.cpp
@@ -42,7 +42,7 @@ using namespace dataRepository;
 using namespace constitutive;
 
 HydrofractureSolver::HydrofractureSolver( const std::string& name,
-                                      Group * const parent ):
+                                          Group * const parent ):
   SolverBase(name,parent),
   m_solidSolverName(),
   m_flowSolverName(),
@@ -83,7 +83,7 @@ void HydrofractureSolver::RegisterDataOnMesh( dataRepository::Group * const GEOS
 void HydrofractureSolver::ImplicitStepSetup( real64 const & time_n,
                                              real64 const & dt,
                                              DomainPartition * const domain,
-                                             DofManager & GEOSX_UNUSED_ARG( dofManager ),
+                                             DofManager<LAInterface> & GEOSX_UNUSED_ARG( dofManager ),
                                              ParallelMatrix & GEOSX_UNUSED_ARG( matrix ),
                                              ParallelVector & GEOSX_UNUSED_ARG( rhs ),
                                              ParallelVector & GEOSX_UNUSED_ARG( solution ) )
@@ -404,7 +404,7 @@ real64 HydrofractureSolver::ExplicitStep( real64 const& time_n,
 
 
 void HydrofractureSolver::SetupDofs( DomainPartition const * const domain,
-                                     DofManager & dofManager ) const
+                                     DofManager<LAInterface> & dofManager ) const
 {
   GEOSX_MARK_FUNCTION;
   m_solidSolver->SetupDofs( domain, dofManager );
@@ -412,11 +412,11 @@ void HydrofractureSolver::SetupDofs( DomainPartition const * const domain,
 
   dofManager.addCoupling( keys::TotalDisplacement,
                           FlowSolverBase::viewKeyStruct::pressureString,
-                          DofManager::Connectivity::Elem );
+                          DofConnectivity::Elem );
 }
 
 void HydrofractureSolver::SetupSystem( DomainPartition * const domain,
-                                       DofManager & GEOSX_UNUSED_ARG( dofManager ),
+                                       DofManager<LAInterface> & GEOSX_UNUSED_ARG( dofManager ),
                                        ParallelMatrix & GEOSX_UNUSED_ARG( matrix ),
                                        ParallelVector & GEOSX_UNUSED_ARG( rhs ),
                                        ParallelVector & GEOSX_UNUSED_ARG( solution ) )
@@ -522,7 +522,7 @@ void HydrofractureSolver::SetupSystem( DomainPartition * const domain,
 void HydrofractureSolver::AssembleSystem( real64 const time,
                                           real64 const dt,
                                           DomainPartition * const domain,
-                                          DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+                                          DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                                           ParallelMatrix & GEOSX_UNUSED_ARG( matrix ),
                                           ParallelVector & GEOSX_UNUSED_ARG( rhs ) )
 {
@@ -550,7 +550,7 @@ void HydrofractureSolver::AssembleSystem( real64 const time,
 void HydrofractureSolver::ApplyBoundaryConditions( real64 const time,
                                                    real64 const dt,
                                                    DomainPartition * const domain,
-                                                   DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+                                                   DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                                                    ParallelMatrix & GEOSX_UNUSED_ARG( matrix ),
                                                    ParallelVector & GEOSX_UNUSED_ARG( rhs ) )
 {
@@ -674,7 +674,7 @@ void HydrofractureSolver::ApplyBoundaryConditions( real64 const time,
 real64
 HydrofractureSolver::
 CalculateResidualNorm( DomainPartition const * const domain,
-                       DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+                       DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                        ParallelVector const & GEOSX_UNUSED_ARG( rhs ) )
 {
   GEOSX_MARK_FUNCTION;
@@ -896,7 +896,7 @@ AssembleFluidMassResidualDerivativeWrtDisplacement( DomainPartition const * cons
 }
 void
 HydrofractureSolver::
-ApplySystemSolution( DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+ApplySystemSolution( DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                      ParallelVector const & GEOSX_UNUSED_ARG( solution ),
                      real64 const scalingFactor,
                      DomainPartition * const domain )
@@ -1160,7 +1160,7 @@ void scale2x2System( int const use_scaling,
   }
 }
 
-void HydrofractureSolver::SolveSystem( DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+void HydrofractureSolver::SolveSystem( DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                                        ParallelMatrix & ,
                                        ParallelVector & ,
                                        ParallelVector &  )
@@ -1639,8 +1639,8 @@ void HydrofractureSolver::SolveSystem( DofManager const & GEOSX_UNUSED_ARG( dofM
 
 real64
 HydrofractureSolver::ScalingForSystemSolution( DomainPartition const * const domain,
-                                                 DofManager const & GEOSX_UNUSED_ARG( dofManager ),
-                                                 ParallelVector const & GEOSX_UNUSED_ARG( solution ) )
+                                               DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
+                                               ParallelVector const & GEOSX_UNUSED_ARG( solution ) )
 {
   return m_solidSolver->ScalingForSystemSolution( domain,
                                                   m_solidSolver->getDofManager(),

--- a/src/coreComponents/physicsSolvers/CoupledSolvers/HydrofractureSolver.hpp
+++ b/src/coreComponents/physicsSolvers/CoupledSolvers/HydrofractureSolver.hpp
@@ -48,10 +48,10 @@ public:
   virtual void RegisterDataOnMesh( dataRepository::Group * const MeshBodies ) override final;
 
   virtual void SetupDofs( DomainPartition const * const domain,
-                          DofManager & dofManager ) const override;
+                          DofManager<LAInterface> & dofManager ) const override;
 
   virtual void SetupSystem( DomainPartition * const domain,
-                            DofManager & dofManager,
+                            DofManager<LAInterface> & dofManager,
                             ParallelMatrix & matrix,
                             ParallelVector & rhs,
                             ParallelVector & solution ) override;
@@ -60,7 +60,7 @@ public:
   ImplicitStepSetup( real64 const & time_n,
                      real64 const & dt,
                      DomainPartition * const domain,
-                     DofManager & dofManager,
+                     DofManager<LAInterface> & dofManager,
                      ParallelMatrix & matrix,
                      ParallelVector & rhs,
                      ParallelVector & solution ) override final;
@@ -72,34 +72,34 @@ public:
   virtual void AssembleSystem( real64 const time,
                                real64 const dt,
                                DomainPartition * const domain,
-                               DofManager const & dofManager,
+                               DofManager<LAInterface> const & dofManager,
                                ParallelMatrix & matrix,
                                ParallelVector & rhs ) override;
 
   virtual void ApplyBoundaryConditions( real64 const time,
                                         real64 const dt,
                                         DomainPartition * const domain,
-                                        DofManager const & dofManager,
+                                        DofManager<LAInterface> const & dofManager,
                                         ParallelMatrix & matrix,
                                         ParallelVector & rhs ) override;
 
   virtual real64
   CalculateResidualNorm( DomainPartition const * const domain,
-                         DofManager const & dofManager,
+                         DofManager<LAInterface> const & dofManager,
                          ParallelVector const & rhs ) override;
 
-  virtual void SolveSystem( DofManager const & dofManager,
+  virtual void SolveSystem( DofManager<LAInterface> const & dofManager,
                             ParallelMatrix & matrix,
                             ParallelVector & rhs,
                             ParallelVector & solution ) override;
 
   virtual real64
   ScalingForSystemSolution( DomainPartition const * const domain,
-                            DofManager const & dofManager,
+                            DofManager<LAInterface> const & dofManager,
                             ParallelVector const & solution ) override;
 
   virtual void
-  ApplySystemSolution( DofManager const & dofManager,
+  ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor,
                        DomainPartition * const domain ) override;

--- a/src/coreComponents/physicsSolvers/CoupledSolvers/PoroelasticSolver.cpp
+++ b/src/coreComponents/physicsSolvers/CoupledSolvers/PoroelasticSolver.cpp
@@ -79,7 +79,7 @@ void PoroelasticSolver::RegisterDataOnMesh( dataRepository::Group * const MeshBo
 void PoroelasticSolver::ImplicitStepSetup( real64 const & GEOSX_UNUSED_ARG( time_n ),
                                            real64 const & GEOSX_UNUSED_ARG( dt ),
                                            DomainPartition * const domain,
-                                           DofManager & GEOSX_UNUSED_ARG( dofManager ),
+                                           DofManager<LAInterface> & GEOSX_UNUSED_ARG( dofManager ),
                                            ParallelMatrix & GEOSX_UNUSED_ARG( matrix ),
                                            ParallelVector & GEOSX_UNUSED_ARG( rhs ),
                                            ParallelVector & GEOSX_UNUSED_ARG( solution ) )

--- a/src/coreComponents/physicsSolvers/CoupledSolvers/PoroelasticSolver.hpp
+++ b/src/coreComponents/physicsSolvers/CoupledSolvers/PoroelasticSolver.hpp
@@ -44,7 +44,7 @@ public:
   ImplicitStepSetup( real64 const & time_n,
                      real64 const & dt,
                      DomainPartition * const domain,
-                     DofManager & dofManager,
+                     DofManager<LAInterface> & dofManager,
                      ParallelMatrix & matrix,
                      ParallelVector & rhs,
                      ParallelVector & solution ) override final;

--- a/src/coreComponents/physicsSolvers/CoupledSolvers/ReservoirSolver.cpp
+++ b/src/coreComponents/physicsSolvers/CoupledSolvers/ReservoirSolver.cpp
@@ -91,7 +91,7 @@ real64 ReservoirSolver::SolverStep( real64 const & time_n,
 void ReservoirSolver::ImplicitStepSetup( real64 const & time_n,
                                          real64 const & dt,
                                          DomainPartition * const domain,
-                                         DofManager & dofManager,
+                                         DofManager<LAInterface> & dofManager,
                                          ParallelMatrix & matrix,
                                          ParallelVector & rhs,
                                          ParallelVector & solution )
@@ -113,7 +113,7 @@ void ReservoirSolver::ImplicitStepSetup( real64 const & time_n,
 }
 
 void ReservoirSolver::SetupDofs( DomainPartition const * const domain,
-                                 DofManager & dofManager ) const
+                                 DofManager<LAInterface> & dofManager ) const
 {
   m_flowSolver->SetupDofs( domain, dofManager );
   m_wellSolver->SetupDofs( domain, dofManager );
@@ -122,7 +122,7 @@ void ReservoirSolver::SetupDofs( DomainPartition const * const domain,
 }
 
 void ReservoirSolver::SetupSystem( DomainPartition * const domain,
-                                   DofManager & dofManager,
+                                   DofManager<LAInterface> & dofManager,
                                    ParallelMatrix & matrix,
                                    ParallelVector & rhs,
                                    ParallelVector & solution )
@@ -227,7 +227,7 @@ void ReservoirSolver::SetupSystem( DomainPartition * const domain,
 void ReservoirSolver::AssembleSystem( real64 const time_n,
                                       real64 const dt,
                                       DomainPartition * const domain,
-                                      DofManager const & dofManager,
+                                      DofManager<LAInterface> const & dofManager,
                                       ParallelMatrix & matrix,
                                       ParallelVector & rhs )
 {
@@ -276,7 +276,7 @@ void ReservoirSolver::AssembleSystem( real64 const time_n,
 void ReservoirSolver::ApplyBoundaryConditions( real64 const time_n,
                                                real64 const dt,
                                                DomainPartition * const domain,
-                                               DofManager const & dofManager,
+                                               DofManager<LAInterface> const & dofManager,
                                                ParallelMatrix & matrix,
                                                ParallelVector & rhs )
 {
@@ -288,7 +288,7 @@ void ReservoirSolver::ApplyBoundaryConditions( real64 const time_n,
 }
 
 real64 ReservoirSolver::CalculateResidualNorm( DomainPartition const * const domain,
-                                               DofManager const & dofManager,
+                                               DofManager<LAInterface> const & dofManager,
                                                ParallelVector const & rhs )
 {
   // compute norm of reservoir equations residuals
@@ -300,7 +300,7 @@ real64 ReservoirSolver::CalculateResidualNorm( DomainPartition const * const dom
              + wellResidualNorm*wellResidualNorm );
 }
 
-void ReservoirSolver::SolveSystem( DofManager const & dofManager,
+void ReservoirSolver::SolveSystem( DofManager<LAInterface> const & dofManager,
                                    ParallelMatrix & matrix,
                                    ParallelVector & rhs,
                                    ParallelVector & solution )
@@ -319,7 +319,7 @@ void ReservoirSolver::SolveSystem( DofManager const & dofManager,
 }
 
 bool ReservoirSolver::CheckSystemSolution( DomainPartition const * const domain,
-                                           DofManager const & dofManager,
+                                           DofManager<LAInterface> const & dofManager,
                                            ParallelVector const & solution,
                                            real64 const scalingFactor )
 {
@@ -329,7 +329,7 @@ bool ReservoirSolver::CheckSystemSolution( DomainPartition const * const domain,
   return ( validReservoirSolution && validWellSolution );
 }
 
-void ReservoirSolver::ApplySystemSolution( DofManager const & dofManager,
+void ReservoirSolver::ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                                            ParallelVector const & solution,
                                            real64 const scalingFactor,
                                            DomainPartition * const domain )

--- a/src/coreComponents/physicsSolvers/CoupledSolvers/ReservoirSolver.hpp
+++ b/src/coreComponents/physicsSolvers/CoupledSolvers/ReservoirSolver.hpp
@@ -73,52 +73,52 @@ public:
   virtual void ImplicitStepSetup( real64 const & time_n,
                                   real64 const & dt,
                                   DomainPartition * const domain,
-                                  DofManager & dofManager,
+                                  DofManager<LAInterface> & dofManager,
                                   ParallelMatrix & matrix,
                                   ParallelVector & rhs,
                                   ParallelVector & solution ) override final;
 
   virtual void SetupSystem( DomainPartition * const domain,
-                            DofManager & dofManager,
+                            DofManager<LAInterface> & dofManager,
                             ParallelMatrix & matrix,
                             ParallelVector & rhs,
                             ParallelVector & solution ) override;
 
   virtual void SetupDofs( DomainPartition const * const domain,
-                          DofManager & dofManager ) const override;
+                          DofManager<LAInterface> & dofManager ) const override;
 
   virtual void AssembleSystem( real64 const time,
                                real64 const dt,
                                DomainPartition * const domain,
-                               DofManager const & dofManager,
+                               DofManager<LAInterface> const & dofManager,
                                ParallelMatrix & matrix,
                                ParallelVector & rhs ) override;
 
   virtual void ApplyBoundaryConditions( real64 const time,
                                         real64 const dt,
                                         DomainPartition * const domain,
-                                        DofManager const & dofManager,
+                                        DofManager<LAInterface> const & dofManager,
                                         ParallelMatrix & matrix,
                                         ParallelVector & rhs ) override;
 
   virtual real64
   CalculateResidualNorm( DomainPartition const * const domain,
-                         DofManager const & dofManager,
+                         DofManager<LAInterface> const & dofManager,
                          ParallelVector const & rhs ) override;
 
-  virtual void SolveSystem( DofManager const & dofManager,
+  virtual void SolveSystem( DofManager<LAInterface> const & dofManager,
                             ParallelMatrix & matrix,
                             ParallelVector & rhs,
                             ParallelVector & solution ) override;
 
   virtual bool
   CheckSystemSolution( DomainPartition const * const domain,
-                       DofManager const & dofManager,
+                       DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor ) override;
 
   virtual void
-  ApplySystemSolution( DofManager const & dofManager,
+  ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor,
                        DomainPartition * const domain ) override;

--- a/src/coreComponents/physicsSolvers/FiniteVolume/CompositionalMultiphaseFlow.cpp
+++ b/src/coreComponents/physicsSolvers/FiniteVolume/CompositionalMultiphaseFlow.cpp
@@ -663,7 +663,7 @@ void
 CompositionalMultiphaseFlow::ImplicitStepSetup( real64 const & GEOSX_UNUSED_ARG( time_n ),
                                                 real64 const & GEOSX_UNUSED_ARG( dt ),
                                                 DomainPartition * const domain,
-                                                DofManager & dofManager,
+                                                DofManager<LAInterface> & dofManager,
                                                 ParallelMatrix & matrix,
                                                 ParallelVector & rhs,
                                                 ParallelVector & solution )
@@ -685,11 +685,11 @@ CompositionalMultiphaseFlow::ImplicitStepSetup( real64 const & GEOSX_UNUSED_ARG(
 }
 
 void CompositionalMultiphaseFlow::SetupDofs( DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
-                                             DofManager & dofManager ) const
+                                             DofManager<LAInterface> & dofManager ) const
 {
   dofManager.addField( viewKeyStruct::dofFieldString,
-                       DofManager::Location::Elem,
-                       DofManager::Connectivity::Face,
+                       DofLocation::Elem,
+                       DofConnectivity::Face,
                        m_numDofPerCell,
                        m_targetRegions );
 }
@@ -697,7 +697,7 @@ void CompositionalMultiphaseFlow::SetupDofs( DomainPartition const * const GEOSX
 void CompositionalMultiphaseFlow::AssembleSystem( real64 const time_n,
                                                   real64 const dt,
                                                   DomainPartition * const domain,
-                                                  DofManager const & dofManager,
+                                                  DofManager<LAInterface> const & dofManager,
                                                   ParallelMatrix & matrix,
                                                   ParallelVector & rhs )
 {
@@ -750,7 +750,7 @@ void CompositionalMultiphaseFlow::AssembleSystem( real64 const time_n,
 void CompositionalMultiphaseFlow::AssembleAccumulationTerms( real64 const GEOSX_UNUSED_ARG( time_n ),
                                                              real64 const GEOSX_UNUSED_ARG( dt ),
                                                              DomainPartition const * const domain,
-                                                             DofManager const * const dofManager,
+                                                             DofManager<LAInterface> const * const dofManager,
                                                              ParallelMatrix * const matrix,
                                                              ParallelVector * const rhs )
 {
@@ -852,7 +852,7 @@ void CompositionalMultiphaseFlow::AssembleAccumulationTerms( real64 const GEOSX_
 void CompositionalMultiphaseFlow::AssembleFluxTerms( real64 const GEOSX_UNUSED_ARG( time_n ),
                                                      real64 const dt,
                                                      DomainPartition const * const domain,
-                                                     DofManager const * const dofManager,
+                                                     DofManager<LAInterface> const * const dofManager,
                                                      ParallelMatrix * const matrix,
                                                      ParallelVector * const rhs )
 {
@@ -1003,7 +1003,7 @@ void CompositionalMultiphaseFlow::AssembleFluxTerms( real64 const GEOSX_UNUSED_A
 void CompositionalMultiphaseFlow::AssembleVolumeBalanceTerms( real64 const GEOSX_UNUSED_ARG( time_n ),
                                                               real64 const GEOSX_UNUSED_ARG( dt ),
                                                               DomainPartition const * const domain,
-                                                              DofManager const * const dofManager,
+                                                              DofManager<LAInterface> const * const dofManager,
                                                               ParallelMatrix * const matrix,
                                                               ParallelVector * const rhs )
 {
@@ -1084,7 +1084,7 @@ void CompositionalMultiphaseFlow::AssembleVolumeBalanceTerms( real64 const GEOSX
 void CompositionalMultiphaseFlow::ApplyBoundaryConditions( real64 const time_n,
                                                            real64 const dt,
                                                            DomainPartition * const domain,
-                                                           DofManager const & dofManager,
+                                                           DofManager<LAInterface> const & dofManager,
                                                            ParallelMatrix & matrix,
                                                            ParallelVector & rhs )
 {
@@ -1128,7 +1128,7 @@ void CompositionalMultiphaseFlow::ApplyBoundaryConditions( real64 const time_n,
 void
 CompositionalMultiphaseFlow::ApplyDirichletBC_implicit( real64 const time,
                                                         real64 const dt,
-                                                        DofManager const * const dofManager,
+                                                        DofManager<LAInterface> const * const dofManager,
                                                         DomainPartition * const domain,
                                                         ParallelMatrix * const matrix,
                                                         ParallelVector * const rhs )
@@ -1276,7 +1276,7 @@ CompositionalMultiphaseFlow::ApplyDirichletBC_implicit( real64 const time,
 
 real64
 CompositionalMultiphaseFlow::CalculateResidualNorm( DomainPartition const * const domain,
-                                                    DofManager const & dofManager,
+                                                    DofManager<LAInterface> const & dofManager,
                                                     ParallelVector const & rhs )
 {
   MeshLevel const * const mesh = domain->getMeshBody(0)->getMeshLevel(0);
@@ -1319,7 +1319,7 @@ CompositionalMultiphaseFlow::CalculateResidualNorm( DomainPartition const * cons
   return sqrt( globalResidualNorm );
 }
 
-void CompositionalMultiphaseFlow::SolveSystem( DofManager const & dofManager,
+void CompositionalMultiphaseFlow::SolveSystem( DofManager<LAInterface> const & dofManager,
                                                ParallelMatrix & matrix,
                                                ParallelVector & rhs,
                                                ParallelVector & solution )
@@ -1341,7 +1341,7 @@ void CompositionalMultiphaseFlow::SolveSystem( DofManager const & dofManager,
 
 bool
 CompositionalMultiphaseFlow::CheckSystemSolution( DomainPartition const * const domain,
-                                                  DofManager const & dofManager,
+                                                  DofManager<LAInterface> const & dofManager,
                                                   ParallelVector const & solution,
                                                   real64 const scalingFactor )
 {
@@ -1398,7 +1398,7 @@ CompositionalMultiphaseFlow::CheckSystemSolution( DomainPartition const * const 
 }
 
 void
-CompositionalMultiphaseFlow::ApplySystemSolution( DofManager const & dofManager,
+CompositionalMultiphaseFlow::ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                                                   ParallelVector const & solution,
                                                   real64 const scalingFactor,
                                                   DomainPartition * const domain )

--- a/src/coreComponents/physicsSolvers/FiniteVolume/CompositionalMultiphaseFlow.hpp
+++ b/src/coreComponents/physicsSolvers/FiniteVolume/CompositionalMultiphaseFlow.hpp
@@ -106,20 +106,20 @@ public:
   ImplicitStepSetup( real64 const & time_n,
                      real64 const & dt,
                      DomainPartition * const domain,
-                     DofManager & dofManager,
+                     DofManager<LAInterface> & dofManager,
                      ParallelMatrix & matrix,
                      ParallelVector & rhs,
                      ParallelVector & solution ) override;
 
   virtual void
   SetupDofs( DomainPartition const * const domain,
-             DofManager & dofManager ) const override;
+             DofManager<LAInterface> & dofManager ) const override;
 
   virtual void
   AssembleSystem( real64 const time_n,
                   real64 const dt,
                   DomainPartition * const domain,
-                  DofManager const & dofManager,
+                  DofManager<LAInterface> const & dofManager,
                   ParallelMatrix & matrix,
                   ParallelVector & rhs ) override;
 
@@ -127,29 +127,29 @@ public:
   ApplyBoundaryConditions( real64 const time_n,
                            real64 const dt,
                            DomainPartition * const domain,
-                           DofManager const & dofManager,
+                           DofManager<LAInterface> const & dofManager,
                            ParallelMatrix & matrix,
                            ParallelVector & rhs ) override;
 
   virtual real64
   CalculateResidualNorm( DomainPartition const * const domain,
-                         DofManager const & dofManager,
+                         DofManager<LAInterface> const & dofManager,
                          ParallelVector const & rhs ) override;
 
   virtual void
-  SolveSystem( DofManager const & dofManager,
+  SolveSystem( DofManager<LAInterface> const & dofManager,
                ParallelMatrix & matrix,
                ParallelVector & rhs,
                ParallelVector & solution ) override;
 
   virtual bool
   CheckSystemSolution( DomainPartition const * const domain,
-                       DofManager const & dofManager,
+                       DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor ) override;
 
   virtual void
-  ApplySystemSolution( DofManager const & dofManager,
+  ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor,
                        DomainPartition * const domain ) override;
@@ -255,7 +255,7 @@ public:
   void AssembleAccumulationTerms( real64 const time_n,
                                   real64 const dt,
                                   DomainPartition const * const domain,
-                                  DofManager const * const dofManager,
+                                  DofManager<LAInterface> const * const dofManager,
                                   ParallelMatrix * const matrix,
                                   ParallelVector * const rhs );
 
@@ -271,7 +271,7 @@ public:
   void AssembleFluxTerms( real64 const time_n,
                           real64 const dt,
                           DomainPartition const * const domain,
-                          DofManager const * const dofManager,
+                          DofManager<LAInterface> const * const dofManager,
                           ParallelMatrix * const matrix,
                           ParallelVector * const rhs );
 
@@ -287,7 +287,7 @@ public:
   void AssembleVolumeBalanceTerms( real64 const time_n,
                                    real64 const dt,
                                    DomainPartition const * const domain,
-                                   DofManager const * const dofManager,
+                                   DofManager<LAInterface> const * const dofManager,
                                    ParallelMatrix * const matrix,
                                    ParallelVector * const rhs );
 
@@ -440,7 +440,7 @@ private:
    */
   void ApplyDirichletBC_implicit( real64 const time,
                                   real64 const dt,
-                                  DofManager const * const dofManager,
+                                  DofManager<LAInterface> const * const dofManager,
                                   DomainPartition * const domain,
                                   ParallelMatrix * const matrix,
                                   ParallelVector * const rhs );

--- a/src/coreComponents/physicsSolvers/FiniteVolume/SinglePhaseFlow.cpp
+++ b/src/coreComponents/physicsSolvers/FiniteVolume/SinglePhaseFlow.cpp
@@ -278,7 +278,7 @@ real64 SinglePhaseFlow::SolverStep( real64 const& time_n,
 void SinglePhaseFlow::ImplicitStepSetup( real64 const & GEOSX_UNUSED_ARG( time_n ),
                                          real64 const & GEOSX_UNUSED_ARG( dt ),
                                          DomainPartition * const domain,
-                                         DofManager & GEOSX_UNUSED_ARG( dofManager ),
+                                         DofManager<LAInterface> & GEOSX_UNUSED_ARG( dofManager ),
                                          ParallelMatrix & GEOSX_UNUSED_ARG( matrix ),
                                          ParallelVector & GEOSX_UNUSED_ARG( rhs ),
                                          ParallelVector & GEOSX_UNUSED_ARG( solution ) )
@@ -358,18 +358,18 @@ void SinglePhaseFlow::ImplicitStepComplete( real64 const & GEOSX_UNUSED_ARG( tim
 }
 
 void SinglePhaseFlow::SetupDofs( DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
-                                 DofManager & dofManager ) const
+                                 DofManager<LAInterface> & dofManager ) const
 {
   dofManager.addField( viewKeyStruct::pressureString,
-                       DofManager::Location::Elem,
-                       DofManager::Connectivity::Face,
+                       DofLocation::Elem,
+                       DofConnectivity::Face,
                        m_targetRegions );
 }
 
 void SinglePhaseFlow::AssembleSystem( real64 const time_n,
                                       real64 const dt,
                                       DomainPartition * const domain,
-                                      DofManager const & dofManager,
+                                      DofManager<LAInterface> const & dofManager,
                                       ParallelMatrix & matrix,
                                       ParallelVector & rhs )
 {
@@ -430,7 +430,7 @@ template< bool ISPORO >
 void SinglePhaseFlow::AccumulationLaunch( localIndex const er,
                                           localIndex const esr,
                                           CellElementSubRegion const * const subRegion,
-                                          DofManager const * const dofManager,
+                                          DofManager<LAInterface> const * const dofManager,
                                           ParallelMatrix * const matrix,
                                           ParallelVector * const rhs )
 {
@@ -495,7 +495,7 @@ template< bool ISPORO >
 void SinglePhaseFlow::AccumulationLaunch( localIndex const er,
                                           localIndex const esr,
                                           FaceElementSubRegion const * const subRegion,
-                                          DofManager const * const dofManager,
+                                          DofManager<LAInterface> const * const dofManager,
                                           ParallelMatrix * const matrix,
                                           ParallelVector * const rhs )
 {
@@ -534,7 +534,7 @@ void SinglePhaseFlow::AccumulationLaunch( localIndex const er,
 
 template< bool ISPORO >
 void SinglePhaseFlow::AssembleAccumulationTerms( DomainPartition const * const domain,
-                                                 DofManager const * const dofManager,
+                                                 DofManager<LAInterface> const * const dofManager,
                                                  ParallelMatrix * const matrix,
                                                  ParallelVector * const rhs )
 {
@@ -560,7 +560,7 @@ void SinglePhaseFlow::AssembleAccumulationTerms( DomainPartition const * const d
 void SinglePhaseFlow::AssembleFluxTerms( real64 const GEOSX_UNUSED_ARG( time_n ),
                                          real64 const dt,
                                          DomainPartition const * const domain,
-                                         DofManager const * const dofManager,
+                                         DofManager<LAInterface> const * const dofManager,
                                          ParallelMatrix * const matrix,
                                          ParallelVector * const rhs )
 {
@@ -628,7 +628,7 @@ void
 SinglePhaseFlow::ApplyBoundaryConditions( real64 const time_n,
                                           real64 const dt,
                                           DomainPartition * const domain,
-                                          DofManager const & dofManager,
+                                          DofManager<LAInterface> const & dofManager,
                                           ParallelMatrix & matrix,
                                           ParallelVector & rhs )
 {
@@ -748,7 +748,7 @@ SinglePhaseFlow::ApplyBoundaryConditions( real64 const time_n,
 
 void SinglePhaseFlow::ApplyFaceDirichletBC_implicit( real64 const time_n,
                                                      real64 const dt,
-                                                     DofManager const * const dofManager,
+                                                     DofManager<LAInterface> const * const dofManager,
                                                      DomainPartition * const domain,
                                                      ParallelMatrix * const matrix,
                                                      ParallelVector * const rhs )
@@ -1021,7 +1021,7 @@ void SinglePhaseFlow::ApplyFaceDirichletBC_implicit( real64 const time_n,
 }
 
 real64 SinglePhaseFlow::CalculateResidualNorm( DomainPartition const * const domain,
-                                               DofManager const & dofManager,
+                                               DofManager<LAInterface> const & dofManager,
                                                ParallelVector const & rhs )
 {
   MeshLevel const * const mesh = domain->getMeshBody(0)->getMeshLevel(0);
@@ -1065,7 +1065,7 @@ real64 SinglePhaseFlow::CalculateResidualNorm( DomainPartition const * const dom
   return sqrt(globalResidualNorm);
 }
 
-void SinglePhaseFlow::ApplySystemSolution( DofManager const & dofManager,
+void SinglePhaseFlow::ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                                            ParallelVector const & solution,
                                            real64 const scalingFactor,
                                            DomainPartition * const domain )
@@ -1098,7 +1098,7 @@ void SinglePhaseFlow::ApplySystemSolution( DofManager const & dofManager,
   } );
 }
 
-void SinglePhaseFlow::SolveSystem( DofManager const & dofManager,
+void SinglePhaseFlow::SolveSystem( DofManager<LAInterface> const & dofManager,
                                    ParallelMatrix & matrix,
                                    ParallelVector & rhs,
                                    ParallelVector & solution )

--- a/src/coreComponents/physicsSolvers/FiniteVolume/SinglePhaseFlow.hpp
+++ b/src/coreComponents/physicsSolvers/FiniteVolume/SinglePhaseFlow.hpp
@@ -98,20 +98,20 @@ public:
   ImplicitStepSetup( real64 const & time_n,
                      real64 const & dt,
                      DomainPartition * const domain,
-                     DofManager & dofManager,
+                     DofManager<LAInterface> & dofManager,
                      ParallelMatrix & matrix,
                      ParallelVector & rhs,
                      ParallelVector & solution ) override;
 
   virtual void
   SetupDofs( DomainPartition const * const domain,
-             DofManager & dofManager ) const override;
+             DofManager<LAInterface> & dofManager ) const override;
 
   virtual void
   AssembleSystem( real64 const time_n,
                   real64 const dt,
                   DomainPartition * const domain,
-                  DofManager const & dofManager,
+                  DofManager<LAInterface> const & dofManager,
                   ParallelMatrix & matrix,
                   ParallelVector & rhs ) override;
 
@@ -119,23 +119,23 @@ public:
   ApplyBoundaryConditions( real64 const time_n,
                            real64 const dt,
                            DomainPartition * const domain,
-                           DofManager const & dofManager,
+                           DofManager<LAInterface> const & dofManager,
                            ParallelMatrix & matrix,
                            ParallelVector & rhs ) override;
 
   virtual real64
   CalculateResidualNorm( DomainPartition const * const domain,
-                         DofManager const & dofManager,
+                         DofManager<LAInterface> const & dofManager,
                          ParallelVector const & rhs ) override;
 
   virtual void
-  SolveSystem( DofManager const & dofManager,
+  SolveSystem( DofManager<LAInterface> const & dofManager,
                ParallelMatrix & matrix,
                ParallelVector & rhs,
                ParallelVector & solution ) override;
 
   virtual void
-  ApplySystemSolution( DofManager const & dofManager,
+  ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor,
                        DomainPartition * const domain ) override;
@@ -152,7 +152,7 @@ public:
   void AccumulationLaunch( localIndex const er,
                            localIndex const esr,
                            CellElementSubRegion const * const subRegion,
-                           DofManager const * const dofManager,
+                           DofManager<LAInterface> const * const dofManager,
                            ParallelMatrix * const matrix,
                            ParallelVector * const rhs );
 
@@ -160,7 +160,7 @@ public:
   void AccumulationLaunch( localIndex const er,
                            localIndex const esr,
                            FaceElementSubRegion const * const subRegion,
-                           DofManager const * const dofManager,
+                           DofManager<LAInterface> const * const dofManager,
                            ParallelMatrix * const matrix,
                            ParallelVector * const rhs );
 
@@ -176,7 +176,7 @@ public:
    */
   template< bool ISPORO >
   void AssembleAccumulationTerms( DomainPartition const * const domain,
-                                  DofManager const * const dofManager,
+                                  DofManager<LAInterface> const * const dofManager,
                                   ParallelMatrix * const matrix,
                                   ParallelVector * const rhs );
 
@@ -192,7 +192,7 @@ public:
   void AssembleFluxTerms( real64 const time_n,
                           real64 const dt,
                           DomainPartition const * const domain,
-                          DofManager const * const dofManager,
+                          DofManager<LAInterface> const * const dofManager,
                           ParallelMatrix * const matrix,
                           ParallelVector * const rhs );
 
@@ -272,7 +272,7 @@ private:
    */
   void ApplyFaceDirichletBC_implicit( real64 const time_n,
                                       real64 const dt,
-                                      DofManager const * const dofManager,
+                                      DofManager<LAInterface> const * const dofManager,
                                       DomainPartition * const domain,
                                       ParallelMatrix * const matrix,
                                       ParallelVector * const rhs );

--- a/src/coreComponents/physicsSolvers/SimpleSolvers/LaplaceFEM.cpp
+++ b/src/coreComponents/physicsSolvers/SimpleSolvers/LaplaceFEM.cpp
@@ -144,7 +144,7 @@ real64 LaplaceFEM::ExplicitStep( real64 const& GEOSX_UNUSED_ARG( time_n ),
 void LaplaceFEM::ImplicitStepSetup( real64 const & GEOSX_UNUSED_ARG( time_n ),
                                     real64 const & GEOSX_UNUSED_ARG( dt ),
                                     DomainPartition * const domain,
-                                    DofManager & dofManager,
+                                    DofManager<LAInterface> & dofManager,
                                     ParallelMatrix & matrix,
                                     ParallelVector & rhs,
                                     ParallelVector & solution )
@@ -160,17 +160,17 @@ void LaplaceFEM::ImplicitStepComplete( real64 const & GEOSX_UNUSED_ARG( time_n )
 }
 
 void LaplaceFEM::SetupDofs( DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
-                            DofManager & dofManager ) const
+                            DofManager<LAInterface> & dofManager ) const
 {
   dofManager.addField( m_fieldName,
-                       DofManager::Location::Node,
-                       DofManager::Connectivity::Elem );
+                       DofLocation::Node,
+                       DofConnectivity::Elem );
 }
 
 void LaplaceFEM::AssembleSystem( real64 const time_n,
                                  real64 const GEOSX_UNUSED_ARG( dt ),
                                  DomainPartition * const domain,
-                                 DofManager const & dofManager,
+                                 DofManager<LAInterface> const & dofManager,
                                  ParallelMatrix & matrix,
                                  ParallelVector & rhs )
 {
@@ -280,7 +280,7 @@ void LaplaceFEM::AssembleSystem( real64 const time_n,
   }
 }
 
-void LaplaceFEM::ApplySystemSolution( DofManager const & dofManager,
+void LaplaceFEM::ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                                       ParallelVector const & solution,
                                       real64 const scalingFactor,
                                       DomainPartition * const domain )
@@ -302,7 +302,7 @@ void LaplaceFEM::ApplySystemSolution( DofManager const & dofManager,
 void LaplaceFEM::ApplyBoundaryConditions( real64 const time_n,
                                           real64 const dt,
                                           DomainPartition * const domain,
-                                          DofManager const & dofManager,
+                                          DofManager<LAInterface> const & dofManager,
                                           ParallelMatrix & matrix,
                                           ParallelVector & rhs )
 {
@@ -334,7 +334,7 @@ void LaplaceFEM::ApplyBoundaryConditions( real64 const time_n,
   }
 }
 
-void LaplaceFEM::SolveSystem( DofManager const & dofManager,
+void LaplaceFEM::SolveSystem( DofManager<LAInterface> const & dofManager,
                               ParallelMatrix & matrix,
                               ParallelVector & rhs,
                               ParallelVector & solution )
@@ -353,7 +353,7 @@ void LaplaceFEM::SolveSystem( DofManager const & dofManager,
 }
 
 void LaplaceFEM::ApplyDirichletBC_implicit( real64 const time,
-                                            DofManager const & dofManager,
+                                            DofManager<LAInterface> const & dofManager,
                                             DomainPartition & domain,
                                             ParallelMatrix & matrix,
                                             ParallelVector & rhs )

--- a/src/coreComponents/physicsSolvers/SimpleSolvers/LaplaceFEM.hpp
+++ b/src/coreComponents/physicsSolvers/SimpleSolvers/LaplaceFEM.hpp
@@ -70,20 +70,20 @@ public:
   ImplicitStepSetup( real64 const & time_n,
                      real64 const & dt,
                      DomainPartition * const domain,
-                     DofManager & dofManager,
+                     DofManager<LAInterface> & dofManager,
                      ParallelMatrix & matrix,
                      ParallelVector & rhs,
                      ParallelVector & solution ) override;
 
   virtual void
   SetupDofs( DomainPartition const * const domain,
-             DofManager & dofManager ) const override;
+             DofManager<LAInterface> & dofManager ) const override;
 
   virtual void
   AssembleSystem( real64 const time,
                   real64 const dt,
                   DomainPartition * const domain,
-                  DofManager const & dofManager,
+                  DofManager<LAInterface> const & dofManager,
                   ParallelMatrix & matrix,
                   ParallelVector & rhs ) override;
 
@@ -91,18 +91,18 @@ public:
   ApplyBoundaryConditions( real64 const time,
                            real64 const dt,
                            DomainPartition * const domain,
-                           DofManager const & dofManager,
+                           DofManager<LAInterface> const & dofManager,
                            ParallelMatrix & matrix,
                            ParallelVector & rhs ) override;
 
   virtual void
-  SolveSystem( DofManager const & dofManager,
+  SolveSystem( DofManager<LAInterface> const & dofManager,
                ParallelMatrix & matrix,
                ParallelVector & rhs,
                ParallelVector & solution ) override;
 
   virtual void
-  ApplySystemSolution( DofManager const & dofManager,
+  ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor,
                        DomainPartition * const domain ) override;
@@ -118,7 +118,7 @@ public:
   /**@}*/
 
   void ApplyDirichletBC_implicit( real64 const time,
-                                  DofManager const & dofManager,
+                                  DofManager<LAInterface> const & dofManager,
                                   DomainPartition & domain,
                                   ParallelMatrix & matrix,
                                   ParallelVector & rhs );

--- a/src/coreComponents/physicsSolvers/SolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.cpp
@@ -214,7 +214,7 @@ real64 SolverBase::LinearImplicitStep( real64 const & time_n,
                                        real64 const & dt,
                                        integer const GEOSX_UNUSED_ARG( cycleNumber ),
                                        DomainPartition * const domain,
-                                       DofManager & dofManager,
+                                       DofManager<LAInterface> & dofManager,
                                        ParallelMatrix & matrix,
                                        ParallelVector & rhs,
                                        ParallelVector & solution )
@@ -245,7 +245,7 @@ bool SolverBase::LineSearch( real64 const & time_n,
                              real64 const & dt,
                              integer const GEOSX_UNUSED_ARG( cycleNumber ),
                              DomainPartition * const domain,
-                             DofManager const & dofManager,
+                             DofManager<LAInterface> const & dofManager,
                              ParallelMatrix & matrix,
                              ParallelVector & rhs,
                              ParallelVector const & solution,
@@ -317,7 +317,7 @@ real64 SolverBase::NonlinearImplicitStep( real64 const & time_n,
                                           real64 const & dt,
                                           integer const cycleNumber,
                                           DomainPartition * const domain,
-                                          DofManager const & dofManager,
+                                          DofManager<LAInterface> const & dofManager,
                                           ParallelMatrix & matrix,
                                           ParallelVector & rhs,
                                           ParallelVector & solution )
@@ -455,7 +455,7 @@ real64 SolverBase::ExplicitStep( real64 const & GEOSX_UNUSED_ARG( time_n ),
 void SolverBase::ImplicitStepSetup( real64 const & GEOSX_UNUSED_ARG( time_n ),
                                     real64 const & GEOSX_UNUSED_ARG( dt ),
                                     DomainPartition * const GEOSX_UNUSED_ARG( domain ),
-                                    DofManager & GEOSX_UNUSED_ARG( dofManager ),
+                                    DofManager<LAInterface> & GEOSX_UNUSED_ARG( dofManager ),
                                     ParallelMatrix & GEOSX_UNUSED_ARG( matrix ),
                                     ParallelVector & GEOSX_UNUSED_ARG( rhs ),
                                     ParallelVector & GEOSX_UNUSED_ARG( solution ) )
@@ -464,13 +464,13 @@ void SolverBase::ImplicitStepSetup( real64 const & GEOSX_UNUSED_ARG( time_n ),
 }
 
 void SolverBase::SetupDofs( DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
-                            DofManager & GEOSX_UNUSED_ARG( dofManager ) ) const
+                            DofManager<LAInterface> & GEOSX_UNUSED_ARG( dofManager ) ) const
 {
   GEOS_ERROR( "SolverBase::SetupDofs called!. Should be overridden." );
 }
 
 void SolverBase::SetupSystem( DomainPartition * const domain,
-                              DofManager & dofManager,
+                              DofManager<LAInterface> & dofManager,
                               ParallelMatrix & matrix,
                               ParallelVector & rhs,
                               ParallelVector & solution )
@@ -490,7 +490,7 @@ void SolverBase::SetupSystem( DomainPartition * const domain,
 void SolverBase::AssembleSystem( real64 const GEOSX_UNUSED_ARG( time ),
                                  real64 const GEOSX_UNUSED_ARG( dt ),
                                  DomainPartition * const GEOSX_UNUSED_ARG( domain ),
-                                 DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+                                 DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                                  ParallelMatrix & GEOSX_UNUSED_ARG( matrix ),
                                  ParallelVector & GEOSX_UNUSED_ARG( rhs ) )
 {
@@ -500,7 +500,7 @@ void SolverBase::AssembleSystem( real64 const GEOSX_UNUSED_ARG( time ),
 void SolverBase::ApplyBoundaryConditions( real64 const GEOSX_UNUSED_ARG( time ),
                                           real64 const GEOSX_UNUSED_ARG( dt ),
                                           DomainPartition * const GEOSX_UNUSED_ARG( domain ),
-                                          DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+                                          DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                                           ParallelMatrix & GEOSX_UNUSED_ARG( matrix ),
                                           ParallelVector & GEOSX_UNUSED_ARG( rhs ) )
 {
@@ -509,14 +509,14 @@ void SolverBase::ApplyBoundaryConditions( real64 const GEOSX_UNUSED_ARG( time ),
 
 real64
 SolverBase::CalculateResidualNorm( DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
-                                   DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+                                   DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                                    ParallelVector const & GEOSX_UNUSED_ARG( rhs ) )
 {
   GEOS_ERROR( "SolverBase::CalculateResidualNorm called!. Should be overridden." );
   return 0;
 }
 
-void SolverBase::SolveSystem( DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+void SolverBase::SolveSystem( DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                               ParallelMatrix & matrix,
                               ParallelVector & rhs,
                               ParallelVector & solution )
@@ -529,7 +529,7 @@ void SolverBase::SolveSystem( DofManager const & GEOSX_UNUSED_ARG( dofManager ),
 }
 
 bool SolverBase::CheckSystemSolution( DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
-                                      DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+                                      DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                                       ParallelVector const & GEOSX_UNUSED_ARG( solution ),
                                       real64 const GEOSX_UNUSED_ARG( scalingFactor ) )
 {
@@ -537,13 +537,13 @@ bool SolverBase::CheckSystemSolution( DomainPartition const * const GEOSX_UNUSED
 }
 
 real64 SolverBase::ScalingForSystemSolution( DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
-                                             DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+                                             DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                                              ParallelVector const & GEOSX_UNUSED_ARG( solution ) )
 {
   return 1.0;
 }
 
-void SolverBase::ApplySystemSolution( DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+void SolverBase::ApplySystemSolution( DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                                       ParallelVector const & GEOSX_UNUSED_ARG( solution ),
                                       real64 const GEOSX_UNUSED_ARG( scalingFactor ),
                                       DomainPartition * const GEOSX_UNUSED_ARG( domain ) )

--- a/src/coreComponents/physicsSolvers/SolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.hpp
@@ -104,8 +104,8 @@ public:
    * @brief Getter for degree-of-freedom manager
    * @return a reference to degree-of-freedom manager of this solver
    */
-  DofManager       & getDofManager()       { return m_dofManager; }
-  DofManager const & getDofManager() const { return m_dofManager; }
+  DofManager<LAInterface>       & getDofManager()       { return m_dofManager; }
+  DofManager<LAInterface> const & getDofManager() const { return m_dofManager; }
 
   /**
    * @defgroup Solver Interface Functions
@@ -164,7 +164,7 @@ public:
                                         real64 const & dt,
                                         integer const cycleNumber,
                                         DomainPartition * const domain,
-                                        DofManager const & dofManager,
+                                        DofManager<LAInterface> const & dofManager,
                                         ParallelMatrix & matrix,
                                         ParallelVector & rhs,
                                         ParallelVector & solution );
@@ -192,7 +192,7 @@ public:
               real64 const & dt,
               integer const cycleNumber,
               DomainPartition * const domain,
-              DofManager const & dofManager,
+              DofManager<LAInterface> const & dofManager,
               ParallelMatrix & matrix,
               ParallelVector & rhs,
               ParallelVector const & solution,
@@ -221,7 +221,7 @@ public:
                                      real64 const & dt,
                                      integer const cycleNumber,
                                      DomainPartition * const domain,
-                                     DofManager & dofManager,
+                                     DofManager<LAInterface> & dofManager,
                                      ParallelMatrix & matrix,
                                      ParallelVector & rhs,
                                      ParallelVector & solution );
@@ -246,7 +246,7 @@ public:
   ImplicitStepSetup( real64 const & time_n,
                      real64 const & dt,
                      DomainPartition * const domain,
-                     DofManager & dofManager,
+                     DofManager<LAInterface> & dofManager,
                      ParallelMatrix & matrix,
                      ParallelVector & rhs,
                      ParallelVector & solution );
@@ -257,7 +257,7 @@ public:
    */
   virtual void
   SetupDofs( DomainPartition const * const domain,
-             DofManager & dofManager ) const;
+             DofManager<LAInterface> & dofManager ) const;
 
   /**
    * @brief Set up the linear system (DOF indices and sparsity patterns)
@@ -272,7 +272,7 @@ public:
    */
   virtual void
   SetupSystem( DomainPartition * const domain,
-               DofManager & dofManager,
+               DofManager<LAInterface> & dofManager,
                ParallelMatrix & matrix,
                ParallelVector & rhs,
                ParallelVector & solution );
@@ -300,7 +300,7 @@ public:
   AssembleSystem( real64 const time,
                   real64 const dt,
                   DomainPartition * const domain,
-                  DofManager const & dofManager,
+                  DofManager<LAInterface> const & dofManager,
                   ParallelMatrix & matrix,
                   ParallelVector & rhs );
 
@@ -320,7 +320,7 @@ public:
   ApplyBoundaryConditions( real64 const time,
                            real64 const dt,
                            DomainPartition * const domain,
-                           DofManager const & dofManager,
+                           DofManager<LAInterface> const & dofManager,
                            ParallelMatrix & matrix,
                            ParallelVector & rhs );
 
@@ -336,7 +336,7 @@ public:
    */
   virtual real64
   CalculateResidualNorm( DomainPartition const * const domain,
-                         DofManager const & dofManager,
+                         DofManager<LAInterface> const & dofManager,
                          ParallelVector const & rhs );
 
   /**
@@ -354,7 +354,7 @@ public:
    * solution method such as LinearImplicitStep() or NonlinearImplicitStep().
    */
   virtual void
-  SolveSystem( DofManager const & dofManager,
+  SolveSystem( DofManager<LAInterface> const & dofManager,
                ParallelMatrix & matrix,
                ParallelVector & rhs,
                ParallelVector & solution );
@@ -375,7 +375,7 @@ public:
    */
   virtual bool
   CheckSystemSolution( DomainPartition const * const domain,
-                       DofManager const & dofManager,
+                       DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor );
 
@@ -388,7 +388,7 @@ public:
    */
   virtual real64
   ScalingForSystemSolution( DomainPartition const * const domain,
-                            DofManager const & dofManager,
+                            DofManager<LAInterface> const & dofManager,
                             ParallelVector const & solution );
 
   /**
@@ -415,7 +415,7 @@ public:
    *
    */
   virtual void
-  ApplySystemSolution( DofManager const & dofManager,
+  ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor,
                        DomainPartition * const domain );
@@ -559,7 +559,7 @@ protected:
 
 
   /// Data structure to handle degrees of freedom
-  DofManager m_dofManager;
+  DofManager<LAInterface> m_dofManager;
 
   /// System matrix, rhs and solution
   ParallelMatrix m_matrix;

--- a/src/coreComponents/physicsSolvers/Wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/Wells/CompositionalMultiphaseWell.cpp
@@ -529,7 +529,7 @@ void CompositionalMultiphaseWell::InitializeWells( DomainPartition * const domai
 
 
 void CompositionalMultiphaseWell::SetupDofs( DomainPartition const * const domain,
-                                             DofManager & dofManager ) const
+                                             DofManager<LAInterface> & dofManager ) const
 {
   MeshLevel const * const meshLevel = domain->getMeshBody( 0 )->getMeshLevel( 0 );
   ElementRegionManager const * const elemManager = meshLevel->getElemManager();
@@ -541,8 +541,8 @@ void CompositionalMultiphaseWell::SetupDofs( DomainPartition const * const domai
   } );
 
   dofManager.addField( WellElementDofName(),
-                       DofManager::Location::Elem,
-                       DofManager::Connectivity::Node,
+                       DofLocation::Elem,
+                       DofConnectivity::Node,
                        NumDofPerWellElement(),
                        regions );
 }
@@ -550,7 +550,7 @@ void CompositionalMultiphaseWell::SetupDofs( DomainPartition const * const domai
 void CompositionalMultiphaseWell::AssembleFluxTerms( real64 const GEOSX_UNUSED_ARG( time_n ),
                                                      real64 const dt,
                                                      DomainPartition const * const domain,
-                                                     DofManager const * const dofManager,
+                                                     DofManager<LAInterface> const * const dofManager,
                                                      ParallelMatrix * const matrix,
                                                      ParallelVector * const rhs )
 {
@@ -830,7 +830,7 @@ void CompositionalMultiphaseWell::AssembleFluxTerms( real64 const GEOSX_UNUSED_A
 void CompositionalMultiphaseWell::AssembleVolumeBalanceTerms( real64 const GEOSX_UNUSED_ARG( time_n ),
                                                               real64 const GEOSX_UNUSED_ARG( dt ),
                                                               DomainPartition const * const domain,
-                                                              DofManager const * const dofManager,
+                                                              DofManager<LAInterface> const * const dofManager,
                                                               ParallelMatrix * const matrix,
                                                               ParallelVector * const rhs )
 {
@@ -930,7 +930,7 @@ void CompositionalMultiphaseWell::AssembleVolumeBalanceTerms( real64 const GEOSX
 void CompositionalMultiphaseWell::AssemblePerforationTerms( real64 const GEOSX_UNUSED_ARG( time_n ),
                                                             real64 const dt,
                                                             DomainPartition const * const domain, 
-                                                            DofManager const * const dofManager,
+                                                            DofManager<LAInterface> const * const dofManager,
                                                             ParallelMatrix * const matrix,
                                                             ParallelVector * const rhs )
 {
@@ -1062,7 +1062,7 @@ void CompositionalMultiphaseWell::AssemblePerforationTerms( real64 const GEOSX_U
 
 real64
 CompositionalMultiphaseWell::CalculateResidualNorm( DomainPartition const * const domain,
-                                                    DofManager const & dofManager,
+                                                    DofManager<LAInterface> const & dofManager,
                                                     ParallelVector const & rhs )
 {
   // get a view into local residual vector
@@ -1119,7 +1119,7 @@ CompositionalMultiphaseWell::CalculateResidualNorm( DomainPartition const * cons
 
 bool
 CompositionalMultiphaseWell::CheckSystemSolution(  DomainPartition const * const domain,
-                                                   DofManager const & dofManager,
+                                                   DofManager<LAInterface> const & dofManager,
                                                    ParallelVector const & solution,
                                                    real64 const scalingFactor )
 {
@@ -1193,7 +1193,7 @@ CompositionalMultiphaseWell::CheckSystemSolution(  DomainPartition const * const
 }
 
 void
-CompositionalMultiphaseWell::ApplySystemSolution( DofManager const & dofManager,
+CompositionalMultiphaseWell::ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                                                   ParallelVector const & solution,
                                                   real64 const scalingFactor,
                                                   DomainPartition * const domain )
@@ -1366,7 +1366,7 @@ void CompositionalMultiphaseWell::ResetViews(DomainPartition * const domain)
 
 
 void CompositionalMultiphaseWell::FormPressureRelations( DomainPartition const * const domain,
-                                                         DofManager const * const dofManager, 
+                                                         DofManager<LAInterface> const * const dofManager,
                                                          ParallelMatrix * const matrix,
                                                          ParallelVector * const rhs )
 {
@@ -1512,7 +1512,7 @@ void CompositionalMultiphaseWell::FormPressureRelations( DomainPartition const *
 }
   
 void CompositionalMultiphaseWell::FormControlEquation( DomainPartition const * const domain,
-                                                       DofManager const * const dofManager,
+                                                       DofManager<LAInterface> const * const dofManager,
                                                        ParallelMatrix * const matrix,
                                                        ParallelVector * const rhs )
 {

--- a/src/coreComponents/physicsSolvers/Wells/CompositionalMultiphaseWell.hpp
+++ b/src/coreComponents/physicsSolvers/Wells/CompositionalMultiphaseWell.hpp
@@ -107,17 +107,17 @@ public:
 
   virtual real64
   CalculateResidualNorm( DomainPartition const * const domain,
-                         DofManager const & dofManager,
+                         DofManager<LAInterface> const & dofManager,
                          ParallelVector const & rhs ) override;
     
   virtual bool
   CheckSystemSolution( DomainPartition const * const domain,
-                       DofManager const & dofManager,
+                       DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor ) override;
 
   virtual void
-  ApplySystemSolution( DofManager const & dofManager,
+  ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor,
                        DomainPartition * const domain ) override;
@@ -132,7 +132,7 @@ public:
 
   virtual void
   SetupDofs( DomainPartition const * const domain,
-             DofManager & dofManager ) const override;
+             DofManager<LAInterface> & dofManager ) const override;
 
   /**@}*/
 
@@ -172,7 +172,7 @@ public:
   virtual void AssembleFluxTerms( real64 const time_n,
                                   real64 const dt,
                                   DomainPartition const * const domain,
-                                  DofManager const * const dofManager,
+                                  DofManager<LAInterface> const * const dofManager,
                                   ParallelMatrix * const matrix,
                                   ParallelVector * const rhs ) override;
 
@@ -188,7 +188,7 @@ public:
   virtual void AssemblePerforationTerms( real64 const time_n,
                                          real64 const dt,
                                          DomainPartition const * const domain,
-                                         DofManager const * const dofManager,
+                                         DofManager<LAInterface> const * const dofManager,
                                          ParallelMatrix * const matrix,
                                          ParallelVector * const rhs ) override;
 
@@ -204,7 +204,7 @@ public:
   virtual void AssembleVolumeBalanceTerms( real64 const time_n,
                                            real64 const dt,
                                            DomainPartition const * const domain,
-                                           DofManager const * const dofManager,
+                                           DofManager<LAInterface> const * const dofManager,
                                            ParallelMatrix * const matrix,
                                            ParallelVector * const rhs ) override;
 
@@ -216,7 +216,7 @@ public:
    * @param rhs the system right-hand side vector
    */
   virtual void FormPressureRelations( DomainPartition const * const domain,
-                                      DofManager const * const dofManager,
+                                      DofManager<LAInterface> const * const dofManager,
                                       ParallelMatrix * const matrix,
                                       ParallelVector * const rhs ) override;
 
@@ -228,7 +228,7 @@ public:
    * @param rhs the system right-hand side vector
    */
   virtual void FormControlEquation( DomainPartition const * const domain,
-                                    DofManager const * const dofManager,
+                                    DofManager<LAInterface> const * const dofManager,
                                     ParallelMatrix * const matrix,
                                     ParallelVector * const rhs ) override;
   

--- a/src/coreComponents/physicsSolvers/Wells/SinglePhaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/Wells/SinglePhaseWell.cpp
@@ -254,7 +254,7 @@ void SinglePhaseWell::InitializeWells( DomainPartition * const domain )
 
 
 void SinglePhaseWell::SetupDofs( DomainPartition const * const domain,
-                                 DofManager & dofManager ) const
+                                 DofManager<LAInterface> & dofManager ) const
 {
   MeshLevel const * const meshLevel = domain->getMeshBody( 0 )->getMeshLevel( 0 );
   ElementRegionManager const * const elemManager = meshLevel->getElemManager();
@@ -266,8 +266,8 @@ void SinglePhaseWell::SetupDofs( DomainPartition const * const domain,
   } );
 
   dofManager.addField( WellElementDofName(),
-                       DofManager::Location::Elem,
-                       DofManager::Connectivity::Node,
+                       DofLocation::Elem,
+                       DofConnectivity::Node,
                        NumDofPerWellElement(),
                        regions );
 }
@@ -275,7 +275,7 @@ void SinglePhaseWell::SetupDofs( DomainPartition const * const domain,
 void SinglePhaseWell::AssembleFluxTerms( real64 const GEOSX_UNUSED_ARG( time_n ),
                                          real64 const dt,
                                          DomainPartition const * const domain,
-                                         DofManager const * const dofManager,
+                                         DofManager<LAInterface> const * const dofManager,
                                          ParallelMatrix * const matrix,
                                          ParallelVector * const rhs )
 {
@@ -392,7 +392,7 @@ void SinglePhaseWell::AssembleFluxTerms( real64 const GEOSX_UNUSED_ARG( time_n )
 void SinglePhaseWell::AssemblePerforationTerms( real64 const GEOSX_UNUSED_ARG( time_n ),
                                                 real64 const dt,
                                                 DomainPartition const * const domain,
-                                                DofManager const * const dofManager,
+                                                DofManager<LAInterface> const * const dofManager,
                                                 ParallelMatrix * const matrix,
                                                 ParallelVector * const rhs )
 {
@@ -502,7 +502,7 @@ void SinglePhaseWell::AssemblePerforationTerms( real64 const GEOSX_UNUSED_ARG( t
 
 
 void SinglePhaseWell::FormPressureRelations( DomainPartition const * const domain,
-                                             DofManager const * const dofManager,
+                                             DofManager<LAInterface> const * const dofManager,
                                              ParallelMatrix * const matrix,
                                              ParallelVector * const rhs )
 {
@@ -615,7 +615,7 @@ void SinglePhaseWell::FormPressureRelations( DomainPartition const * const domai
 void SinglePhaseWell::AssembleVolumeBalanceTerms( real64 const GEOSX_UNUSED_ARG( time_n ),
                                                   real64 const GEOSX_UNUSED_ARG( dt ),
                                                   DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
-                                                  DofManager const * const GEOSX_UNUSED_ARG( dofManager ),
+                                                  DofManager<LAInterface> const * const GEOSX_UNUSED_ARG( dofManager ),
                                                   ParallelMatrix * const GEOSX_UNUSED_ARG( matrix ),
                                                   ParallelVector * const GEOSX_UNUSED_ARG( rhs ) )
 {
@@ -718,7 +718,7 @@ void SinglePhaseWell::CheckWellControlSwitch( DomainPartition * const domain )
 
 real64
 SinglePhaseWell::CalculateResidualNorm( DomainPartition const * const domain,
-                                        DofManager const & dofManager,
+                                        DofManager<LAInterface> const & dofManager,
                                         ParallelVector const & rhs )
 {
   // get a view into local residual vector
@@ -774,7 +774,7 @@ SinglePhaseWell::CalculateResidualNorm( DomainPartition const * const domain,
 
 bool
 SinglePhaseWell::CheckSystemSolution( DomainPartition const * const domain,
-                                      DofManager const & dofManager,
+                                      DofManager<LAInterface> const & dofManager,
                                       ParallelVector const & solution,
                                       real64 const scalingFactor )
 {
@@ -831,7 +831,7 @@ SinglePhaseWell::CheckSystemSolution( DomainPartition const * const domain,
 }
 
 void
-SinglePhaseWell::ApplySystemSolution( DofManager const & dofManager,
+SinglePhaseWell::ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                                       ParallelVector const & solution,
                                       real64 const scalingFactor,
                                       DomainPartition * const domain )
@@ -1099,7 +1099,7 @@ void SinglePhaseWell::ComputeAllPerforationRates( WellElementSubRegion const * c
 
 
 void SinglePhaseWell::FormControlEquation( DomainPartition const * const domain,
-                                           DofManager const * const dofManager,
+                                           DofManager<LAInterface> const * const dofManager,
                                            ParallelMatrix * const matrix,
                                            ParallelVector * const rhs )
 {

--- a/src/coreComponents/physicsSolvers/Wells/SinglePhaseWell.hpp
+++ b/src/coreComponents/physicsSolvers/Wells/SinglePhaseWell.hpp
@@ -104,17 +104,17 @@ public:
 
   virtual real64
   CalculateResidualNorm( DomainPartition const * const domain,
-                         DofManager const & dofManager,
+                         DofManager<LAInterface> const & dofManager,
                          ParallelVector const & rhs ) override;
   
   virtual bool
   CheckSystemSolution( DomainPartition const * const domain,
-                       DofManager const & dofManager,
+                       DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor ) override;
 
   virtual void
-  ApplySystemSolution( DofManager const & dofManager,
+  ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor,
                        DomainPartition * const domain ) override;
@@ -129,7 +129,7 @@ public:
 
   virtual void
   SetupDofs( DomainPartition const * const domain,
-             DofManager & dofManager ) const override;
+             DofManager<LAInterface> & dofManager ) const override;
 
   /**@}*/
 
@@ -157,7 +157,7 @@ public:
   void AssembleFluxTerms( real64 const time_n,
                           real64 const dt,
                           DomainPartition const * const domain,
-                          DofManager const * const dofManager,
+                          DofManager<LAInterface> const * const dofManager,
                           ParallelMatrix * const matrix,
                           ParallelVector * const rhs ) override;
 
@@ -174,7 +174,7 @@ public:
   virtual void AssemblePerforationTerms( real64 const time_n,
                                          real64 const dt,
                                          DomainPartition const * const domain,
-                                         DofManager const * const dofManager,
+                                         DofManager<LAInterface> const * const dofManager,
                                          ParallelMatrix * const matrix,
                                          ParallelVector * const rhs ) override;
   
@@ -190,7 +190,7 @@ public:
   virtual void AssembleVolumeBalanceTerms( real64 const time_n,
                                            real64 const dt,
                                            DomainPartition const * const domain,
-                                           DofManager const * const dofManager,
+                                           DofManager<LAInterface> const * const dofManager,
                                            ParallelMatrix * const matrix,
                                            ParallelVector * const rhs ) override;
 
@@ -202,7 +202,7 @@ public:
    * @param rhs the system right-hand side vector
    */
   virtual void FormPressureRelations( DomainPartition const * const domain,
-                                      DofManager const * const dofManager,
+                                      DofManager<LAInterface> const * const dofManager,
                                       ParallelMatrix * const matrix,
                                       ParallelVector * const rhs ) override;
 
@@ -214,7 +214,7 @@ public:
    * @param rhs the system right-hand side vector
    */
   virtual void FormControlEquation( DomainPartition const * const domain,
-                                    DofManager const * const dofManager,
+                                    DofManager<LAInterface> const * const dofManager,
                                     ParallelMatrix * const matrix,
                                     ParallelVector * const rhs ) override;
 

--- a/src/coreComponents/physicsSolvers/Wells/WellSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/Wells/WellSolverBase.cpp
@@ -90,7 +90,7 @@ void WellSolverBase::RegisterDataOnMesh( Group * const meshBodies )
 void WellSolverBase::ImplicitStepSetup( real64 const & time_n,
                                         real64 const & GEOSX_UNUSED_ARG( dt ),
                                         DomainPartition * const domain,
-                                        DofManager & GEOSX_UNUSED_ARG( dofManager ),
+                                        DofManager<LAInterface> & GEOSX_UNUSED_ARG( dofManager ),
                                         ParallelMatrix & GEOSX_UNUSED_ARG( matrix ),
                                         ParallelVector & GEOSX_UNUSED_ARG( rhs ),
                                         ParallelVector & GEOSX_UNUSED_ARG( solution ) )
@@ -114,7 +114,7 @@ void WellSolverBase::ImplicitStepSetup( real64 const & time_n,
 void WellSolverBase::AssembleSystem( real64 const time,
                                      real64 const dt,
                                      DomainPartition * const domain,
-                                     DofManager const & dofManager,
+                                     DofManager<LAInterface> const & dofManager,
                                      ParallelMatrix & matrix,
                                      ParallelVector & rhs )
 { 

--- a/src/coreComponents/physicsSolvers/Wells/WellSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/Wells/WellSolverBase.hpp
@@ -154,7 +154,7 @@ public:
   virtual void ImplicitStepSetup( real64 const & time_n,
                                   real64 const & dt,
                                   DomainPartition * const domain,
-                                  DofManager & dofManager,
+                                  DofManager<LAInterface> & dofManager,
                                   ParallelMatrix & matrix,
                                   ParallelVector & rhs,
                                   ParallelVector & solution ) override;
@@ -178,7 +178,7 @@ public:
   virtual void AssembleSystem( real64 const time,
                                real64 const dt,
                                DomainPartition * const domain,
-                               DofManager const & dofManager,
+                               DofManager<LAInterface> const & dofManager,
                                ParallelMatrix & matrix,
                                ParallelVector & rhs ) override;
 
@@ -194,7 +194,7 @@ public:
   virtual void AssembleFluxTerms( real64 const time_n,
                                   real64 const dt,
                                   DomainPartition const * const domain,
-                                  DofManager const * const dofManager,
+                                  DofManager<LAInterface> const * const dofManager,
                                   ParallelMatrix * const matrix,
                                   ParallelVector * const rhs ) = 0;
 
@@ -209,7 +209,7 @@ public:
   virtual void AssemblePerforationTerms( real64 const time_n,
                                          real64 const dt,
                                          DomainPartition const * const domain,
-                                         DofManager const * const dofManager,
+                                         DofManager<LAInterface> const * const dofManager,
                                          ParallelMatrix * const matrix,
                                          ParallelVector * const rhs ) = 0;
 
@@ -225,7 +225,7 @@ public:
   virtual void AssembleVolumeBalanceTerms( real64 const time_n,
                                            real64 const dt,
                                            DomainPartition const * const domain,
-                                           DofManager const * const dofManager,
+                                           DofManager<LAInterface> const * const dofManager,
                                            ParallelMatrix * const matrix,
                                            ParallelVector * const rhs ) = 0;
 
@@ -237,7 +237,7 @@ public:
    * @param rhs the system right-hand side vector
    */
   virtual void FormPressureRelations( DomainPartition const * const domain,
-                                      DofManager const * const dofManager,
+                                      DofManager<LAInterface> const * const dofManager,
                                       ParallelMatrix * const matrix,
                                       ParallelVector * const rhs ) = 0;
   
@@ -249,7 +249,7 @@ public:
    * @param rhs the system right-hand side vector
    */
   virtual void FormControlEquation( DomainPartition const * const domain,
-                                    DofManager const * const dofManager,
+                                    DofManager<LAInterface> const * const dofManager,
                                     ParallelMatrix * const matrix,
                                     ParallelVector * const rhs ) = 0;
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
@@ -639,7 +639,7 @@ real64 SolidMechanicsLagrangianFEM::ExplicitStep( real64 const& time_n,
 
 
 void SolidMechanicsLagrangianFEM::ApplyDisplacementBC_implicit( real64 const time,
-                                                                DofManager const & dofManager,
+                                                                DofManager<LAInterface> const & dofManager,
                                                                 DomainPartition & domain,
                                                                 ParallelMatrix & matrix,
                                                                 ParallelVector & rhs )
@@ -672,7 +672,7 @@ void SolidMechanicsLagrangianFEM::ApplyDisplacementBC_implicit( real64 const tim
 
 
 void SolidMechanicsLagrangianFEM::ApplyTractionBC( real64 const time,
-                                                   DofManager const & dofManager,
+                                                   DofManager<LAInterface> const & dofManager,
                                                    DomainPartition * const domain,
                                                    ParallelVector & rhs )
 {
@@ -775,7 +775,7 @@ void SolidMechanicsLagrangianFEM::ApplyTractionBC( real64 const time,
   });
 }
 
-void SolidMechanicsLagrangianFEM::ApplyChomboPressure( DofManager const & dofManager,
+void SolidMechanicsLagrangianFEM::ApplyChomboPressure( DofManager<LAInterface> const & dofManager,
                                                        DomainPartition * const domain,
                                                        ParallelVector & rhs )
 {
@@ -819,7 +819,7 @@ SolidMechanicsLagrangianFEM::
 ImplicitStepSetup( real64 const & GEOSX_UNUSED_ARG( time_n ),
                    real64 const & dt,
                    DomainPartition * const domain,
-                   DofManager & GEOSX_UNUSED_ARG( dofManager ),
+                   DofManager<LAInterface> & GEOSX_UNUSED_ARG( dofManager ),
                    ParallelMatrix & GEOSX_UNUSED_ARG( matrix ),
                    ParallelVector & GEOSX_UNUSED_ARG( rhs ),
                    ParallelVector & GEOSX_UNUSED_ARG( solution ) )
@@ -926,16 +926,16 @@ void SolidMechanicsLagrangianFEM::ImplicitStepComplete( real64 const & GEOSX_UNU
 }
 
 void SolidMechanicsLagrangianFEM::SetupDofs( DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
-                                             DofManager & dofManager ) const
+                                             DofManager<LAInterface> & dofManager ) const
 {
   dofManager.addField( keys::TotalDisplacement,
-                       DofManager::Location::Node,
-                       DofManager::Connectivity::Elem,
+                       DofLocation::Node,
+                       DofConnectivity::Elem,
                        3 );
 }
 
 void SolidMechanicsLagrangianFEM::SetupSystem( DomainPartition * const domain,
-                                               DofManager & dofManager,
+                                               DofManager<LAInterface> & dofManager,
                                                ParallelMatrix & matrix,
                                                ParallelVector & rhs,
                                                ParallelVector & solution )
@@ -988,7 +988,7 @@ void SolidMechanicsLagrangianFEM::SetupSystem( DomainPartition * const domain,
 void SolidMechanicsLagrangianFEM::AssembleSystem( real64 const GEOSX_UNUSED_ARG( time_n ),
                                                   real64 const dt,
                                                   DomainPartition * const domain,
-                                                  DofManager const & dofManager,
+                                                  DofManager<LAInterface> const & dofManager,
                                                   ParallelMatrix & matrix,
                                                   ParallelVector & rhs )
 {
@@ -1112,7 +1112,7 @@ SolidMechanicsLagrangianFEM::
 ApplyBoundaryConditions( real64 const time_n,
                          real64 const dt,
                          DomainPartition * const domain,
-                         DofManager const & dofManager,
+                         DofManager<LAInterface> const & dofManager,
                          ParallelMatrix & matrix,
                          ParallelVector & rhs )
 {
@@ -1181,7 +1181,7 @@ ApplyBoundaryConditions( real64 const time_n,
 real64
 SolidMechanicsLagrangianFEM::
 CalculateResidualNorm( DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
-                       DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+                       DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                        ParallelVector const & rhs )
 {
   real64 const * localResidual = rhs.extractLocalVector();
@@ -1233,7 +1233,7 @@ CalculateResidualNorm( DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
 
 
 void
-SolidMechanicsLagrangianFEM::ApplySystemSolution( DofManager const & dofManager,
+SolidMechanicsLagrangianFEM::ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                                                   ParallelVector const & solution,
                                                   real64 const scalingFactor,
                                                   DomainPartition * const domain )
@@ -1253,7 +1253,7 @@ SolidMechanicsLagrangianFEM::ApplySystemSolution( DofManager const & dofManager,
                                          domain->getReference< array1d<NeighborCommunicator> >( domain->viewKeys.neighbors ) );
 }
 
-void SolidMechanicsLagrangianFEM::SolveSystem( DofManager const & dofManager,
+void SolidMechanicsLagrangianFEM::SolveSystem( DofManager<LAInterface> const & dofManager,
                                                ParallelMatrix & matrix,
                                                ParallelVector & rhs,
                                                ParallelVector & solution )
@@ -1288,7 +1288,7 @@ void SolidMechanicsLagrangianFEM::ResetStateToBeginningOfStep( DomainPartition *
 }
 
 
-void SolidMechanicsLagrangianFEM::ApplyContactConstraint( DofManager const & dofManager,
+void SolidMechanicsLagrangianFEM::ApplyContactConstraint( DofManager<LAInterface> const & dofManager,
                                                           DomainPartition & domain,
                                                           ParallelMatrix * const matrix,
                                                           ParallelVector * const rhs )
@@ -1397,7 +1397,7 @@ void SolidMechanicsLagrangianFEM::ApplyContactConstraint( DofManager const & dof
 
 real64
 SolidMechanicsLagrangianFEM::ScalingForSystemSolution( DomainPartition const * const GEOSX_UNUSED_ARG( domain ),
-                                                       DofManager const & GEOSX_UNUSED_ARG( dofManager ),
+                                                       DofManager<LAInterface> const & GEOSX_UNUSED_ARG( dofManager ),
                                                        ParallelVector const & GEOSX_UNUSED_ARG( solution ) )
 {
   GEOSX_MARK_FUNCTION;

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp
@@ -99,18 +99,18 @@ public:
   ImplicitStepSetup( real64 const & time_n,
                      real64 const & dt,
                      DomainPartition * const domain,
-                     DofManager & dofManager,
+                     DofManager<LAInterface> & dofManager,
                      ParallelMatrix & matrix,
                      ParallelVector & rhs,
                      ParallelVector & solution ) override;
 
   virtual void
   SetupDofs( DomainPartition const * const domain,
-             DofManager & dofManager ) const override;
+             DofManager<LAInterface> & dofManager ) const override;
 
   virtual void
   SetupSystem( DomainPartition * const domain,
-               DofManager & dofManager,
+               DofManager<LAInterface> & dofManager,
                ParallelMatrix & matrix,
                ParallelVector & rhs,
                ParallelVector & solution ) override;
@@ -119,18 +119,18 @@ public:
   AssembleSystem( real64 const time,
                   real64 const dt,
                   DomainPartition * const domain,
-                  DofManager const & dofManager,
+                  DofManager<LAInterface> const & dofManager,
                   ParallelMatrix & matrix,
                   ParallelVector & rhs ) override;
 
   virtual void
-  SolveSystem( DofManager const & dofManager,
+  SolveSystem( DofManager<LAInterface> const & dofManager,
                ParallelMatrix & matrix,
                ParallelVector & rhs,
                ParallelVector & solution ) override;
 
   virtual void
-  ApplySystemSolution( DofManager const & dofManager,
+  ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                        ParallelVector const & solution,
                        real64 const scalingFactor,
                        DomainPartition * const domain ) override;
@@ -138,13 +138,13 @@ public:
   virtual void ApplyBoundaryConditions( real64 const time,
                                         real64 const dt,
                                         DomainPartition * const domain,
-                                        DofManager const & dofManager,
+                                        DofManager<LAInterface> const & dofManager,
                                         ParallelMatrix & matrix,
                                         ParallelVector & rhs ) override;
 
   virtual real64
   CalculateResidualNorm( DomainPartition const * const domain,
-                         DofManager const & dofManager,
+                         DofManager<LAInterface> const & dofManager,
                          ParallelVector const & rhs ) override;
 
   virtual void ResetStateToBeginningOfStep( DomainPartition * const domain ) override;
@@ -262,7 +262,7 @@ public:
                                real64 const massDamping,
                                real64 const newmarkBeta,
                                real64 const newmarkGamma,
-                               DofManager const * const dofManager,
+                               DofManager<LAInterface> const * const dofManager,
                                ParallelMatrix * const matrix,
                                ParallelVector * const rhs ) const
   {
@@ -307,30 +307,30 @@ public:
    * @param solution the solution vector
    */
   void ApplyDisplacementBC_implicit( real64 const time,
-                                     DofManager const & dofManager,
+                                     DofManager<LAInterface> const & dofManager,
                                      DomainPartition & domain,
                                      ParallelMatrix & matrix,
                                      ParallelVector & rhs );
 
 
   void ApplyTractionBC( real64 const time,
-                        DofManager const & dofManager,
+                        DofManager<LAInterface> const & dofManager,
                         DomainPartition * const domain,
                         ParallelVector & rhs );
 
-  void ApplyChomboPressure( DofManager const & dofManager,
+  void ApplyChomboPressure( DofManager<LAInterface> const & dofManager,
                             DomainPartition * const domain,
                             ParallelVector & rhs );
 
 
-  void ApplyContactConstraint( DofManager const & dofManager,
+  void ApplyContactConstraint( DofManager<LAInterface> const & dofManager,
                                DomainPartition & domain,
                                ParallelMatrix * const matrix,
                                ParallelVector * const rhs );
 
   virtual real64
   ScalingForSystemSolution( DomainPartition const * const domain,
-                            DofManager const & dofManager,
+                            DofManager<LAInterface> const & dofManager,
                             ParallelVector const & solution ) override;
 
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEMKernels.hpp
@@ -398,7 +398,7 @@ struct ImplicitKernel
           real64 const GEOSX_UNUSED_ARG( massDamping ),
           real64 const GEOSX_UNUSED_ARG( newmarkBeta ),
           real64 const GEOSX_UNUSED_ARG( newmarkGamma ),
-          DofManager const * const GEOSX_UNUSED_ARG( dofManager ),
+          DofManager<LAInterface> const * const GEOSX_UNUSED_ARG( dofManager ),
           ParallelMatrix * const GEOSX_UNUSED_ARG( matrix ),
           ParallelVector * const GEOSX_UNUSED_ARG( rhs ) )
   {

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianSSLE.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianSSLE.cpp
@@ -39,7 +39,7 @@ SolidMechanicsLagrangianSSLE::SolidMechanicsLagrangianSSLE( string const & name,
 SolidMechanicsLagrangianSSLE::~SolidMechanicsLagrangianSSLE()
 {}
 
-void SolidMechanicsLagrangianSSLE::ApplySystemSolution( DofManager const & dofManager,
+void SolidMechanicsLagrangianSSLE::ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                                                         ParallelVector const & solution,
                                                         real64 const scalingFactor,
                                                         DomainPartition * const domain  )

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianSSLE.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianSSLE.hpp
@@ -42,7 +42,7 @@ public:
 
 
 
-  virtual void ApplySystemSolution( DofManager const & dofManager,
+  virtual void ApplySystemSolution( DofManager<LAInterface> const & dofManager,
                                     ParallelVector const & solution,
                                     real64 const scalingFactor,
                                     DomainPartition * const domain  ) override;
@@ -104,7 +104,7 @@ public:
                                real64 const massDamping,
                                real64 const newmarkBeta,
                                real64 const newmarkGamma,
-                               DofManager const * const dofManager,
+                               DofManager<LAInterface> const * const dofManager,
                                ParallelMatrix * const matrix,
                                ParallelVector * const rhs ) const override
   {

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianSSLEKernels.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianSSLEKernels.hpp
@@ -291,7 +291,7 @@ struct ImplicitKernel
           real64 const massDamping,
           real64 const newmarkBeta,
           real64 const newmarkGamma,
-          DofManager const * const GEOSX_UNUSED_ARG( dofManager ),
+          DofManager<LAInterface> const * const GEOSX_UNUSED_ARG( dofManager ),
           ParallelMatrix * const matrix,
           ParallelVector * const rhs )
   {

--- a/src/coreComponents/physicsSolvers/unitTests/testCompMultiphaseFlow.cpp
+++ b/src/coreComponents/physicsSolvers/unitTests/testCompMultiphaseFlow.cpp
@@ -53,7 +53,7 @@ void testNumericalJacobian( CompositionalMultiphaseFlow * solver,
 
   ParallelMatrix & jacobian = solver->getSystemMatrix();
   ParallelVector & residual = solver->getSystemRhs();
-  DofManager const & dofManager = solver->getDofManager();
+  DofManager<LAInterface> const & dofManager = solver->getDofManager();
 
   // get a view into local residual vector
   real64 const * localResidual = residual.extractLocalVector();
@@ -581,7 +581,7 @@ TEST_F(CompositionalMultiphaseFlowTest, jacobianNumericalCheck_accumulation)
 //                               DomainPartition * targetDomain,
 //                               ParallelMatrix * targetJacobian,
 //                               ParallelVector * targetResidual,
-//                               DofManager const * targetDofManager )
+//                               DofManager<LAInterface> const * targetDofManager )
 //  {
 //    targetSolver->AssembleAccumulationTerms( targetDomain, targetJacobian, targetResidual, targetDofManager, time, dt );
 //  });
@@ -610,7 +610,7 @@ TEST_F(CompositionalMultiphaseFlowTest, jacobianNumericalCheck_flux)
                                DomainPartition * const targetDomain,
                                ParallelMatrix * targetJacobian,
                                ParallelVector * targetResidual,
-                               DofManager const * targetDofManager )
+                               DofManager<LAInterface> const * targetDofManager )
   {
     targetSolver->AssembleFluxTerms( time, dt, targetDomain, targetDofManager, targetJacobian, targetResidual );
   });
@@ -641,7 +641,7 @@ TEST_F(CompositionalMultiphaseFlowTest, jacobianNumericalCheck_volumeBalance)
                                DomainPartition * targetDomain,
                                ParallelMatrix * targetJacobian,
                                ParallelVector * targetResidual,
-                               DofManager const * targetDofManager )
+                               DofManager<LAInterface> const * targetDofManager )
   {
     targetSolver->AssembleVolumeBalanceTerms( time, dt, targetDomain, targetDofManager, targetJacobian, targetResidual );
   });

--- a/src/coreComponents/physicsSolvers/unitTests/testCompMultiphaseFlowCapPressure.cpp
+++ b/src/coreComponents/physicsSolvers/unitTests/testCompMultiphaseFlowCapPressure.cpp
@@ -52,7 +52,7 @@ void testNumericalJacobian( CompositionalMultiphaseFlow * solver,
 
   ParallelMatrix & jacobian = solver->getSystemMatrix();
   ParallelVector & residual = solver->getSystemRhs();
-  DofManager const & dofManager = solver->getDofManager();
+  DofManager<LAInterface> const & dofManager = solver->getDofManager();
 
   // get a view into local residual vector
   real64 const * localResidual = residual.extractLocalVector();
@@ -252,7 +252,7 @@ TEST_F(CompositionalMultiphaseFlowTest, jacobianNumericalCheck_flux)
                                DomainPartition * const targetDomain,
                                ParallelMatrix * targetJacobian,
                                ParallelVector * targetResidual,
-                               DofManager const * targetDofManager )
+                               DofManager<LAInterface> const * targetDofManager )
   {
     targetSolver->AssembleFluxTerms( time, dt, targetDomain, targetDofManager, targetJacobian, targetResidual );
   });

--- a/src/coreComponents/physicsSolvers/unitTests/testReservoirCompositionalMultiphaseMSWells.cpp
+++ b/src/coreComponents/physicsSolvers/unitTests/testReservoirCompositionalMultiphaseMSWells.cpp
@@ -173,7 +173,7 @@ void testNumericalJacobian( ReservoirSolver * solver,
   
   ParallelMatrix & jacobian = solver->getSystemMatrix();
   ParallelVector & residual = solver->getSystemRhs();
-  DofManager const & dofManager = solver->getDofManager();
+  DofManager<LAInterface> const & dofManager = solver->getDofManager();
 
   // get a view into local residual vector
   real64 const * localResidual = residual.extractLocalVector();
@@ -547,13 +547,14 @@ TEST_F(ReservoirSolverTest, jacobianNumericalCheck_Perforation)
                              solver->getSystemSolution() );
 
 /*
-  testNumericalJacobian( solver, domain, system, eps, tol,
+  testNumericalJacobian( solver, domain, eps, tol,
                          [&] ( CompositionalMultiphaseWell * const targetSolver,
                                DomainPartition * const targetDomain,
-                               Epetra_FECrsMatrix * const targetJacobian,
-                               Epetra_FEVector * const targetResidual ) -> void
+                               ParallelMatrix * targetJacobian,
+                               ParallelVector * targetResidual,
+                               DofManager<LAInterface> const * targetDofManager ) -> void
   {
-    targetSolver->AssemblePerforationTerms( targetDomain, targetJacobian, targetResidual, time, dt );
+    targetSolver->AssemblePerforationTerms( time, dt, targetDomain, targetDofManager, targetJacobian, targetResidual );
   });
   */
 }
@@ -581,7 +582,7 @@ TEST_F(ReservoirSolverTest, jacobianNumericalCheck_Flux)
                                DomainPartition * const targetDomain,
                                ParallelMatrix * targetJacobian,
                                ParallelVector * targetResidual,
-                               DofManager const * targetDofManager ) -> void
+                               DofManager<LAInterface> const * targetDofManager ) -> void
   {
     targetSolver->AssembleFluxTerms( time, dt, targetDomain, targetDofManager, targetJacobian, targetResidual );
   });
@@ -612,7 +613,7 @@ TEST_F(ReservoirSolverTest, jacobianNumericalCheck_Control)
                                DomainPartition * const targetDomain,
                                ParallelMatrix * targetJacobian,
                                ParallelVector * targetResidual,
-                               DofManager const * targetDofManager ) -> void
+                               DofManager<LAInterface> const * targetDofManager ) -> void
   {
     targetSolver->FormControlEquation( targetDomain, targetDofManager, targetJacobian, targetResidual );
   });
@@ -642,7 +643,7 @@ TEST_F(ReservoirSolverTest, jacobianNumericalCheck_VolumeBalance)
                                DomainPartition * const targetDomain,
                                ParallelMatrix * targetJacobian,
                                ParallelVector * targetResidual,
-                               DofManager const * targetDofManager ) -> void
+                               DofManager<LAInterface> const * targetDofManager ) -> void
   {
     targetSolver->AssembleVolumeBalanceTerms( time, dt, targetDomain, targetDofManager, targetJacobian, targetResidual );
   });
@@ -671,7 +672,7 @@ TEST_F(ReservoirSolverTest, jacobianNumericalCheck_PressureRel)
                                DomainPartition * const targetDomain,
                                ParallelMatrix * targetJacobian,
                                ParallelVector * targetResidual,
-                               DofManager const * targetDofManager ) -> void
+                               DofManager<LAInterface> const * targetDofManager ) -> void
   {
     targetSolver->FormPressureRelations( targetDomain, targetDofManager, targetJacobian, targetResidual );
   });

--- a/src/coreComponents/physicsSolvers/unitTests/testReservoirSinglePhaseMSWells.cpp
+++ b/src/coreComponents/physicsSolvers/unitTests/testReservoirSinglePhaseMSWells.cpp
@@ -57,7 +57,7 @@ void testNumericalJacobian( ReservoirSolver * solver,
 
   ParallelMatrix & jacobian = solver->getSystemMatrix();
   ParallelVector & residual = solver->getSystemRhs();
-  DofManager const & dofManager = solver->getDofManager();
+  DofManager<LAInterface> const & dofManager = solver->getDofManager();
 
   // get a view into local residual vector
   real64 const * localResidual = residual.extractLocalVector();
@@ -339,7 +339,7 @@ TEST_F(ReservoirSolverTest, jacobianNumericalCheck_Perforation)
                                DomainPartition * const targetDomain,
                                ParallelMatrix * targetJacobian,
                                ParallelVector * targetResidual,
-                               DofManager const * targetDofManager ) -> void
+                               DofManager<LAInterface> const * targetDofManager ) -> void
   {
     targetSolver->AssemblePerforationTerms( time, dt, targetDomain, targetDofManager, targetJacobian, targetResidual );
   });
@@ -369,7 +369,7 @@ TEST_F(ReservoirSolverTest, jacobianNumericalCheck_Flux)
                                DomainPartition * const targetDomain,
                                ParallelMatrix * targetJacobian,
                                ParallelVector * targetResidual,
-                               DofManager const * targetDofManager ) -> void
+                               DofManager<LAInterface> const * targetDofManager ) -> void
   {
     targetSolver->AssembleFluxTerms( time, dt, targetDomain, targetDofManager, targetJacobian, targetResidual );
   });
@@ -399,7 +399,7 @@ TEST_F(ReservoirSolverTest, jacobianNumericalCheck_Control)
                                DomainPartition * const targetDomain,
                                ParallelMatrix * targetJacobian,
                                ParallelVector * targetResidual,
-                               DofManager const * targetDofManager ) -> void
+                               DofManager<LAInterface> const * targetDofManager ) -> void
   {
     targetSolver->FormControlEquation( targetDomain, targetDofManager, targetJacobian, targetResidual );
   });
@@ -429,7 +429,7 @@ TEST_F(ReservoirSolverTest, jacobianNumericalCheck_PressureRel)
                                DomainPartition * const targetDomain,
                                ParallelMatrix * targetJacobian,
                                ParallelVector * targetResidual,
-                               DofManager const * targetDofManager ) -> void
+                               DofManager<LAInterface> const * targetDofManager ) -> void
   {
     targetSolver->FormPressureRelations( targetDomain, targetDofManager, targetJacobian, targetResidual );
   });


### PR DESCRIPTION
A pretty straightforward change. Reasons:
 * testing DofManager with different LA packages independently
 * needed for developing preconditioners templated on LAI 

36 files touched, but most of those are just adding a template argument in solver function signatures.