### PR TITLE
added better error output when inputting invalid xml attributes

### DIFF
--- a/src/coreComponents/dataRepository/Group.hpp
+++ b/src/coreComponents/dataRepository/Group.hpp
@@ -177,6 +177,12 @@ public:
    */
   void PrintDataHierarchy( integer indent = 0 );
 
+  /**
+   * @brief Generates a table formatted string containing all input options.
+   * @return a string containing a well formatted table containing input options.
+   */
+  string dumpInputOptions();
+
   ///@}
 
   //START_SPHINX_INCLUDE_REGISTER_GROUP

--- a/src/coreComponents/dataRepository/InputFlags.hpp
+++ b/src/coreComponents/dataRepository/InputFlags.hpp
@@ -45,7 +45,7 @@ enum class InputFlags : int
 
 /**
  * @brief Convert integer value to InputFlags
- * @param val value to convert
+ * @param[in] val value to convert
  * @return converted enumeration
  */
 inline InputFlags IntToInputFlag( int const val )
@@ -78,12 +78,62 @@ inline InputFlags IntToInputFlag( int const val )
 
 /**
  * @brief Convert InputFlags to int
- * @param val value to convert
+ * @param[in] val value to convert
  * @return converted integer
  */
 inline int InputFlagToInt( InputFlags const val )
 {
   return static_cast< int >(val);
+}
+
+
+/**
+ * @brief Convert an InputFlags value to a string.
+ * @param[in] val The value of the input flag that will be converted to a string
+ * @return The string equivalent of the input @p val.
+ */
+inline std::string InputFlagToString( InputFlags const val )
+{
+  std::string rval;
+  switch( val )
+  {
+    case InputFlags::INVALID:
+    {
+      rval = "INVALID";
+      break;
+    }
+    case InputFlags::FALSE:
+    {
+      rval = "FALSE";
+      break;
+    }
+    case InputFlags::OPTIONAL:
+    {
+      rval = "OPTIONAL";
+      break;
+    }
+    case InputFlags::OPTIONAL_NONUNIQUE:
+    {
+      rval = "OPTIONAL_NONUNIQUE";
+      break;
+    }
+    case InputFlags::REQUIRED:
+    {
+      rval = "REQUIRED";
+      break;
+    }
+    case InputFlags::REQUIRED_NONUNIQUE:
+    {
+      rval = "REQUIRED_NONUNIQUE";
+      break;
+    }
+    case InputFlags::PROBLEM_ROOT:
+    {
+      rval = "PROBLEM_ROOT";
+      break;
+    }
+  }
+  return rval;
 }
 
 /**

--- a/src/coreComponents/dataRepository/xmlWrapper.hpp
+++ b/src/coreComponents/dataRepository/xmlWrapper.hpp
@@ -147,9 +147,10 @@ public:
    * @param[in] name       the name of the xml attribute to process
    * @param[in] targetNode the xml node that should contain the attribute
    * @param[in] required   whether or not the value is required
+   * @return boolean value indicating whether the value was successfully read from XML.
    */
   template< typename T >
