### PR TITLE
Fix table caption bug in Publications.rst

### DIFF
--- a/src/docs/sphinx/Publications.rst
+++ b/src/docs/sphinx/Publications.rst
@@ -2,7 +2,7 @@
 Publications
 ###############################################################################
 
-Last updated 13-July-2020
+Last updated 14-July-2020
 
 Preprints
 =========
@@ -11,25 +11,25 @@ Preprints
    :widths: 100
    :header-rows: 0
 
-  * - | **Simulation of coupled multiphase flow and geomechanics in porous media with embedded discrete fractures**
-      | M Cusini, JA White, N Castelletto, RR Settgast
-      | arXiv preprint
-      | `arXiv:2007.05069 <https://arxiv.org/abs/2007.05069>`_
+   * - | **Simulation of coupled multiphase flow and geomechanics in porous media with embedded discrete fractures**
+       | M Cusini, JA White, N Castelletto, RR Settgast
+       | arXiv preprint
+       | `arXiv:2007.05069 <https://arxiv.org/abs/2007.05069>`_
 
-  * - | **Nonlinear multigrid based on local spectral coarsening for heterogeneous diffusion problems**
-      | CS Lee, F Hamon, N Castelletto, PS Vassilevski, JA White
-      | arXiv preprint
-      | `arXiv:2005.01275 <https://arxiv.org/abs/2005.01275>`_
+   * - | **Nonlinear multigrid based on local spectral coarsening for heterogeneous diffusion problems**
+       | CS Lee, F Hamon, N Castelletto, PS Vassilevski, JA White
+       | arXiv preprint
+       | `arXiv:2005.01275 <https://arxiv.org/abs/2005.01275>`_
 
-  * - | **Efficient solvers for hybridized three-field mixed finite element coupled poromechanics**
-      | M Frigo, N Castelletto, M Ferronato, JA White
-      | arXiv preprint
-      | `arXiv:2002.09603 <https://arxiv.org/abs/2002.09603>`_
+   * - | **Efficient solvers for hybridized three-field mixed finite element coupled poromechanics**
+       | M Frigo, N Castelletto, M Ferronato, JA White
+       | arXiv preprint
+       | `arXiv:2002.09603 <https://arxiv.org/abs/2002.09603>`_
 
-  * - | **Enhanced multiscale restriction-smoothed basis (MsRSB) preconditioning with applications to porous media flow and geomechanics**
-      | S Bosma, S Klevtsov, O Møyner, N Castelletto
-      | arXiv preprint
-      | `arXiv:1912.06934 <https://arxiv.org/abs/1912.06934>`_
+   * - | **Enhanced multiscale restriction-smoothed basis (MsRSB) preconditioning with applications to porous media flow and geomechanics**
+       | S Bosma, S Klevtsov, O Møyner, N Castelletto
+       | arXiv preprint
+       | `arXiv:1912.06934 <https://arxiv.org/abs/1912.06934>`_
 
 
 2020
@@ -39,40 +39,40 @@ Preprints
    :widths: 100
    :header-rows: 0
 
-  * - | **An inelastic homogenization framework for layered materials with planes of weakness**
-      | SJ Semnani, JA White
-      | Computer Methods in Applied Mechanics and Engineering 370, 113221
-      | `doi:10.1016/j.cma.2020.113221 <https://doi.org/10.1016/j.cma.2020.113221>`_
+   * - | **An inelastic homogenization framework for layered materials with planes of weakness**
+       | SJ Semnani, JA White
+       | Computer Methods in Applied Mechanics and Engineering 370, 113221
+       | `doi:10.1016/j.cma.2020.113221 <https://doi.org/10.1016/j.cma.2020.113221>`_
 
-  * - | **Algebraically stabilized Lagrange multiplier method for frictional contact mechanics with hydraulically active fractures**.
-      | A Franceschini, N Castelletto, JA White, HA Tchelepi
-      | Computer Methods in Applied Mechanics and Engineering 368, 113161
-      | `doi:10.1016/j.cma.2020.113161 <https://doi.org/10.1016/j.cma.2020.113161>`_
+   * - | **Algebraically stabilized Lagrange multiplier method for frictional contact mechanics with hydraulically active fractures**.
+       | A Franceschini, N Castelletto, JA White, HA Tchelepi
+       | Computer Methods in Applied Mechanics and Engineering 368, 113161
+       | `doi:10.1016/j.cma.2020.113161 <https://doi.org/10.1016/j.cma.2020.113161>`_
 
-  * - | **A macroelement stabilization for mixed finite element/finite volume discretizations of multiphase poromechanics**
-      | JT Camargo, JA White, RI Borja
-      | Computational Geosciences
-      | `doi:10.1007/s10596-020-09964-3 <https://doi.org/10.1007/s10596-020-09964-3>`_
+   * - | **A macroelement stabilization for mixed finite element/finite volume discretizations of multiphase poromechanics**
+       | JT Camargo, JA White, RI Borja
+       | Computational Geosciences
+       | `doi:10.1007/s10596-020-09964-3 <https://doi.org/10.1007/s10596-020-09964-3>`_
 
-  * - | **Approximate inverse-based block preconditioners in poroelasticity**
-      | A Franceschini, N Castelletto, M Ferronato
-      | Computational Geosciences
-      | `doi:10.1007/s10596-020-09981-2 <https://doi.org/10.1007/s10596-020-09981-2>`_
+   * - | **Approximate inverse-based block preconditioners in poroelasticity**
+       | A Franceschini, N Castelletto, M Ferronato
+       | Computational Geosciences
+       | `doi:10.1007/s10596-020-09981-2 <https://doi.org/10.1007/s10596-020-09981-2>`_
 
