### PR TITLE
Sphinx warning about python 2

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -242,7 +242,7 @@ texinfo_documents = [
 numfig = True
 
 # Additional stuff for the LaTeX preamble.
-latex_elements['preamble'] = '\usepackage{amsmath}\n\usepackage{amssymb}\n\usepackage[retainorgcmds]{IEEEtrantools}\n'
+latex_elements['preamble'] = '\\usepackage{amsmath}\n\\usepackage{amssymb}\n\\usepackage[retainorgcmds]{IEEEtrantools}\n'
 
 imgmath_image_format='svg'
 imgmath_font_size=14


### PR DESCRIPTION
To avoid a warning about the use of Python 2, I propose a very small change in the Sphinx configuration file (`conf.py`).