### PR TITLE
Change error message when event not found.

### DIFF
--- a/src/coreComponents/managers/Events/EventBase.cpp
+++ b/src/coreComponents/managers/Events/EventBase.cpp
@@ -143,7 +143,7 @@ void EventBase::GetTargetReferences()
   {
     Group * tmp = this->GetGroupByPath( m_eventTarget );
     m_target = Group::group_cast< ExecutableGroup * >( tmp );
-    GEOSX_ERROR_IF( m_target == nullptr, "The target of an event must be executable! " << m_target );
+    GEOSX_ERROR_IF( m_target == nullptr, "The event " << m_eventTarget << " does not exist or it is not executable." );
   }
 
   this->forSubGroups< EventBase >( []( EventBase & subEvent )


### PR DESCRIPTION
The original message was not very clear and returns a pointer value (which is 0). Now it returns the path of the Event.