### PR TITLE
Petsc without Fortran

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: minimal
 
 env:
   global:
-  - GEOSX_TPL_TAG=93-322
+  - GEOSX_TPL_TAG=96-325
 
 # The integrated test repository contains large data (using git lfs) and we do not use them here.
 # To save time (and money) we do not let travis automatically clone all our (lfs) subrepositories and do it by hand.


### PR DESCRIPTION
This PR simply updates the TPL TAG in `.travis.yml`.
It's related to PR #96 in `thirdPartyLibs`.