### PR TITLE
Changes for lassen clang10-cuda11.2 and clang13-cuda11.6 host-configs

### DIFF
--- a/host-configs/LLNL/lassen-base.cmake
+++ b/host-configs/LLNL/lassen-base.cmake
@@ -25,20 +25,6 @@ set(ENABLE_OPENMP ON CACHE BOOL "" FORCE)
 # LvArray sets this to the CMAKE_CXX_COMPILER.
 set(CMAKE_CUDA_HOST_COMPILER ${MPI_CXX_COMPILER} CACHE STRING "")
 
-# ESSL
-set(ENABLE_ESSL ON CACHE BOOL "")
-set(ESSL_INCLUDE_DIRS /usr/tcetmp/packages/essl/essl-6.3.0.1/include CACHE STRING "")
-set(ESSL_LIBRARIES /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/libesslsmpcuda.so
-                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlsmp.so
-                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlfmath.so
-                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlf90_r.so
-                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcublas.so
-                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcudart.so
-                   /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/liblapackforessl.so
-                   /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/liblapackforessl_.so
-                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxl.a
-                   CACHE PATH "")
-
 # TPL
 set(ENABLE_PAPI OFF CACHE BOOL "")
 set(SILO_BUILD_TYPE powerpc64-unknown-linux-gnu CACHE STRING "")

--- a/host-configs/LLNL/lassen-base.cmake
+++ b/host-configs/LLNL/lassen-base.cmake
@@ -27,15 +27,15 @@ set(CMAKE_CUDA_HOST_COMPILER ${MPI_CXX_COMPILER} CACHE STRING "")
 
 # ESSL
 set(ENABLE_ESSL ON CACHE BOOL "")