-  * - | **Multi-stage preconditioners for thermal–compositional–reactive flow in porous media**.
-      | MA Cremon, N Castelletto, JA White
-      | Journal of Computational Physics, 109607
-      | `doi:10.1016/j.jcp.2020.109607 <https://doi.org/10.1016/j.jcp.2020.109607>`_
+   * - | **Multi-stage preconditioners for thermal–compositional–reactive flow in porous media**.
+       | MA Cremon, N Castelletto, JA White
+       | Journal of Computational Physics, 109607
+       | `doi:10.1016/j.jcp.2020.109607 <https://doi.org/10.1016/j.jcp.2020.109607>`_
 
-  * - | **Scalable multigrid reduction framework for multiphase poromechanics of heterogeneous media**
-      | QM Bui, D Osei-Kuffuor, N Castelletto, JA White
-      | SIAM Journal on Scientific Computing 42 (2), B379-B396
-      | `doi:10.1137/19M1256117 <https://doi.org/10.1137/19M1256117>`_
+   * - | **Scalable multigrid reduction framework for multiphase poromechanics of heterogeneous media**
+       | QM Bui, D Osei-Kuffuor, N Castelletto, JA White
+       | SIAM Journal on Scientific Computing 42 (2), B379-B396
+       | `doi:10.1137/19M1256117 <https://doi.org/10.1137/19M1256117>`_
 
-  * - | **Fully implicit multidimensional hybrid upwind scheme for coupled flow and transport**
-      | F Hamon, B Mallison
-      | Computer Methods in Applied Mechanics and Engineering  358, 112606
-      | `doi:10.1016/j.cma.2019.112606 <https://doi.org/10.1016/j.cma.2019.112606>`_
+   * - | **Fully implicit multidimensional hybrid upwind scheme for coupled flow and transport**
+       | F Hamon, B Mallison
+       | Computer Methods in Applied Mechanics and Engineering  358, 112606
+       | `doi:10.1016/j.cma.2019.112606 <https://doi.org/10.1016/j.cma.2019.112606>`_
 
 
 2019
@@ -82,22 +82,24 @@ Preprints
    :widths: 100
    :header-rows: 0
 
-  * - | **A two-stage preconditioner for multiphase poromechanics in reservoir simulation**
-      | JA White, N Castelletto, S Klevtsov, QM Bui, D Osei-Kuffuor, HA Tchelepi
-      | Computer Methods in Applied Mechanics and Engineering 357, 112575
-      | `doi:10.1016/j.cma.2019.112575 <https://doi.org/10.1016/j.cma.2019.112575>`_
+   * - | **A two-stage preconditioner for multiphase poromechanics in reservoir simulation**
+       | JA White, N Castelletto, S Klevtsov, QM Bui, D Osei-Kuffuor, HA Tchelepi
+       | Computer Methods in Applied Mechanics and Engineering 357, 112575
+       | `doi:10.1016/j.cma.2019.112575 <https://doi.org/10.1016/j.cma.2019.112575>`_
 
-  * - | **Multiscale two-stage solver for Biot’s poroelasticity equations in subsurface media**
-      | N Castelletto, S Klevtsov, H Hajibeygi, HA Tchelepi
-      | Computational Geosciences 23 (2), 207-224
-      | `doi:10.1007/s10596-018-9791-z <https://doi.org/10.1007/s10596-018-9791-z>`_
+   * - | **Multiscale two-stage solver for Biot’s poroelasticity equations in subsurface media**
+       | N Castelletto, S Klevtsov, H Hajibeygi, HA Tchelepi
+       | Computational Geosciences 23 (2), 207-224
+       | `doi:10.1007/s10596-018-9791-z <https://doi.org/10.1007/s10596-018-9791-z>`_
 
-  * - | **Block preconditioning for fault/fracture mechanics saddle-point problems**
-      | A Franceschini, N Castelletto, M Ferronato
-      | Computer Methods in Applied Mechanics and Engineering 344, 376-401
-      | `doi:10.1016/j.cma.2018.09.039 <https://doi.org/10.1016/j.cma.2018.09.039>`_
+   * - | **Block preconditioning for fault/fracture mechanics saddle-point problems**
+       | A Franceschini, N Castelletto, M Ferronato
+       | Computer Methods in Applied Mechanics and Engineering 344, 376-401
+       | `doi:10.1016/j.cma.2018.09.039 <https://doi.org/10.1016/j.cma.2018.09.039>`_
 
-  * - | **A relaxed physical factorization preconditioner for mixed finite element coupled poromechanics**
-      | M Frigo, N Castelletto, M Ferronato
-      | SIAM Journal on Scientific Computing 41 (4), B694-B720
-      | `doi:10.1137/18M120645X <https://doi.org/10.1137/18M120645X>`_
+   * - | **A relaxed physical factorization preconditioner for mixed finite element coupled poromechanics**
+       | M Frigo, N Castelletto, M Ferronato
+       | SIAM Journal on Scientific Computing 41 (4), B694-B720
+       | `doi:10.1137/18M120645X <https://doi.org/10.1137/18M120645X>`_
+
+


### PR DESCRIPTION
The odd table caption is due to a space missing in the table alignment.