### PR TITLE
Clear nonLocalGhosts before populating.

### DIFF
--- a/src/coreComponents/managers/ObjectManagerBase.hpp
+++ b/src/coreComponents/managers/ObjectManagerBase.hpp
@@ -213,6 +213,7 @@ public:
   {
     arrayView1d< localIndex const > const & ghostsToSend = getNeighborData( neighborRank ).ghostsToSend();
     array1d< std::pair< globalIndex, int > > & nonLocalGhosts = getNeighborData( neighborRank ).nonLocalGhosts();
+    nonLocalGhosts.clear();
 
     for( localIndex const index : ghostsToSend )
     {


### PR DESCRIPTION
Caught from #841 

So we run `ObjectManagerBase::SetGhostRankForSenders` twice. The first time we populate `nonLocalGhosts` and use it to fix any communication issues. The second time is after we've fixed the issues. After the second time through `verifyGhostingConsistency` in `CommunicationTools.cpp` is called which checks that everything each rank owns everything they are sending and that each object being received is coming from the rank that owns it. It also checks that `nonLocalGhosts` is empty, since everything should have been correct the second time through `SetGhostRankForSenders`. However `nonLocalGhosts` wasn't being cleared between the two calls to `SetGhostRankForSenders`. I don't know how this got past me.

Edit:
It didn't get past me in my initial PR, I added the check later.
https://github.com/GEOSX/GEOSX/blame/99ea9f814a83adec7b9754cfbc70ac9da466007e/src/coreComponents/mpiCommunications/CommunicationTools.cpp#L518