### PR TITLE
Fix PetscMatrix::clearRow()

### DIFF
--- a/src/coreComponents/linearAlgebra/interfaces/MatrixBase.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/MatrixBase.hpp
@@ -656,10 +656,14 @@ protected:
    * @brief Clear a row, and optionally set diagonal element to <tt>diagValue</tt>.
    * @param row globalIndex of the row to be cleared.
    * @param diagValue (Optional) set diagonal element to desired value.
+   * @param keepDiag if @p true, @p diagValue is ignored and original diagonal is preserved
+   * @return original diagonal value if matrix is square; zero otherwise
    *
+   * @note @p diagValue and @p keepDiag are ignored if the matrix is not square
    */
-  virtual void clearRow( globalIndex const row,
-                         real64 const diagValue ) = 0;
+  virtual real64 clearRow( globalIndex const row,
+                           bool const keepDiag = false,
+                           real64 const diagValue = 0.0 ) = 0;
 
   ///@}
 

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMatrix.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreMatrix.hpp
@@ -230,8 +230,9 @@ public:
 
   virtual void transpose( HypreMatrix & dst ) const override;
 
-  virtual void clearRow( globalIndex const row,
-                         real64 const diagValue ) override;
+  virtual real64 clearRow( globalIndex const row,
+                           bool const keepDiag = false,
+                           real64 const diagValue = 0.0 ) override;
 
   virtual localIndex maxRowLength() const override;
 

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscMatrix.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscMatrix.cpp
@@ -177,12 +177,34 @@ void PetscMatrix::open()
 void PetscMatrix::close()
 {
   GEOSX_LAI_ASSERT( !closed() );
+
+  // Initiate global assembly
   GEOSX_LAI_CHECK_ERROR( MatAssemblyBegin( m_mat, MAT_FINAL_ASSEMBLY ) );
   GEOSX_LAI_CHECK_ERROR( MatAssemblyEnd( m_mat, MAT_FINAL_ASSEMBLY ) );
-  GEOSX_LAI_CHECK_ERROR( MatSetOption( m_mat, MAT_NEW_NONZERO_LOCATIONS, PETSC_FALSE ) );
-  GEOSX_LAI_CHECK_ERROR( MatSetOption( m_mat, MAT_NEW_NONZERO_LOCATION_ERR, PETSC_TRUE ) );
-  GEOSX_LAI_CHECK_ERROR( MatSetOption( m_mat, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE ) );
-  GEOSX_LAI_CHECK_ERROR( MatSetOption( m_mat, MAT_NO_OFF_PROC_ZERO_ROWS, PETSC_TRUE ) );
+
+  // Clear any rows that have been marked for clearing
+  if( assembled() )
+  {
+    GEOSX_LAI_CHECK_ERROR( MatZeroRows( m_mat, m_rowsToClear.size(), m_rowsToClear, 1.0, nullptr, nullptr ) );
+
+    for( localIndex i = 0; i < m_rowsToClear.size(); ++i )
+    {
+      set( m_rowsToClear[i], m_rowsToClear[i], m_diagValues[i] );
+    }
+    GEOSX_LAI_CHECK_ERROR( MatAssemblyBegin( m_mat, MAT_FINAL_ASSEMBLY ) );
+    GEOSX_LAI_CHECK_ERROR( MatAssemblyEnd( m_mat, MAT_FINAL_ASSEMBLY ) );
+    m_rowsToClear.clear();
+    m_diagValues.clear();
+  }
+
+  // If this is initial assembly, set some useful options on the matrix
+  if( !assembled() )
+  {
+    GEOSX_LAI_CHECK_ERROR( MatSetOption( m_mat, MAT_NEW_NONZERO_LOCATIONS, PETSC_FALSE ) );
+    GEOSX_LAI_CHECK_ERROR( MatSetOption( m_mat, MAT_NEW_NONZERO_LOCATION_ERR, PETSC_TRUE ) );
+    GEOSX_LAI_CHECK_ERROR( MatSetOption( m_mat, MAT_KEEP_NONZERO_PATTERN, PETSC_TRUE ) );
+    GEOSX_LAI_CHECK_ERROR( MatSetOption( m_mat, MAT_NO_OFF_PROC_ZERO_ROWS, PETSC_TRUE ) );
+  }
   m_assembled = true;
   m_closed = true;
 }
@@ -568,38 +590,41 @@ void PetscMatrix::transpose( PetscMatrix & dst ) const
   dst.m_assembled = true;
 }
 
