### PR TITLE
Making string emptiness comparison more explicit

### DIFF
--- a/src/coreComponents/managers/ProblemManager.cpp
+++ b/src/coreComponents/managers/ProblemManager.cpp
@@ -309,7 +309,7 @@ void ProblemManager::GenerateDocumentation()
   Group * commandLine = GetGroup< Group >( groupKeys.commandLine );
   std::string const & schemaName = commandLine->getReference< std::string >( viewKeys.schemaFileName );
 
-  if( not schemaName.empty() )
+  if( !schemaName.empty() )
   {
     // Generate an extensive data structure
     GenerateDataStructureSkeleton( 0 );


### PR DESCRIPTION
Changing `schemaName.empty() == 0` with `not schemaName.empty()` for better readability.
I think `not` (like `and`, `or`...) is in the standard so I like using it.
What is the GEOSX policy on this?