-set(ESSL_INCLUDE_DIRS /usr/tcetmp/packages/essl/essl-6.2.1/include CACHE STRING "")
-set(ESSL_LIBRARIES /usr/tcetmp/packages/essl/essl-6.2.1/lib64/libesslsmpcuda.so
+set(ESSL_INCLUDE_DIRS /usr/tcetmp/packages/essl/essl-6.3.0.1/include CACHE STRING "")
+set(ESSL_LIBRARIES /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/libesslsmpcuda.so
                    /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlsmp.so
                    /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlfmath.so
                    /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlf90_r.so
                    ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcublas.so
                    ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcudart.so
-                   /usr/tcetmp/packages/essl/essl-6.2.1/lib64/liblapackforessl.so
-                   /usr/tcetmp/packages/essl/essl-6.2.1/lib64/liblapackforessl_.so
+                   /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/liblapackforessl.so
+                   /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/liblapackforessl_.so
                    /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxl.a
                    CACHE PATH "")
 

--- a/host-configs/LLNL/lassen-clang10-cuda11.cmake
+++ b/host-configs/LLNL/lassen-clang10-cuda11.cmake
@@ -13,4 +13,18 @@ set(MPI_Fortran_COMPILER /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-rel
 
 include(${CMAKE_CURRENT_LIST_DIR}/lassen-base.cmake)
 
+# ESSL
+set(ENABLE_ESSL ON CACHE BOOL "")
+set(ESSL_INCLUDE_DIRS /usr/tcetmp/packages/essl/essl-6.3.0.1/include CACHE STRING "")
+set(ESSL_LIBRARIES /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/libesslsmpcuda.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlsmp.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlfmath.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlf90_r.so
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcublas.so
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcudart.so
+                   /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/liblapackforessl.so
+                   /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/liblapackforessl_.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxl.a
+                   CACHE PATH "")
+
 set(ENABLE_CUDA_NVTOOLSEXT ON CACHE BOOL "")

--- a/host-configs/LLNL/lassen-clang13-cuda11.cmake
+++ b/host-configs/LLNL/lassen-clang13-cuda11.cmake
@@ -13,4 +13,18 @@ set(MPI_Fortran_COMPILER /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-rel
 
 include(${CMAKE_CURRENT_LIST_DIR}/lassen-base.cmake)
 
+# ESSL
+set(ENABLE_ESSL ON CACHE BOOL "")
+set(ESSL_INCLUDE_DIRS /usr/tcetmp/packages/essl/essl-6.3.0.1/include CACHE STRING "")
+set(ESSL_LIBRARIES /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/libesslsmpcuda.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlsmp.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlfmath.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlf90_r.so
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcublas.so
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcudart.so
+                   /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/liblapackforessl.so
+                   /usr/tcetmp/packages/essl/essl-6.3.0.1/lib64/liblapackforessl_.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxl.a
+                   CACHE PATH "")
+
 set(ENABLE_CUDA_NVTOOLSEXT ON CACHE BOOL "")

--- a/host-configs/LLNL/lassen-clang@upstream.cmake
+++ b/host-configs/LLNL/lassen-clang@upstream.cmake
@@ -11,32 +11,7 @@ set(OpenMP_Fortran_LIB_NAMES "" CACHE STRING "")
 set(MPI_HOME /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-upstream-2019.03.26 CACHE PATH "")
 set(MPI_Fortran_COMPILER /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-beta-2019.06.20/bin/mpifort CACHE PATH "")
 
-###############################################################################
-#
-# Base configuration for LC Quartz builds
-# Calling configuration file must define the following CMAKE variables:
-#
-# MPI_HOME
-#
-###############################################################################
-
-# Fortran
-set(ENABLE_FORTRAN OFF CACHE BOOL "")
-
-# MPI
-set(ENABLE_MPI ON CACHE BOOL "")
-set(MPI_C_COMPILER ${MPI_HOME}/bin/mpicc CACHE PATH "")
-set(MPI_CXX_COMPILER ${MPI_HOME}/bin/mpicxx CACHE PATH "")
-set(MPIEXEC lrun CACHE STRING "")
-set(MPIEXEC_NUMPROC_FLAG -n CACHE STRING "")
-set(ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC ON CACHE BOOL "")
-
-# OpenMP
-set(ENABLE_OPENMP ON CACHE BOOL "" FORCE)
-
-# CUDA
-# LvArray sets this to the CMAKE_CXX_COMPILER.
-set(CMAKE_CUDA_HOST_COMPILER ${MPI_CXX_COMPILER} CACHE STRING "")
+include(${CMAKE_CURRENT_LIST_DIR}/lassen-base.cmake)
 
 # ESSL
 set(ENABLE_ESSL ON CACHE BOOL "")
@@ -51,35 +26,3 @@ set(ESSL_LIBRARIES /usr/tcetmp/packages/essl/essl-6.2.1/lib64/libesslsmpcuda.so
                    /usr/tcetmp/packages/essl/essl-6.2.1/lib64/liblapackforessl_.so
                    /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxl.a
                    CACHE PATH "")
-
-# TPL
-set(ENABLE_PAPI OFF CACHE BOOL "")
-set(SILO_BUILD_TYPE powerpc64-unknown-linux-gnu CACHE STRING "")
-
-# GEOSX specific options
-set(ENABLE_PVTPackage ON CACHE BOOL "")
-set(ENABLE_PETSC OFF CACHE BOOL "" FORCE )
-
-
-  
-set( ENABLE_HYPRE_CUDA ON CACHE BOOL "" FORCE )
-if( ENABLE_HYPRE_CUDA )
-    set(ENABLE_TRILINOS OFF CACHE BOOL "" FORCE )
-else()
-    set(ENABLE_HYPRE OFF CACHE BOOL "" FORCE )    
-    set(GEOSX_LA_INTERFACE "Trilinos" CACHE STRING "" FORCE )
-endif()
-
-
-# Documentation
-set(ENABLE_UNCRUSTIFY OFF CACHE BOOL "" FORCE)
-set(ENABLE_DOXYGEN OFF CACHE BOOL "" FORCE)
-
-# Other
-set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
-
-include(${CMAKE_CURRENT_LIST_DIR}/../tpls.cmake)
-
-
-#include(${CMAKE_CURRENT_LIST_DIR}/lassen-base.cmake)
-

--- a/host-configs/LLNL/lassen-clang@upstream.cmake
+++ b/host-configs/LLNL/lassen-clang@upstream.cmake
@@ -11,5 +11,75 @@ set(OpenMP_Fortran_LIB_NAMES "" CACHE STRING "")
 set(MPI_HOME /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-clang-upstream-2019.03.26 CACHE PATH "")
 set(MPI_Fortran_COMPILER /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-xl-beta-2019.06.20/bin/mpifort CACHE PATH "")
 
-include(${CMAKE_CURRENT_LIST_DIR}/lassen-base.cmake)
+###############################################################################
+#
+# Base configuration for LC Quartz builds
+# Calling configuration file must define the following CMAKE variables:
+#
+# MPI_HOME
+#
+###############################################################################
+
+# Fortran
+set(ENABLE_FORTRAN OFF CACHE BOOL "")
+
+# MPI
+set(ENABLE_MPI ON CACHE BOOL "")
+set(MPI_C_COMPILER ${MPI_HOME}/bin/mpicc CACHE PATH "")
+set(MPI_CXX_COMPILER ${MPI_HOME}/bin/mpicxx CACHE PATH "")
+set(MPIEXEC lrun CACHE STRING "")
+set(MPIEXEC_NUMPROC_FLAG -n CACHE STRING "")
+set(ENABLE_WRAP_ALL_TESTS_WITH_MPIEXEC ON CACHE BOOL "")
+
+# OpenMP
+set(ENABLE_OPENMP ON CACHE BOOL "" FORCE)
+
+# CUDA
+# LvArray sets this to the CMAKE_CXX_COMPILER.
+set(CMAKE_CUDA_HOST_COMPILER ${MPI_CXX_COMPILER} CACHE STRING "")
+
+# ESSL
+set(ENABLE_ESSL ON CACHE BOOL "")
+set(ESSL_INCLUDE_DIRS /usr/tcetmp/packages/essl/essl-6.2.1/include CACHE STRING "")
+set(ESSL_LIBRARIES /usr/tcetmp/packages/essl/essl-6.2.1/lib64/libesslsmpcuda.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlsmp.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlfmath.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlf90_r.so
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcublas.so
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcudart.so
+                   /usr/tcetmp/packages/essl/essl-6.2.1/lib64/liblapackforessl.so
+                   /usr/tcetmp/packages/essl/essl-6.2.1/lib64/liblapackforessl_.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxl.a
+                   CACHE PATH "")
+
+# TPL
+set(ENABLE_PAPI OFF CACHE BOOL "")
+set(SILO_BUILD_TYPE powerpc64-unknown-linux-gnu CACHE STRING "")
+
+# GEOSX specific options
+set(ENABLE_PVTPackage ON CACHE BOOL "")
+set(ENABLE_PETSC OFF CACHE BOOL "" FORCE )
+
+
+  
+set( ENABLE_HYPRE_CUDA ON CACHE BOOL "" FORCE )
+if( ENABLE_HYPRE_CUDA )
+    set(ENABLE_TRILINOS OFF CACHE BOOL "" FORCE )
+else()
+    set(ENABLE_HYPRE OFF CACHE BOOL "" FORCE )    
+    set(GEOSX_LA_INTERFACE "Trilinos" CACHE STRING "" FORCE )
+endif()
+
+
+# Documentation
+set(ENABLE_UNCRUSTIFY OFF CACHE BOOL "" FORCE)
+set(ENABLE_DOXYGEN OFF CACHE BOOL "" FORCE)
+
+# Other
+set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
+
+include(${CMAKE_CURRENT_LIST_DIR}/../tpls.cmake)
+
+
+#include(${CMAKE_CURRENT_LIST_DIR}/lassen-base.cmake)
 

--- a/host-configs/LLNL/lassen-gcc@8.3.1.cmake
+++ b/host-configs/LLNL/lassen-gcc@8.3.1.cmake
@@ -15,3 +15,17 @@ set(MPI_HOME /usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-release-gcc-8.3
 set(MPI_Fortran_COMPILER ${MPI_HOME}/bin/mpifort CACHE PATH "")
 
 include(${CMAKE_CURRENT_LIST_DIR}/lassen-base.cmake)
+
+# ESSL
+set(ENABLE_ESSL ON CACHE BOOL "")
+set(ESSL_INCLUDE_DIRS /usr/tcetmp/packages/essl/essl-6.2.1/include CACHE STRING "")
+set(ESSL_LIBRARIES /usr/tcetmp/packages/essl/essl-6.2.1/lib64/libesslsmpcuda.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlsmp.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlfmath.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxlf90_r.so
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcublas.so
+                   ${CUDA_TOOLKIT_ROOT_DIR}/lib64/libcudart.so
+                   /usr/tcetmp/packages/essl/essl-6.2.1/lib64/liblapackforessl.so
+                   /usr/tcetmp/packages/essl/essl-6.2.1/lib64/liblapackforessl_.so
+                   /usr/tce/packages/xl/xl-beta-2019.06.20/alllibs/libxl.a
+                   CACHE PATH "")

--- a/src/coreComponents/mesh/generators/CellBlockUtilities.hpp
+++ b/src/coreComponents/mesh/generators/CellBlockUtilities.hpp
@@ -110,7 +110,7 @@ computeUniqueValueOffsets( ArrayOfArraysView< T const > const & sortedLists )
   // (RAJA's Inclusive scan produces garbage values with CUDA 11.2.2)
   array1d< localIndex > myUniques( numNodes + 1 );
   myUniques[0] = uniqueValueOffsets[0];
-  for (int i = 1; i < uniqueValueOffsets.size(); i++)
+  for( int i = 1; i < uniqueValueOffsets.size(); i++ )
   {
     myUniques[i] = uniqueValueOffsets[i] + myUniques[i - 1];
   }

--- a/src/coreComponents/mesh/generators/CellBlockUtilities.hpp
+++ b/src/coreComponents/mesh/generators/CellBlockUtilities.hpp
@@ -108,13 +108,13 @@ computeUniqueValueOffsets( ArrayOfArraysView< T const > const & sortedLists )
 
   // Perform a prefix-sum to get the unique edge offset.
   // (RAJA's Inclusive scan produces garbage values with CUDA 11.2.2)
-  array1d< localIndex > myUniques( numNodes + 1 );
-  myUniques[0] = uniqueValueOffsets[0];
+  array1d< localIndex > offsets( numNodes + 1 );
+  offsets[0] = uniqueValueOffsets[0];
   for( int i = 1; i < uniqueValueOffsets.size(); i++ )
   {
-    myUniques[i] = uniqueValueOffsets[i] + myUniques[i - 1];
+    offsets[i] = uniqueValueOffsets[i] + offsets[i - 1];
   }
-  return myUniques;
+  return offsets;
 }
 
 }


### PR DESCRIPTION
This PR:

- Makes modifications so `clang10-cuda11.2` and `clang13-cuda11.6` lassen host-configs will build and run unit tests.
- Unit test failures for `clang10-cuda11.2` :
```
The following tests FAILED  :
  112 - testLinearAlgebra_Vectors (Failed)
  113 - testLinearAlgebra_ExternalSolvers (Failed)
  114 - testLinearAlgebra_KrylovSolvers (Failed)
```
- Unit test failures for `clang13-cuda11.6` :
```
The following tests FAILED  :
  67 - testTensorOpsDeterminant (Failed)
  80 - testTensorOps (Failed) 
  112 - testLinearAlgebra_Vectors (Failed) 
  113 - testLinearAlgebra_ExternalSolvers (Failed)
  114 - testLinearAlgebra_KrylovSolvers (Failed)
  177 - testWavePropagation (Failed)
  178 - testWavePropagationAcousticFirstOrder (Failed)

```

Related to GEOSX/LvArray#279