-void PetscMatrix::clearRow( globalIndex const globalRow,
-                            real64 const diagValue )
+real64 PetscMatrix::clearRow( globalIndex const globalRow,
+                              bool const keepDiag,
+                              real64 const diagValue )
 {
   GEOSX_LAI_ASSERT( modifiable() );
   GEOSX_LAI_ASSERT_GE( globalRow, ilower() );
   GEOSX_LAI_ASSERT_GT( iupper(), globalRow );
 
-  // The implementation below is not the most efficient, but we can't use
-  // PETCs's MatZeroRows because it is collective and clearRow() is not
-  localIndex const numEntries = globalRowLength( globalRow );
-  array1d< globalIndex > colIndices( numEntries );
-  array1d< real64 > values( numEntries );
-  values = 0.0;
-
+  PetscInt numEntries = 0;
   PetscInt const * inds;
-  GEOSX_LAI_CHECK_ERROR( MatGetRow( m_mat, globalRow, nullptr, &inds, nullptr ) );
+  PetscReal const * vals;
+  GEOSX_LAI_CHECK_ERROR( MatGetRow( m_mat, globalRow, &numEntries, &inds, &vals ) );
 
-  bool const isDiagonal = numGlobalRows() == numGlobalCols();
-  for( localIndex i = 0; i < numEntries; ++i )
+  bool const square = numGlobalRows() == numGlobalCols();
+
+  real64 oldDiag = 0.0;
+  if( square )
   {
-    colIndices[i] = inds[i];
-    if( colIndices[i] == globalRow && isDiagonal )
+    for( localIndex i = 0; i < numEntries; ++i )
     {
-      values[i] = diagValue;
+      if( inds[i] == globalRow )
+      {
+        oldDiag = vals[i];
+      }
     }
   }
-  GEOSX_LAI_CHECK_ERROR( MatRestoreRow( m_mat, globalRow, nullptr, &inds, nullptr ) );
-  set( globalRow, colIndices, values );
+  GEOSX_LAI_CHECK_ERROR( MatRestoreRow( m_mat, globalRow, &numEntries, &inds, &vals ) );
 
-  // Call a final assembly because PETSc consider the matrix not assembled after a set
-  GEOSX_LAI_CHECK_ERROR( MatAssemblyBegin( m_mat, MAT_FINAL_ASSEMBLY ) );
-  GEOSX_LAI_CHECK_ERROR( MatAssemblyEnd( m_mat, MAT_FINAL_ASSEMBLY ) );
+  // There is no legitimate way in PETSc to zero out a row in a local fashion,
+  // without any collective calls. Therefore, we store the rows to be cleared
+  // and perform the clearing at the next close() call.
+  m_rowsToClear.push_back( globalRow );
+  m_diagValues.push_back( keepDiag ? oldDiag : diagValue );
+
+  return oldDiag;
 }
 
 localIndex PetscMatrix::maxRowLength() const

--- a/src/coreComponents/linearAlgebra/interfaces/petsc/PetscMatrix.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/petsc/PetscMatrix.hpp
@@ -224,8 +224,9 @@ public:
 
   virtual void transpose( PetscMatrix & dst ) const override;
 
-  virtual void clearRow( globalIndex const globalRow,
-                         real64 const diagValue ) override;
+  virtual real64 clearRow( globalIndex const row,
+                           bool const keepDiag = false,
+                           real64 const diagValue = 0.0 ) override;
 
   virtual localIndex maxRowLength() const override;
 
@@ -288,6 +289,12 @@ private:
 
   /// Underlying Petsc object.
   Mat m_mat;
+
+  /// Indices of rows to be cleared on next close()
+  array1d< globalIndex > m_rowsToClear;
+
+  /// Diagonal values of rows to be set on next close()
+  array1d< real64 > m_diagValues;
 
 };
 

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraMatrix.hpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraMatrix.hpp
@@ -224,8 +224,9 @@ public:
 
   virtual void transpose( EpetraMatrix & dst ) const override;
 
-  virtual void clearRow( globalIndex const row,
-                         real64 const diagValue ) override;
+  virtual real64 clearRow( globalIndex const row,
+                           bool const keepDiag = false,
+                           real64 const diagValue = 0.0 ) override;
 
   virtual localIndex maxRowLength() const override;
 

--- a/src/coreComponents/managers/FieldSpecification/FieldSpecificationBase.hpp
+++ b/src/coreComponents/managers/FieldSpecification/FieldSpecificationBase.hpp
@@ -676,7 +676,7 @@ void FieldSpecificationBase::ZeroSystemRowsForBoundaryCondition( SortedArrayView
   for( auto a : targetSet )
   {
     globalIndex const dof = dofMap[a]+component;
-    matrix.clearRow( dof, 0.0 );
+    matrix.clearRow( dof );
   }
 }
 }

--- a/src/coreComponents/managers/FieldSpecification/FieldSpecificationOps.hpp
+++ b/src/coreComponents/managers/FieldSpecification/FieldSpecificationOps.hpp
@@ -377,8 +377,7 @@ struct FieldSpecificationEqual : public FieldSpecificationOp< OpEqual >
   {
     if( matrix.getLocalRowID( dof ) >= 0 )
     {
-      real64 const diag = matrix.getDiagValue( dof );
-      matrix.clearRow( dof, diag );
+      real64 const diag = matrix.clearRow( dof, true );
       rhs = -diag * (bcValue - fieldValue);
     }
     else


### PR DESCRIPTION
So, the last fix for `PetscMatrix::clearRow()` in https://github.com/GEOSX/GEOSX/pull/847 had a bug that got overlooked. Namely, if there were different numbers of BC rows to be cleared on different ranks, `MatAssemblyBegin`/`MatAssemblyEnd` would be called different number of times, and PETSc would eventually crash due to non-matching MPI calls. An easy reproducer is to run
```
mpirun -n 2 ./geosx -i ../src/coreComponents/physicsSolvers/fluidFlow/integratedTests/compositionalMultiphaseFlow/deadoil_3ph_staircase_3d.xml -x 2
```

After spending some time in PETSc documentation and source code, I'm convinced that there is no legitimate way to just clear a single row locally. Therefore, this PR changes the implementation (in `PetscMatrix` only) to instead accumulate a list of row indices to be cleared, and then physically do the clearing in a single `MatZeroRows` call on the next closing of the matrix. This seems to work well as I was able to pass integrated tests with a PETSc-based build (obviously, except for Hydrofracture solver, and minor diffs in compositional tests, as usual).

In addition, I slightly changed the interface of `clearRow`. In particular, it returns the old diagonal value which eliminates the need to separately call `getDiagValue()` when applying the BC (this is also how the old block interface used to work). There is also the option to keep old diagonal value or replace with a new one.