### PR TITLE
Prevent using solid mechanics Lagragian FEM kernels on GPU.

### DIFF
--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEMKernels.hpp
@@ -113,9 +113,11 @@ ElementKernelLaunchSelector( localIndex NUM_NODES_PER_ELEM,
     }
     else if( NUM_NODES_PER_ELEM==4 && NUM_QUADRATURE_POINTS==1 )
     {
+      #if defined( GEOSX_USE_CUDA )
       GEOSX_ERROR( "Not implemented!" );
-//      rval = KERNELWRAPPER::template Launch< 4, 1, CONSTITUTIVE_TYPE >( constitutive,
-//                                                                        std::forward< PARAMS >( params )... );
+      #else
+      rval = KERNELWRAPPER::template Launch< 4, 1, CONSTITUTIVE_TYPE >( constitutive, std::forward< PARAMS >( params )... );
+      #endif
     }
   } );
   return rval;


### PR DESCRIPTION
One combination of parameters is avoided. Another is still there.

Related to issue https://github.com/GEOSX/GEOSX/issues/957