### PR TITLE
Fixed bug in the BatchUpdate for CompressibleSinglePhaseFluid

### DIFF
--- a/src/coreComponents/constitutive/fluid/CompressibleSinglePhaseFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/CompressibleSinglePhaseFluid.cpp
@@ -160,7 +160,7 @@ void CompressibleSinglePhaseFluid::BatchUpdate( arrayView1d< double const > cons
   } );
   makeExponentialRelation( m_viscosityModelType, m_referencePressure, m_referenceViscosity, m_viscosibility, [&] ( auto relation )
   {
-    SingleFluidBase::BatchDensityUpdateKernel< CompressibleSinglePhaseFluid >( pressure, relation );
+    SingleFluidBase::BatchViscosityUpdateKernel< CompressibleSinglePhaseFluid >( pressure, relation );
   } );
 }
 


### PR DESCRIPTION
This bug went unnoticed because this function is currently never called in the solvers. Therefore this PR does not need a rebaseline of the integrated tests.