-  static void ReadAttributeAsType( T & rval,
+  static bool ReadAttributeAsType( T & rval,
                                    string const & name,
                                    xmlNode const & targetNode,
                                    bool const required );
@@ -162,9 +163,10 @@ public:
    * @param[in] name       the name of the xml attribute to process
    * @param[in] targetNode the xml node that should contain the attribute
    * @param[in] defVal     default value of @p rval (or entries of @p rval, if it is an array)
+   * @return boolean value indicating whether the value was successfully read from XML.
    */
   template< typename T, typename T_DEF = T >
-  static void ReadAttributeAsType( T & rval,
+  static bool ReadAttributeAsType( T & rval,
                                    string const & name,
                                    xmlNode const & targetNode,
                                    T_DEF const & defVal );
@@ -176,17 +178,17 @@ public:
    * @param[in] name       the name of the xml attribute to process
    * @param[in] targetNode the xml node that should contain the attribute
    * @param[in] defVal     default value of @p rval (or entries of @p rval, if it is an array)
-   * @return
+   * @return boolean value indicating whether the value was successfully read from XML.
    */
   template< typename T >
-  static typename std::enable_if_t< !dataRepository::DefaultValue< T >::has_default_value >
+  static std::enable_if_t< !dataRepository::DefaultValue< T >::has_default_value, bool >
   ReadAttributeAsType( T & rval,
                        string const & name,
                        xmlNode const & targetNode,
                        dataRepository::DefaultValue< T > const & defVal )
   {
     GEOSX_UNUSED_VAR( defVal );
-    ReadAttributeAsType( rval, name, targetNode, false );
+    return ReadAttributeAsType( rval, name, targetNode, false );
   }
 
   /**
@@ -196,16 +198,16 @@ public:
    * @param[in] name       the name of the xml attribute to process
    * @param[in] targetNode the xml node that should contain the attribute
    * @param[in] defVal     default value of @p rval (or entries of @p rval, if it is an array)
-   * @return
+   * @return boolean value indicating whether the value was successfully read from XML.
    */
   template< typename T >
-  static typename std::enable_if_t< dataRepository::DefaultValue< T >::has_default_value >
+  static typename std::enable_if_t< dataRepository::DefaultValue< T >::has_default_value, bool >
   ReadAttributeAsType( T & rval,
                        string const & name,
                        xmlNode const & targetNode,
                        dataRepository::DefaultValue< T > const & defVal )
   {
-    ReadAttributeAsType( rval, name, targetNode, defVal.value );
+    return ReadAttributeAsType( rval, name, targetNode, defVal.value );
   }
 
   ///@}
@@ -227,22 +229,27 @@ void xmlWrapper::StringToInputVariable( Array< T, NDIM > & array, string valueSt
 }
 
 template< typename T >
-void xmlWrapper::ReadAttributeAsType( T & rval,
+bool xmlWrapper::ReadAttributeAsType( T & rval,
                                       string const & name,
                                       xmlNode const & targetNode,
                                       bool const required )
 {
   pugi::xml_attribute xmlatt = targetNode.attribute( name.c_str() );
 
-  GEOSX_ERROR_IF( xmlatt.empty() && required, "Input variable " + name + " is required in " + targetNode.path() );
+  bool const success = !(xmlatt.empty() && required);
+  //GEOSX_ERROR_IF( xmlatt.empty() && required, "Input variable " + name + " is required in " + targetNode.path() );
 
-  // parse the string/attribute into a value
-  StringToInputVariable( rval, xmlatt.value() );
+  if( success )
+  {
+    // parse the string/attribute into a value
+    StringToInputVariable( rval, xmlatt.value() );
+  }
+  return success;
 }
 
 
 template< typename T, typename T_DEF >
-void xmlWrapper::ReadAttributeAsType( T & rval,
+bool xmlWrapper::ReadAttributeAsType( T & rval,
                                       string const & name,
                                       xmlNode const & targetNode,
                                       T_DEF const & defVal )
@@ -258,6 +265,7 @@ void xmlWrapper::ReadAttributeAsType( T & rval,
     // set the value to the default value
     rval = defVal;
   }
+  return true;
 }
 
 


### PR DESCRIPTION
Gives better error messages for invalid XML input.
for a required attribute:
```
(feature/improvedErrorMessages00 *+)$ bin/geosx -i integratedTests/solidMechanicsSSLE/SSLE-sedov.xml 
Max threads: 36
MKL max threads: 1
real64 is alias of double
localIndex is alias of long
globalIndex is alias of long long
GEOS must be configured to use Python to use parameters, symbolic math, etc. in input files
Adding Solver of type SolidMechanicsLagrangianSSLE, named lagsolve
Adding Mesh: InternalMesh, mesh1
Adding Event: PeriodicEvent, solverApplications
Adding Event: PeriodicEvent, restarts
Adding Output: Silo, siloOutput
Adding Output: Restart, restartOutput
Adding Geometric Object: Box, source
***** ERROR
***** LOCATION: /usr/workspace/settgast/Codes/geosx/GEOSX_develop/src/coreComponents/dataRepository/Group.cpp:200
***** Controlling expression (should be false): processedXmlNodes.count( childName )==0
XML Node (LinearElasticIsotropic) with attribute name=(granite) contains child node named (density) that is not read. Valid options are: 
  |         name         |  opt/req  | Description 
  |----------------------|-----------|-----------------------------------------
  |       defaultDensity |  REQUIRED | Default Material Density 
  |   defaultBulkModulus |  OPTIONAL | Elastic Bulk Modulus Parameter 
  |  defaultShearModulus |  OPTIONAL | Elastic Shear Modulus Parameter 
  | defaultYoungsModulus |  OPTIONAL | Elastic Young's Modulus. 
  |  defaultPoissonRatio |  OPTIONAL | Poisson's ratio 

For more details, please refer to documentation at: 
http://geosx-geosx.readthedocs-hosted.com/en/latest/docs/sphinx/userGuide/Index.html 

Received signal 1: Hangup

** StackTrace of 9 frames **
Frame 1: cxx_utilities::handler(int, int, int)
Frame 2: cxx_utilities::handler1(int)
Frame 3: geosx::dataRepository::Group::ProcessInputFile(pugi::xml_node const&)
Frame 4: geosx::dataRepository::Group::ProcessInputFileRecursive(pugi::xml_node&)
Frame 5: geosx::dataRepository::Group::ProcessInputFileRecursive(pugi::xml_node&)
Frame 6: geosx::ProblemManager::ParseInputFile()
Frame 7: main
Frame 8: __libc_start_main
Frame 9: bin/geosx() [0x404653]
=====
```

For an invalid attribute:
```
(feature/improvedErrorMessages00 *+)$ bin/geosx -i integratedTests/solidMechanicsSSLE/SSLE-sedov.xml 
Max threads: 36
MKL max threads: 1
real64 is alias of double
localIndex is alias of long
globalIndex is alias of long long
GEOS must be configured to use Python to use parameters, symbolic math, etc. in input files
Adding Solver of type SolidMechanicsLagrangianSSLE, named lagsolve
Adding Mesh: InternalMesh, mesh1
Adding Event: PeriodicEvent, solverApplications
Adding Event: PeriodicEvent, restarts
Adding Output: Silo, siloOutput
Adding Output: Restart, restartOutput
Adding Geometric Object: Box, source
***** ERROR
***** LOCATION: /usr/workspace/settgast/Codes/geosx/GEOSX_develop/src/coreComponents/dataRepository/Group.cpp:178
***** Controlling expression (should be false): !readSuccess
Input variable defaultDensity is required in /Problem/Constitutive/LinearElasticIsotropic. Available options are: 
  |         name         |  opt/req  | Description 
  |----------------------|-----------|-----------------------------------------
  |       defaultDensity |  REQUIRED | Default Material Density 
  |   defaultBulkModulus |  OPTIONAL | Elastic Bulk Modulus Parameter 
  |  defaultShearModulus |  OPTIONAL | Elastic Shear Modulus Parameter 
  | defaultYoungsModulus |  OPTIONAL | Elastic Young's Modulus. 
  |  defaultPoissonRatio |  OPTIONAL | Poisson's ratio 

For more details, please refer to documentation at: 
http://geosx-geosx.readthedocs-hosted.com/en/latest/docs/sphinx/userGuide/Index.html 

Received signal 1: Hangup

** StackTrace of 11 frames **
Frame 1: cxx_utilities::handler(int, int, int)
Frame 2: cxx_utilities::handler1(int)
Frame 3: 
Frame 4: 
Frame 5: geosx::dataRepository::Group::ProcessInputFile(pugi::xml_node const&)
Frame 6: geosx::dataRepository::Group::ProcessInputFileRecursive(pugi::xml_node&)
Frame 7: geosx::dataRepository::Group::ProcessInputFileRecursive(pugi::xml_node&)
Frame 8: geosx::ProblemManager::ParseInputFile()
Frame 9: main
Frame 10: __libc_start_main
Frame 11: bin/geosx() [0x404653]
=====

```


resolves #694 
maybe #530 ?? At least part of this one. There may be more to do @klevzoff 

