### PR TITLE
Changed path definition from string to Path in TableFunction

### DIFF
--- a/src/coreComponents/fileIO/schema/docs/TableFunction.rst
+++ b/src/coreComponents/fileIO/schema/docs/TableFunction.rst
@@ -3,13 +3,13 @@
 =============== ============ ======== ============================================================== 
 Name            Type         Default  Description                                                    
 =============== ============ ======== ============================================================== 
-coordinateFiles string_array {}       List of coordinate file names for ND Table                     
+coordinateFiles path_array   {}       List of coordinate file names for ND Table                     
 coordinates     real64_array {0}      Coordinates inputs for 1D tables                               
 inputVarNames   string_array {}       Name of fields are input to function.                          
 interpolation   string       linear   Interpolation method (options = linear, nearest, upper, lower) 
 name            string       required A name is required for any non-unique nodes                    
 values          real64_array {0}      Values for 1D tables                                           
-voxelFile       string                Voxel file name for ND Table                                   
+voxelFile       path                  Voxel file name for ND Table                                   
 =============== ============ ======== ============================================================== 
 
 

--- a/src/coreComponents/fileIO/schema/schema.xsd
+++ b/src/coreComponents/fileIO/schema/schema.xsd
@@ -404,7 +404,7 @@
 	</xsd:complexType>
 	<xsd:complexType name="TableFunctionType">
 		<!--coordinateFiles => List of coordinate file names for ND Table-->
-		<xsd:attribute name="coordinateFiles" type="string_array" default="{}" />
+		<xsd:attribute name="coordinateFiles" type="path_array" default="{}" />
 		<!--coordinates => Coordinates inputs for 1D tables-->
 		<xsd:attribute name="coordinates" type="real64_array" default="{0}" />
 		<!--inputVarNames => Name of fields are input to function.-->
@@ -414,7 +414,7 @@
 		<!--values => Values for 1D tables-->
 		<xsd:attribute name="values" type="real64_array" default="{0}" />
 		<!--voxelFile => Voxel file name for ND Table-->
-		<xsd:attribute name="voxelFile" type="string" default="" />
+		<xsd:attribute name="voxelFile" type="path" default="" />
 		<!--name => A name is required for any non-unique nodes-->
 		<xsd:attribute name="name" type="string" use="required" />
 	</xsd:complexType>

--- a/src/coreComponents/managers/Functions/TableFunction.hpp
+++ b/src/coreComponents/managers/Functions/TableFunction.hpp
@@ -130,10 +130,10 @@ private:
   real64_array m_tableCoordinates1D;
 
   /// List of table coordinate file names
-  string_array m_coordinateFiles;
+  array1d< Path > m_coordinateFiles;
 
   /// Table voxel file names
-  string m_voxelFile;
+  Path m_voxelFile;
 
   /// Table interpolation method input string
   string m_interpolationMethodString;


### PR DESCRIPTION
While running the Tutorial 3, the following error appeared 
![image](https://user-images.githubusercontent.com/68332658/88052406-7fcf2b00-cb5a-11ea-9362-ac13478113d2.png) 
It showed that in the file GEOSX/src/coreComponents/managers/Functions/TableFunction.hpp the paths are written as string_array and string

https://github.com/GEOSX/GEOSX/blob/b91787ff152ddcd26bffc955fd4030833c019c3c/src/coreComponents/managers/Functions/TableFunction.hpp#L132-L136
I changed them to array1d< Path > and Path object so the global path can be received correctly