### PR TITLE
Increased snprintf buffer size and error checking.

### DIFF
--- a/src/coreComponents/dataRepository/ConduitRestart.cpp
+++ b/src/coreComponents/dataRepository/ConduitRestart.cpp
@@ -58,9 +58,9 @@ std::string writeRootFile( conduit::Node & root, std::string const & rootPath )
 
   MpiWrapper::Barrier( MPI_COMM_GEOSX );
 
-  char buffer[ 200 ];
-  std::snprintf( buffer, 200, "%s/rank_%07d.hdf5", rootPath.data(), MpiWrapper::Comm_rank() );
-  return buffer;
+  std::vector< char > buffer( rootPath.size() + 64 );
+  GEOSX_ERROR_IF_GE( std::snprintf( buffer.data(), buffer.size(), "%s/rank_%07d.hdf5", rootPath.data(), MpiWrapper::Comm_rank() ), 1024 );
+  return buffer.data();
 }
 
 
@@ -86,8 +86,8 @@ std::string readRootNode( std::string const & rootPath )
 
   MpiWrapper::Broadcast( rankFilePattern, 0 );
 
-  char buffer[ 200 ];
-  std::snprintf( buffer, 200, rankFilePattern.data(), MpiWrapper::Comm_rank() );
+  char buffer[ 1024 ];
+  GEOSX_ERROR_IF_GE( std::snprintf( buffer, 1024, rankFilePattern.data(), MpiWrapper::Comm_rank() ), 1024 );
   return buffer;
 }
 

--- a/src/coreComponents/managers/Outputs/BlueprintOutput.cpp
+++ b/src/coreComponents/managers/Outputs/BlueprintOutput.cpp
@@ -145,9 +145,9 @@ void BlueprintOutput::Execute( real64 const time,
   GEOSX_ASSERT_MSG( conduit::blueprint::mesh::index::verify( index, info ), info.to_json() );
 
   /// Write out the root index file, then write out the mesh.
-  char rootFilePath[ 64 ];
-  sprintf( rootFilePath, "blueprintFiles/cycle_%07d", cycle );
-  std::string const filePathForRank = dataRepository::writeRootFile( fileRoot, rootFilePath );
+  char buffer[ 128 ];
+  GEOSX_ERROR_IF_GE( snprintf( buffer, 128, "blueprintFiles/cycle_%07d", cycle ), 128 );
+  std::string const filePathForRank = dataRepository::writeRootFile( fileRoot, buffer );
   conduit::relay::io::save( meshRoot, filePathForRank, "hdf5" );
 }
 


### PR DESCRIPTION
This doesn't fix the issue we've been having with `mkdir -p` failing, but it does fix these kind of errors
https://github.com/GEOSX/NightlyTests/blob/master/quartz/integratedTestsDebugFiles/compositional_multiphase_wells_1d_01.err