### PR TITLE
Fix for failed linking on LC systems due to PR763

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,12 +96,13 @@ blt_add_executable(NAME geosx
 
 # Removing all transitive link dependencies from geosx_core target to circumvent
 # the BLT behavior which imposes all dependencies to be public
-set_target_properties(geosx_core PROPERTIES INTERFACE_LINK_LIBRARIES "")
+#set_target_properties(geosx_core PROPERTIES INTERFACE_LINK_LIBRARIES "")
 
 target_include_directories( geosx PUBLIC ${CMAKE_SOURCE_DIR}/coreComponents)
 
 # To change the runtime path during installation
 set_target_properties( geosx PROPERTIES INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib" )
+set_target_properties( geosx PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE )
 
 install(TARGETS geosx RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 


### PR DESCRIPTION
PR #763 broke our LC builds as described here:
https://github.com/GEOSX/GEOSX/commit/eb077abcd679ae41b46721ab7397c2075bf200ee

This fixes it....

@TotoGaz @af1990 This has to be fixed immediately. Also, requiring that we manually link in some dependencies on some platforms because we wiped the link dependencies seems counter-productive. 