### PR TITLE
Add MPI barrier after creating composite input XML

### DIFF
--- a/src/coreComponents/dataRepository/xmlWrapper.hpp
+++ b/src/coreComponents/dataRepository/xmlWrapper.hpp
@@ -78,12 +78,13 @@ constexpr char const includedFileTag[] = "File";
 /**
  * @brief Function to add xml nodes from included files.
  * @param targetNode the node for which to look for included children specifications
+ * @param level include tree level used to detect circular includes
  *
  * This function looks for a "Included" node under the targetNode, loops over all subnodes under the "Included"
  * node, and then parses the file specified in those subnodes taking all the nodes in the file and adding them to
  * the targetNode.
  */
-void addIncludedXML( xmlNode & targetNode );
+void addIncludedXML( xmlNode & targetNode, int level = 0 );
 
 /**
  * @brief Function to handle multiple input xml files.


### PR DESCRIPTION
This small PR adds a barrier to writing composite input XML that ensures it is fully written by one rank before any other rank attempts to read it. I was able to reliably reproduce this issue on `develop` when running with 16 ranks or more. It also adds circular include detection, similar to the one in `geosx_xml_tools` preprocessor.