### PR TITLE
Fix problem with unused parameter without USE_GEOSX_PTP

### DIFF
--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -477,8 +477,7 @@ real64 SurfaceGenerator::SolverStep( real64 const & time_n,
 
 int SurfaceGenerator::SeparationDriver( DomainPartition * domain,
                                         MeshLevel * const mesh,
-                                        array1d<NeighborCommunicator> & 
-                                        neighbors,
+                                        array1d<NeighborCommunicator> & neighbors,
                                         int const tileColor,
                                         int const numTileColors,
                                         bool const prefrac,


### PR DESCRIPTION
Related to issue #616

If you have another idea, please tell me, (enable `USE_GEOSX_PTP`  by default?) but I find annoying that the compilation fails if you follow step by step the user guide.