### PR TITLE
Modify submodule CI test

### DIFF
--- a/scripts/test_submodule_updated.sh
+++ b/scripts/test_submodule_updated.sh
@@ -58,44 +58,28 @@ do
     continue
   fi
 
-  # Check if PR has modified the submodule
-  submodule_modified=0
-  for modification in "${diff_array[@]}"
-  do
-    if [ "${paths_array[$i]}" = "$modification" ]
-    then
-      submodule_modified=1
-      break
-    fi
-  done
+  # Check hashes if not excluded
 
-  if [ $submodule_modified -eq 0 ]
+  # Submodule's main branch
+  main_branch="${main_branches[$module_name]}"
+
+  # Submodule main hash
+  main_hash="$( git -C ${paths_array[$i]} rev-parse $main_branch )"
+
+  # PR hash with prefixed character removed
+  pr_hash="$( echo ${pr_hashes_array[$i]} | tr -cd [:alnum:] )"
+
+  if [ $pr_hash == $main_hash ]
   then
-    echo "PR branch does not change module $module_name"
-  else 
-    # Check hashes if not excluded and differs from develop's hash
-
-    # Submodule's main branch
-    main_branch="${main_branches[$module_name]}"
-
-    # Submodule main hash
-    main_hash="$( git -C ${paths_array[$i]} rev-parse $main_branch )"
-
-    # PR hash with prefixed character removed
-    pr_hash="$( echo ${pr_hashes_array[$i]} | tr -cd [:alnum:] )"
-
-    if [ $pr_hash == $main_hash ]
-    then
-      echo "PR branch and $main_branch have the same hashes for submodule"\
-           "$module_name : $pr_hash"
-    else
-      echo "PR branch and $main_branch have different hashes for submodule"\
-           "$module_name:"
-      echo "---- PR branch has hash $pr_hash"
-      echo "---- $module_name/$main_branch has hash $main_hash"
-      unsync_submodules+=( "$module_name" )
-      exit_code=1
-    fi
+    echo "PR branch and $main_branch have the same hashes for submodule"\
+         "$module_name : $pr_hash"
+  else
+    echo "PR branch and $main_branch have different hashes for submodule"\
+         "$module_name:"
+    echo "---- PR branch has hash $pr_hash"
+    echo "---- $module_name/$main_branch has hash $main_hash"
+    unsync_submodules+=( "$module_name" )
+    exit_code=1
   fi
 done
 


### PR DESCRIPTION
This PR modifies the Travis CI job that verifies a PR's submodule hashes are up to date with each submodule's main branch.

- Removes a check to see if the PR has modified a submodule before verifying the PR and submodule hash.
- Travis CI job will now always compare PR and submodule hashes.  All other PR's will be blocked from merging to GEOSX if a specific PR's submodule changes have been merged, but the specific PR has not yet merged with GEOSX.