### PR TITLE
Expose a bug with restart serialization

### DIFF
--- a/src/coreComponents/dataRepository/unitTests/CMakeLists.txt
+++ b/src/coreComponents/dataRepository/unitTests/CMakeLists.txt
@@ -7,6 +7,7 @@ set( dataRepository_tests
      testWrapper.cpp
      testXmlWrapper.cpp
      testBufferOps.cpp
+     testRestartAfterGroupRemoval.cpp
    )
 
 set( dependencyList gtest dataRepository )

--- a/src/coreComponents/dataRepository/unitTests/testRestartAfterGroupRemoval.cpp
+++ b/src/coreComponents/dataRepository/unitTests/testRestartAfterGroupRemoval.cpp
@@ -1,0 +1,104 @@
+
+#include "dataRepository/Group.hpp"
+
+#include <conduit.hpp>
+#include <conduit_relay_io.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace geosx::dataRepository;
+
+void testConduit( bool const removeOne )
+{
+  std::string const filename = GEOSX_FMT( "conduit-{}.hdf5", removeOne );
+
+  // write data
+  {
+    conduit::Node root;
+    conduit::Node & group = root["group"];
+    for( int i = 0; i < 3; ++i )
+    {
+      conduit::Node & subgroup = group[std::to_string( i )];
+      subgroup["data"] = i;
+    }
+    if( removeOne ) group.remove( "0" );
+    conduit::relay::io::save( root, filename, "hdf5" );
+  }
+
+  // read data
+  {
+    conduit::Node root;
+    conduit::relay::io::load( filename, "hdf5", root );
+    conduit::Node const & group = root["group"];
+    for( int i = 1; i < 3; ++i )
+    {
+      conduit::Node const & subgroup = group[ std::to_string( i ) ];
+      int const value = subgroup["data"].value();
+      EXPECT_EQ( value, i );
+    }
+  }
+}
+
+TEST( conduit, noRemoval )
+{
+  testConduit( false );
+}
+
+TEST( conduit, withRemoval )
+{
+  testConduit( true );
+}
+
+void testDataRepository( bool const removeOne )
+{
+  std::string const filename = GEOSX_FMT( "dataRepository-{}.hdf5", removeOne );
+
+  // write data
+  {
+    conduit::Node root;
+    Group group( "group", root );
+    for( int i = 0; i < 3; ++i )
+    {
+      Group & subgroup = group.registerGroup( std::to_string( i ) );
+      subgroup.registerWrapper< int >( "data" )
+        .setSizedFromParent( false )
+        .setRestartFlags( RestartFlags::WRITE_AND_READ )
+        .reference() = i;
+    }
+    if( removeOne ) group.deregisterGroup( "0" );
+    group.prepareToWrite();
+    conduit::relay::io::save( root, filename, "hdf5" );
+    group.finishWriting();
+  }
+
+  // read data
+  {
+    conduit::Node root;
+    conduit::relay::io::load( filename, "hdf5", root );
+    Group group( "group", root );
+    for( int i = 1; i < 3; ++i )
+    {
+      Group & subgroup = group.registerGroup( std::to_string( i ) );
+      subgroup.registerWrapper< int >( "data" )
+        .setSizedFromParent( false )
+        .setRestartFlags( RestartFlags::WRITE_AND_READ );
+    }
+    group.loadFromConduit();
+    for( int i = 1; i < 3; ++i )
+    {
+      Group const & subgroup = group.getGroup( std::to_string( i ) );
+      int const value = subgroup.getReference< int >( "data" );
+      EXPECT_EQ( value, i );
+    }
+  }
+}
+
+TEST( dataRepository, noRemoval )
+{
+  testDataRepository( false );
+}
+
+TEST( dataRepository, withRemoval )
+{
+  testDataRepository( true );
+}


### PR DESCRIPTION
This PR is a reproducer for https://github.com/GEOSX/GEOSX/issues/1834.
It adds a unit test that exposes a bug in our restart serialization that occurs after a Group is removed via a call to `deregisterGroup()`.

It creates a simple tree of a root group and three subgroups (minimum number required to trigger the bug) and one wrapper on each.
Then the first group (named "0") is optionally removed, and the remaining tree is written to restart. Attempting to populate the tree from restart file leads to an exception being thrown with the message:
```
{
  "file": "/home/geosx/thirdPartyLibs/build-gcc8-release/conduit/src/conduit/src/libs/conduit/conduit_node.cpp",
  "line": 12043,
  "message": "Cannot fetch non-existent child \"__size__\" from Node(group/2)"
}
```
Manual inspection of the `.hdf5` file also reveals that it was not written correctly:
```
HDF5 "dataRepository-true.hdf5" {
GROUP "/" {
   GROUP "group" {
      GROUP "1" {
         DATASET "__size__" {
            DATATYPE  H5T_STD_I32LE
            DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
            DATA {
            (0): 0
            }
         }
         GROUP "data" {
            DATASET "__sizedFromParent__" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
               DATA {
               (0): 0
               }
            }
            DATASET "__values__" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
               DATA {
               (0): 1
               }
            }
         }
      }
      GROUP "2" {
         DATASET "data" {
            DATATYPE  H5T_OPAQUE {
               OPAQUE_TAG "";
            }
            DATASPACE  NULL
            DATA {
            }
         }
      }
      DATASET "__size__" {
         DATATYPE  H5T_STD_I32LE
         DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
         DATA {
         (0): 0
         }
      }
   }
}
}
```
Here group "0" is (correctly) missing, group "1" is (correctly) written in full, and group "2"'s wrapper is not properly written: note that "data" is added as a `DATASET` with unknown type, instead of being a `GROUP` with nested datasets.

Attempts to reproduce this issue directly with `conduit` nodes (also present in test) are unsuccessful: everything is written and read correctly. So it's somehow related to `dataRepository` classes, although it could also be a `conduit` bug that is only reproduced under very specific usage.

This PR is not intended for merging, unless we develop a bugfix on the same branch.