### PR TITLE
update embedded xml using raw string literals

### DIFF
--- a/src/coreComponents/unitTests/dataRepositoryTests/testGroupPath.cpp
+++ b/src/coreComponents/unitTests/dataRepositoryTests/testGroupPath.cpp
@@ -27,56 +27,57 @@ TEST( testGroupPath, testGlobalPaths )
   using namespace geos;
   using namespace dataRepository;
 
-  char const *  xmlInput =
-    "<?xml version=\"1.0\" ?>\n"
-    "<Problem>\n"
-    "  <Solvers>\n"
-    "    <SolidMechanics_LagrangianFEM\n"
-    "      name=\"lagsolve\"\n"
-    "      cflFactor=\"0.25\"\n"
-    "      discretization=\"FE1\"\n"
-    "      targetRegions=\"{ Region2 }\"/>\n"
-    "  </Solvers>\n"
-    "  <Mesh>\n"
-    "    <InternalMesh\n"
-    "      name=\"mesh1\"\n"
-    "      elementTypes=\"{ C3D8 }\"\n"
-    "      xCoords=\"{ 0, 3 }\"\n"
-    "      yCoords=\"{ 0, 1 }\"\n"
-    "      zCoords=\"{ 0, 1 }\"\n"
-    "      nx=\"{ 4 }\"\n"
-    "      ny=\"{ 1 }\"\n"
-    "      nz=\"{ 1 }\"\n"
-    "      cellBlockNames=\"{ cb1 }\"/>\n"
-    "  </Mesh>\n"
-    "  <Events\n"
-    "    maxTime=\"1.0e-3\">\n"
-    "    <PeriodicEvent\n"
-    "      name=\"solverApplications\"\n"
-    "      forceDt=\"1.0e-3\"\n"
-    "      target=\"/Solvers/lagsolve\"/>\n"
-    "  </Events>\n"
-    "  <NumericalMethods>\n"
-    "    <FiniteElements>\n"
-    "      <FiniteElementSpace\n"
-    "        name=\"FE1\"\n"
-    "        order=\"1\"/>\n"
-    "    </FiniteElements>\n"
-    "  </NumericalMethods>\n"
-    "  <ElementRegions>\n"
-    "    <CellElementRegion\n"
-    "      name=\"Region2\"\n"
-    "      cellBlocks=\"{ cb1 }\"\n"
-    "      materialList=\"{ shale }\"/>\n"
-    "  </ElementRegions>\n"
-    "  <Constitutive>\n"
-    "    <ElasticIsotropic\n"
-    "      name=\"shale\"\n"
-    "      defaultDensity=\"2700\"\n"
-    "      defaultBulkModulus=\"5.5556e9\"\n"
-    "      defaultShearModulus=\"4.16667e9\"/>\n"
-    "  </Constitutive>\n"
-    "</Problem>";
+  char const * xmlInput =
+    R"xml(
+    <Problem>
+      <Solvers>
+        <SolidMechanics_LagrangianFEM
+          name="lagsolve"
+          cflFactor="0.25"
+          discretization="FE1"
+          targetRegions="{ Region2 }"/>
+      </Solvers>
+      <Mesh>
+        <InternalMesh
+          name="mesh1"
+          elementTypes="{ C3D8 }"
+          xCoords="{ 0, 3 }"
+          yCoords="{ 0, 1 }"
+          zCoords="{ 0, 1 }"
+          nx="{ 4 }"
+          ny="{ 1 }"
+          nz="{ 1 }"
+          cellBlockNames="{ cb1 }"/>
+      </Mesh>
+      <Events
+        maxTime="1.0e-3">
+        <PeriodicEvent
+          name="solverApplications"
+          forceDt="1.0e-3"
+          target="/Solvers/lagsolve"/>
+      </Events>
+      <NumericalMethods>
+        <FiniteElements>
+          <FiniteElementSpace
+            name="FE1"
+            order="1"/>
+        </FiniteElements>
+      </NumericalMethods>
+      <ElementRegions>
+        <CellElementRegion
+          name="Region2"
+          cellBlocks="{ cb1 }"
+          materialList="{ shale }"/>
+      </ElementRegions>
+      <Constitutive>
+        <ElasticIsotropic
+          name="shale"
+          defaultDensity="2700"
+          defaultBulkModulus="5.5556e9"
+          defaultShearModulus="4.16667e9"/>
+      </Constitutive>
+    </Problem>
+    )xml";
 
   std::vector< string > const groupPaths{
     "/Mesh/mesh1",

--- a/src/coreComponents/unitTests/fluidFlowTests/testCompMultiphaseFlow.cpp
+++ b/src/coreComponents/unitTests/fluidFlowTests/testCompMultiphaseFlow.cpp
@@ -34,121 +34,123 @@ CommandLineOptions g_commandLineOptions;
 // Sphinx start after input XML
 
 char const * xmlInput =
-  "<Problem>\n"
-  "  <Solvers gravityVector=\"{ 0.0, 0.0, -9.81 }\">\n"
-  "    <CompositionalMultiphaseFVM name=\"compflow\"\n"
-  "                                 logLevel=\"0\"\n"
-  "                                 discretization=\"fluidTPFA\"\n"
-  "                                 targetRegions=\"{region}\"\n"
-  "                                 temperature=\"297.15\"\n"
-  "                                 useMass=\"1\">\n"
-  "                                 \n"
-  "      <NonlinearSolverParameters newtonTol=\"1.0e-6\"\n"
-  "                                 newtonMaxIter=\"2\"/>\n"
-  "      <LinearSolverParameters solverType=\"gmres\"\n"
-  "                              krylovTol=\"1.0e-10\"/>\n"
-  "    </CompositionalMultiphaseFVM>\n"
-  "  </Solvers>\n"
-  "  <Mesh>\n"
-  "    <InternalMesh name=\"mesh\"\n"
-  "                  elementTypes=\"{C3D8}\" \n"
-  "                  xCoords=\"{0, 3}\"\n"
-  "                  yCoords=\"{0, 1}\"\n"
-  "                  zCoords=\"{0, 1}\"\n"
-  "                  nx=\"{3}\"\n"
-  "                  ny=\"{1}\"\n"
-  "                  nz=\"{1}\"\n"
-  "                  cellBlockNames=\"{cb1}\"/>\n"
-  "  </Mesh>\n"
-  "  <NumericalMethods>\n"
-  "    <FiniteVolume>\n"
-  "      <TwoPointFluxApproximation name=\"fluidTPFA\"/>\n"
-  "    </FiniteVolume>\n"
-  "  </NumericalMethods>\n"
-  "  <ElementRegions>\n"
-  "    <CellElementRegion name=\"region\" cellBlocks=\"{cb1}\" materialList=\"{fluid, rock, relperm, cappressure}\" />\n"
-  "  </ElementRegions>\n"
-  "  <Constitutive>\n"
-  "    <CompositionalMultiphaseFluid name=\"fluid\"\n"
-  "                                  phaseNames=\"{oil, gas}\"\n"
-  "                                  equationsOfState=\"{PR, PR}\"\n"
-  "                                  componentNames=\"{N2, C10, C20, H2O}\"\n"
-  "                                  componentCriticalPressure=\"{34e5, 25.3e5, 14.6e5, 220.5e5}\"\n"
-  "                                  componentCriticalTemperature=\"{126.2, 622.0, 782.0, 647.0}\"\n"
-  "                                  componentAcentricFactor=\"{0.04, 0.443, 0.816, 0.344}\"\n"
-  "                                  componentMolarWeight=\"{28e-3, 134e-3, 275e-3, 18e-3}\"\n"
-  "                                  componentVolumeShift=\"{0, 0, 0, 0}\"\n"
-  "                                  componentBinaryCoeff=\"{ {0, 0, 0, 0},\n"
-  "                                                          {0, 0, 0, 0},\n"
-  "                                                          {0, 0, 0, 0},\n"
-  "                                                          {0, 0, 0, 0} }\"/>\n"
-  "    <CompressibleSolidConstantPermeability name=\"rock\"\n"
-  "        solidModelName=\"nullSolid\"\n"
-  "        porosityModelName=\"rockPorosity\"\n"
-  "        permeabilityModelName=\"rockPerm\"/>\n"
-  "   <NullModel name=\"nullSolid\"/> \n"
-  "   <PressurePorosity name=\"rockPorosity\"\n"
-  "                     defaultReferencePorosity=\"0.05\"\n"
-  "                     referencePressure = \"0.0\"\n"
-  "                     compressibility=\"1.0e-9\"/>\n"
-  "    <BrooksCoreyRelativePermeability name=\"relperm\"\n"
-  "                                     phaseNames=\"{oil, gas}\"\n"
-  "                                     phaseMinVolumeFraction=\"{0.1, 0.15}\"\n"
-  "                                     phaseRelPermExponent=\"{2.0, 2.0}\"\n"
-  "                                     phaseRelPermMaxValue=\"{0.8, 0.9}\"/>\n"
-  "    <BrooksCoreyCapillaryPressure name=\"cappressure\"\n"
-  "                                  phaseNames=\"{oil, gas}\"\n"
-  "                                  phaseMinVolumeFraction=\"{0.2, 0.05}\"\n"
-  "                                  phaseCapPressureExponentInv=\"{4.25, 3.5}\"\n"
-  "                                  phaseEntryPressure=\"{0., 1e8}\"\n"
-  "                                  capPressureEpsilon=\"0.0\"/> \n"
-  "  <ConstantPermeability name=\"rockPerm\"\n"
-  "                        permeabilityComponents=\"{2.0e-16, 2.0e-16, 2.0e-16}\"/> \n"
-  "  </Constitutive>\n"
-  "  <FieldSpecifications>\n"
-  "    <FieldSpecification name=\"initialPressure\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/region/cb1\"\n"
-  "               fieldName=\"pressure\"\n"
-  "               functionName=\"initialPressureFunc\"\n"
-  "               scale=\"5e6\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_N2\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/region/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"0\"\n"
-  "               scale=\"0.099\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_C10\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/region/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"1\"\n"
-  "               scale=\"0.3\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_C20\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/region/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"2\"\n"
-  "               scale=\"0.6\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_H20\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/region/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"3\"\n"
-  "               scale=\"0.001\"/>\n"
-  "  </FieldSpecifications>\n"
-  "  <Functions>\n"
-  "    <TableFunction name=\"initialPressureFunc\"\n"
-  "                   inputVarNames=\"{elementCenter}\"\n"
-  "                   coordinates=\"{0.0, 3.0}\"\n"
-  "                   values=\"{1.0, 0.5}\"/>\n"
-  "  </Functions>"
-  "</Problem>";
+  R"xml(
+  <Problem>
+    <Solvers gravityVector="{ 0.0, 0.0, -9.81 }">
+      <CompositionalMultiphaseFVM name="compflow"
+                                   logLevel="0"
+                                   discretization="fluidTPFA"
+                                   targetRegions="{region}"
+                                   temperature="297.15"
+                                   useMass="1">
+
+        <NonlinearSolverParameters newtonTol="1.0e-6"
+                                   newtonMaxIter="2"/>
+        <LinearSolverParameters solverType="gmres"
+                                krylovTol="1.0e-10"/>
+      </CompositionalMultiphaseFVM>
+    </Solvers>
+    <Mesh>
+      <InternalMesh name="mesh"
+                    elementTypes="{C3D8}"
+                    xCoords="{0, 3}"
+                    yCoords="{0, 1}"
+                    zCoords="{0, 1}"
+                    nx="{3}"
+                    ny="{1}"
+                    nz="{1}"
+                    cellBlockNames="{cb1}"/>
+    </Mesh>
+    <NumericalMethods>
+      <FiniteVolume>
+        <TwoPointFluxApproximation name="fluidTPFA"/>
+      </FiniteVolume>
+    </NumericalMethods>
+    <ElementRegions>
+      <CellElementRegion name="region" cellBlocks="{cb1}" materialList="{fluid, rock, relperm, cappressure}" />
+    </ElementRegions>
+    <Constitutive>
+      <CompositionalMultiphaseFluid name="fluid"
+                                    phaseNames="{oil, gas}"
+                                    equationsOfState="{PR, PR}"
+                                    componentNames="{N2, C10, C20, H2O}"
+                                    componentCriticalPressure="{34e5, 25.3e5, 14.6e5, 220.5e5}"
+                                    componentCriticalTemperature="{126.2, 622.0, 782.0, 647.0}"
+                                    componentAcentricFactor="{0.04, 0.443, 0.816, 0.344}"
+                                    componentMolarWeight="{28e-3, 134e-3, 275e-3, 18e-3}"
+                                    componentVolumeShift="{0, 0, 0, 0}"
+                                    componentBinaryCoeff="{ {0, 0, 0, 0},
+                                                            {0, 0, 0, 0},
+                                                            {0, 0, 0, 0},
+                                                            {0, 0, 0, 0} }"/>
+      <CompressibleSolidConstantPermeability name="rock"
+          solidModelName="nullSolid"
+          porosityModelName="rockPorosity"
+          permeabilityModelName="rockPerm"/>
+     <NullModel name="nullSolid"/>
+     <PressurePorosity name="rockPorosity"
+                       defaultReferencePorosity="0.05"
+                       referencePressure = "0.0"
+                       compressibility="1.0e-9"/>
+      <BrooksCoreyRelativePermeability name="relperm"
+                                       phaseNames="{oil, gas}"
+                                       phaseMinVolumeFraction="{0.1, 0.15}"
+                                       phaseRelPermExponent="{2.0, 2.0}"
+                                       phaseRelPermMaxValue="{0.8, 0.9}"/>
+      <BrooksCoreyCapillaryPressure name="cappressure"
+                                    phaseNames="{oil, gas}"
+                                    phaseMinVolumeFraction="{0.2, 0.05}"
+                                    phaseCapPressureExponentInv="{4.25, 3.5}"
+                                    phaseEntryPressure="{0., 1e8}"
+                                    capPressureEpsilon="0.0"/>
+    <ConstantPermeability name="rockPerm"
+                          permeabilityComponents="{2.0e-16, 2.0e-16, 2.0e-16}"/>
+    </Constitutive>
+    <FieldSpecifications>
+      <FieldSpecification name="initialPressure"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/region/cb1"
+                 fieldName="pressure"
+                 functionName="initialPressureFunc"
+                 scale="5e6"/>
+      <FieldSpecification name="initialComposition_N2"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/region/cb1"
+                 fieldName="globalCompFraction"
+                 component="0"
+                 scale="0.099"/>
+      <FieldSpecification name="initialComposition_C10"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/region/cb1"
+                 fieldName="globalCompFraction"
+                 component="1"
+                 scale="0.3"/>
+      <FieldSpecification name="initialComposition_C20"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/region/cb1"
+                 fieldName="globalCompFraction"
+                 component="2"
+                 scale="0.6"/>
+      <FieldSpecification name="initialComposition_H20"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/region/cb1"
+                 fieldName="globalCompFraction"
+                 component="3"
+                 scale="0.001"/>
+    </FieldSpecifications>
+    <Functions>
+      <TableFunction name="initialPressureFunc"
+                     inputVarNames="{elementCenter}"
+                     coordinates="{0.0, 3.0}"
+                     values="{1.0, 0.5}"/>
+    </Functions>
+  </Problem>
+  )xml";
 
 // Sphinx end before input XML
 

--- a/src/coreComponents/unitTests/fluidFlowTests/testCompMultiphaseFlowHybrid.cpp
+++ b/src/coreComponents/unitTests/fluidFlowTests/testCompMultiphaseFlowHybrid.cpp
@@ -32,127 +32,129 @@ using namespace geos::testing;
 CommandLineOptions g_commandLineOptions;
 
 char const * xmlInput =
-  "<Problem>\n"
-  "  <Solvers gravityVector=\"{ 0.0, 0.0, -9.81 }\">\n"
-  "    <CompositionalMultiphaseHybridFVM name=\"compflow\"\n"
-  "                                 logLevel=\"0\"\n"
-  "                                 discretization=\"fluidHM\"\n"
-  "                                 targetRegions=\"{Region}\"\n"
-  "                                 temperature=\"297.15\"\n"
-  "                                 useMass=\"1\">\n"
-  "                                 \n"
-  "      <NonlinearSolverParameters newtonTol=\"1.0e-6\"\n"
-  "                                 newtonMaxIter=\"2\"/>\n"
-  "      <LinearSolverParameters solverType=\"gmres\"\n"
-  "                              krylovTol=\"1.0e-10\"/>\n"
-  "    </CompositionalMultiphaseHybridFVM>\n"
-  "  </Solvers>\n"
-  "  <Mesh>\n"
-  "    <InternalMesh name=\"mesh1\"\n"
-  "                  elementTypes=\"{C3D8}\" \n"
-  "                  xCoords=\"{0, 1}\"\n"
-  "                  yCoords=\"{0, 1}\"\n"
-  "                  zCoords=\"{0, 10}\"\n"
-  "                  nx=\"{1}\"\n"
-  "                  ny=\"{1}\"\n"
-  "                  nz=\"{4}\"\n"
-  "                  cellBlockNames=\"{cb1}\"/>\n"
-  "  </Mesh>\n"
-  "  <NumericalMethods>\n"
-  "    <FiniteVolume>\n"
-  "      <HybridMimeticDiscretization name=\"fluidHM\"\n"
-  "                                   innerProductType=\"beiraoDaVeigaLipnikovManzini\"/>\n"
-  "    </FiniteVolume>\n"
-  "  </NumericalMethods>\n"
-  "  <ElementRegions>\n"
-  "    <CellElementRegion name=\"Region\" cellBlocks=\"{cb1}\" materialList=\"{fluid1, rock, relperm}\" />\n"
-  "  </ElementRegions>\n"
-  "  <Constitutive>\n"
-  "    <CompositionalMultiphaseFluid name=\"fluid1\"\n"
-  "                                  phaseNames=\"{oil, gas}\"\n"
-  "                                  equationsOfState=\"{PR, PR}\"\n"
-  "                                  componentNames=\"{N2, C10, C20, H2O}\"\n"
-  "                                  componentCriticalPressure=\"{34e5, 25.3e5, 14.6e5, 220.5e5}\"\n"
-  "                                  componentCriticalTemperature=\"{126.2, 622.0, 782.0, 647.0}\"\n"
-  "                                  componentAcentricFactor=\"{0.04, 0.443, 0.816, 0.344}\"\n"
-  "                                  componentMolarWeight=\"{28e-3, 134e-3, 275e-3, 18e-3}\"\n"
-  "                                  componentVolumeShift=\"{0, 0, 0, 0}\"\n"
-  "                                  componentBinaryCoeff=\"{ {0, 0, 0, 0},\n"
-  "                                                          {0, 0, 0, 0},\n"
-  "                                                          {0, 0, 0, 0},\n"
-  "                                                          {0, 0, 0, 0} }\"/>\n"
-  "    <CompressibleSolidConstantPermeability name=\"rock\"\n"
-  "        solidModelName=\"nullSolid\"\n"
-  "        porosityModelName=\"rockPorosity\"\n"
-  "        permeabilityModelName=\"rockPerm\"/>\n"
-  "   <NullModel name=\"nullSolid\"/> \n"
-  "   <PressurePorosity name=\"rockPorosity\"\n"
-  "                     defaultReferencePorosity=\"0.05\"\n"
-  "                     referencePressure = \"0.0\"\n"
-  "                     compressibility=\"1.0e-9\"/>\n"
-  "  <ConstantPermeability name=\"rockPerm\"\n"
-  "                        permeabilityComponents=\"{2.0e-16, 2.0e-16, 2.0e-16}\"/> \n"
-  "    <BrooksCoreyRelativePermeability name=\"relperm\"\n"
-  "                                     phaseNames=\"{oil, gas}\"\n"
-  "                                     phaseMinVolumeFraction=\"{0.1, 0.15}\"\n"
-  "                                     phaseRelPermExponent=\"{2.0, 2.0}\"\n"
-  "                                     phaseRelPermMaxValue=\"{0.8, 0.9}\"/>\n"
-  "  </Constitutive>\n"
-  "  <FieldSpecifications>\n"
-  "    <FieldSpecification name=\"initialPressure\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/Region/cb1\"\n"
-  "               fieldName=\"pressure\"\n"
-  "               functionName=\"initialPressureFunc\"\n"
-  "               scale=\"5e6\"/>\n"
-  "    <FieldSpecification name=\"initialFacePressure\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"faceManager\"\n"
-  "               fieldName=\"facePressure\"\n"
-  "               functionName=\"initialFacePressureFunc\"\n"
-  "               scale=\"5e6\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_N2\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/Region/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"0\"\n"
-  "               scale=\"0.099\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_C10\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/Region/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"1\"\n"
-  "               scale=\"0.3\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_C20\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/Region/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"2\"\n"
-  "               scale=\"0.6\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_H20\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/Region/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"3\"\n"
-  "               scale=\"0.001\"/>\n"
-  "  </FieldSpecifications>\n"
-  "  <Functions>\n"
-  "    <TableFunction name=\"initialPressureFunc\"\n"
-  "                   inputVarNames=\"{elementCenter}\"\n"
-  "                   coordinates=\"{0.0, 2.0, 4.0, 6.0, 8.0, 10.0 }\"\n"
-  "                   values=\"{ 1.0, 0.5, 0.2, 3.0, 2.1, 1.0 }\"/>\n"
-  "    <TableFunction name=\"initialFacePressureFunc\"\n"
-  "                   inputVarNames=\"{faceCenter}\"\n"
-  "                   coordinates=\"{0.0, 2.0, 4.0, 6.0, 8.0, 10.0 }\"\n"
-  "                   values=\"{ 2.0, 0.1, 0.2, 2.1, 2.1, 0.1 }\"/>\n"
-  "  </Functions>"
-  "</Problem>";
+  R"xml(
+  <Problem>
+    <Solvers gravityVector="{ 0.0, 0.0, -9.81 }">
+      <CompositionalMultiphaseHybridFVM name="compflow"
+                                   logLevel="0"
+                                   discretization="fluidHM"
+                                   targetRegions="{Region}"
+                                   temperature="297.15"
+                                   useMass="1">
+
+        <NonlinearSolverParameters newtonTol="1.0e-6"
+                                   newtonMaxIter="2"/>
+        <LinearSolverParameters solverType="gmres"
+                                krylovTol="1.0e-10"/>
+      </CompositionalMultiphaseHybridFVM>
+    </Solvers>
+    <Mesh>
+      <InternalMesh name="mesh1"
+                    elementTypes="{C3D8}"
+                    xCoords="{0, 1}"
+                    yCoords="{0, 1}"
+                    zCoords="{0, 10}"
+                    nx="{1}"
+                    ny="{1}"
+                    nz="{4}"
+                    cellBlockNames="{cb1}"/>
+    </Mesh>
+    <NumericalMethods>
+      <FiniteVolume>
+        <HybridMimeticDiscretization name="fluidHM"
+                                     innerProductType="beiraoDaVeigaLipnikovManzini"/>
+      </FiniteVolume>
+    </NumericalMethods>
+    <ElementRegions>
+      <CellElementRegion name="Region" cellBlocks="{cb1}" materialList="{fluid1, rock, relperm}" />
+    </ElementRegions>
+    <Constitutive>
+      <CompositionalMultiphaseFluid name="fluid1"
+                                    phaseNames="{oil, gas}"
+                                    equationsOfState="{PR, PR}"
+                                    componentNames="{N2, C10, C20, H2O}"
+                                    componentCriticalPressure="{34e5, 25.3e5, 14.6e5, 220.5e5}"
+                                    componentCriticalTemperature="{126.2, 622.0, 782.0, 647.0}"
+                                    componentAcentricFactor="{0.04, 0.443, 0.816, 0.344}"
+                                    componentMolarWeight="{28e-3, 134e-3, 275e-3, 18e-3}"
+                                    componentVolumeShift="{0, 0, 0, 0}"
+                                    componentBinaryCoeff="{ {0, 0, 0, 0},
+                                                            {0, 0, 0, 0},
+                                                            {0, 0, 0, 0},
+                                                            {0, 0, 0, 0} }"/>
+      <CompressibleSolidConstantPermeability name="rock"
+          solidModelName="nullSolid"
+          porosityModelName="rockPorosity"
+          permeabilityModelName="rockPerm"/>
+     <NullModel name="nullSolid"/>
+     <PressurePorosity name="rockPorosity"
+                       defaultReferencePorosity="0.05"
+                       referencePressure = "0.0"
+                       compressibility="1.0e-9"/>
+    <ConstantPermeability name="rockPerm"
+                          permeabilityComponents="{2.0e-16, 2.0e-16, 2.0e-16}"/>
+      <BrooksCoreyRelativePermeability name="relperm"
+                                       phaseNames="{oil, gas}"
+                                       phaseMinVolumeFraction="{0.1, 0.15}"
+                                       phaseRelPermExponent="{2.0, 2.0}"
+                                       phaseRelPermMaxValue="{0.8, 0.9}"/>
+    </Constitutive>
+    <FieldSpecifications>
+      <FieldSpecification name="initialPressure"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/Region/cb1"
+                 fieldName="pressure"
+                 functionName="initialPressureFunc"
+                 scale="5e6"/>
+      <FieldSpecification name="initialFacePressure"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="faceManager"
+                 fieldName="facePressure"
+                 functionName="initialFacePressureFunc"
+                 scale="5e6"/>
+      <FieldSpecification name="initialComposition_N2"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/Region/cb1"
+                 fieldName="globalCompFraction"
+                 component="0"
+                 scale="0.099"/>
+      <FieldSpecification name="initialComposition_C10"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/Region/cb1"
+                 fieldName="globalCompFraction"
+                 component="1"
+                 scale="0.3"/>
+      <FieldSpecification name="initialComposition_C20"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/Region/cb1"
+                 fieldName="globalCompFraction"
+                 component="2"
+                 scale="0.6"/>
+      <FieldSpecification name="initialComposition_H20"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/Region/cb1"
+                 fieldName="globalCompFraction"
+                 component="3"
+                 scale="0.001"/>
+    </FieldSpecifications>
+    <Functions>
+      <TableFunction name="initialPressureFunc"
+                     inputVarNames="{elementCenter}"
+                     coordinates="{0.0, 2.0, 4.0, 6.0, 8.0, 10.0 }"
+                     values="{ 1.0, 0.5, 0.2, 3.0, 2.1, 1.0 }"/>
+      <TableFunction name="initialFacePressureFunc"
+                     inputVarNames="{faceCenter}"
+                     coordinates="{0.0, 2.0, 4.0, 6.0, 8.0, 10.0 }"
+                     values="{ 2.0, 0.1, 0.2, 2.1, 2.1, 0.1 }"/>
+    </Functions>
+  </Problem>
+  )xml";
 
 template< typename LAMBDA >
 void testNumericalJacobian( CompositionalMultiphaseHybridFVM & solver,

--- a/src/coreComponents/unitTests/fluidFlowTests/testReactiveCompositionalMultiphaseOBL.cpp
+++ b/src/coreComponents/unitTests/fluidFlowTests/testReactiveCompositionalMultiphaseOBL.cpp
@@ -33,95 +33,97 @@ CommandLineOptions g_commandLineOptions;
 // Sphinx start after input XML
 
 char const * xmlInput =
-  "<Problem>\n"
-  "  <Solvers gravityVector=\"{ 0.0, 0.0, -9.81 }\">\n"
-  "    <ReactiveCompositionalMultiphaseOBL\n"
-  "                      name=\"compflow\"\n"
-  "                      logLevel=\"1\"\n"
-  "                      discretization=\"fluidTPFA\"\n"
-  "                      targetRegions=\"{ region }\"\n"
-  "                      componentNames=\"{N2, C10, C20}\"\n"
-  "                      enableEnergyBalance=\"0\"\n"
-  "                      maxCompFractionChange=\"1\"\n"
-  "                      numComponents=\"3\"\n"
-  "                      numPhases=\"2\"\n"
-  "                      OBLOperatorsTableFile=\"obl_3comp_static.txt\">\n"
-  "                                 \n"
-  "      <NonlinearSolverParameters newtonTol=\"1.0e-6\"\n"
-  "                                 newtonMaxIter=\"2\"/>\n"
-  "      <LinearSolverParameters solverType=\"gmres\"\n"
-  "                              krylovTol=\"1.0e-10\"/>\n"
-  "    </ReactiveCompositionalMultiphaseOBL>\n"
-  "  </Solvers>\n"
-  "  <Mesh>\n"
-  "    <InternalMesh name=\"mesh\"\n"
-  "                  elementTypes=\"{C3D8}\" \n"
-  "                  xCoords=\"{0, 3}\"\n"
-  "                  yCoords=\"{0, 1}\"\n"
-  "                  zCoords=\"{0, 1}\"\n"
-  "                  nx=\"{3}\"\n"
-  "                  ny=\"{1}\"\n"
-  "                  nz=\"{1}\"\n"
-  "                  cellBlockNames=\"{cb1}\"/>\n"
-  "  </Mesh>\n"
-  "  <NumericalMethods>\n"
-  "    <FiniteVolume>\n"
-  "      <TwoPointFluxApproximation name=\"fluidTPFA\"/>\n"
-  "    </FiniteVolume>\n"
-  "  </NumericalMethods>\n"
-  "  <ElementRegions>\n"
-  "    <CellElementRegion name=\"region\" cellBlocks=\"{cb1}\" materialList=\"{rock}\" />\n"
-  "  </ElementRegions>\n"
-  "  <Constitutive>\n"
-  "    <CompressibleSolidConstantPermeability name=\"rock\"\n"
-  "        solidModelName=\"nullSolid\"\n"
-  "        porosityModelName=\"rockPorosity\"\n"
-  "        permeabilityModelName=\"rockPerm\"/>\n"
-  "   <NullModel name=\"nullSolid\"/> \n"
-  "   <PressurePorosity name=\"rockPorosity\"\n"
-  "                     defaultReferencePorosity=\"0.05\"\n"
-  "                     referencePressure = \"0.0\"\n"
-  "                     compressibility=\"1.0e-9\"/>\n"
-  "  <ConstantPermeability name=\"rockPerm\"\n"
-  "                        permeabilityComponents=\"{2.0e-16, 2.0e-16, 2.0e-16}\"/> \n"
-  "  </Constitutive>\n"
-  "  <FieldSpecifications>\n"
-  "    <FieldSpecification name=\"initialPressure\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/region/cb1\"\n"
-  "               fieldName=\"pressure\"\n"
-  "               functionName=\"initialPressureFunc\"\n"
-  "               scale=\"5e6\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_N2\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/region/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"0\"\n"
-  "               scale=\"0.099\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_C10\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/region/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"1\"\n"
-  "               scale=\"0.3\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_C20\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/region/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"2\"\n"
-  "               scale=\"0.6\"/>\n"
-  "  </FieldSpecifications>\n"
-  "  <Functions>\n"
-  "    <TableFunction name=\"initialPressureFunc\"\n"
-  "                   inputVarNames=\"{elementCenter}\"\n"
-  "                   coordinates=\"{0.0, 3.0}\"\n"
-  "                   values=\"{1.0, 0.5}\"/>\n"
-  "  </Functions>"
-  "</Problem>";
+  R"xml(
+  <Problem>
+    <Solvers gravityVector="{ 0.0, 0.0, -9.81 }">
+      <ReactiveCompositionalMultiphaseOBL
+                        name="compflow"
+                        logLevel="1"
+                        discretization="fluidTPFA"
+                        targetRegions="{ region }"
+                        componentNames="{N2, C10, C20}"
+                        enableEnergyBalance="0"
+                        maxCompFractionChange="1"
+                        numComponents="3"
+                        numPhases="2"
+                        OBLOperatorsTableFile="obl_3comp_static.txt">
+
+        <NonlinearSolverParameters newtonTol="1.0e-6"
+                                   newtonMaxIter="2"/>
+        <LinearSolverParameters solverType="gmres"
+                                krylovTol="1.0e-10"/>
+      </ReactiveCompositionalMultiphaseOBL>
+    </Solvers>
+    <Mesh>
+      <InternalMesh name="mesh"
+                    elementTypes="{C3D8}"
+                    xCoords="{0, 3}"
+                    yCoords="{0, 1}"
+                    zCoords="{0, 1}"
+                    nx="{3}"
+                    ny="{1}"
+                    nz="{1}"
+                    cellBlockNames="{cb1}"/>
+    </Mesh>
+    <NumericalMethods>
+      <FiniteVolume>
+        <TwoPointFluxApproximation name="fluidTPFA"/>
+      </FiniteVolume>
+    </NumericalMethods>
+    <ElementRegions>
+      <CellElementRegion name="region" cellBlocks="{cb1}" materialList="{rock}" />
+    </ElementRegions>
+    <Constitutive>
+      <CompressibleSolidConstantPermeability name="rock"
+          solidModelName="nullSolid"
+          porosityModelName="rockPorosity"
+          permeabilityModelName="rockPerm"/>
+     <NullModel name="nullSolid"/>
+     <PressurePorosity name="rockPorosity"
+                       defaultReferencePorosity="0.05"
+                       referencePressure = "0.0"
+                       compressibility="1.0e-9"/>
+    <ConstantPermeability name="rockPerm"
+                          permeabilityComponents="{2.0e-16, 2.0e-16, 2.0e-16}"/>
+    </Constitutive>
+    <FieldSpecifications>
+      <FieldSpecification name="initialPressure"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/region/cb1"
+                 fieldName="pressure"
+                 functionName="initialPressureFunc"
+                 scale="5e6"/>
+      <FieldSpecification name="initialComposition_N2"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/region/cb1"
+                 fieldName="globalCompFraction"
+                 component="0"
+                 scale="0.099"/>
+      <FieldSpecification name="initialComposition_C10"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/region/cb1"
+                 fieldName="globalCompFraction"
+                 component="1"
+                 scale="0.3"/>
+      <FieldSpecification name="initialComposition_C20"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/region/cb1"
+                 fieldName="globalCompFraction"
+                 component="2"
+                 scale="0.6"/>
+    </FieldSpecifications>
+    <Functions>
+      <TableFunction name="initialPressureFunc"
+                     inputVarNames="{elementCenter}"
+                     coordinates="{0.0, 3.0}"
+                     values="{1.0, 0.5}"/>
+    </Functions>
+  </Problem>
+  )xml";
 
 char const * oblInput =
   "3 28 \n"

--- a/src/coreComponents/unitTests/fluidFlowTests/testThermalCompMultiphaseFlow.cpp
+++ b/src/coreComponents/unitTests/fluidFlowTests/testThermalCompMultiphaseFlow.cpp
@@ -46,191 +46,161 @@ char const * co2flash = "FlashModel CO2Solubility  1e6 7.5e7 5e5 295.15 370.15 2
 char const * xmlInput =
   R"xml(
   <Problem>
-  <Solvers>
-  <CompositionalMultiphaseFVM
-  name="compflow"
-  logLevel="1"
-  discretization="fluidTPFA"
-  temperature="368.15"
-  useMass="1"
-  isThermal="1"
-  initialDt="1000"
-  maxCompFractionChange="0.5"
-  targetRegions="{ region }">
-  <NonlinearSolverParameters
-  newtonTol="1.0e-6"
-  newtonMaxIter="100"
-  lineSearchAction="None"
-  maxTimeStepCuts="5"/>
-  <LinearSolverParameters
-  directParallel="0"/>
-  </CompositionalMultiphaseFVM>
-  </Solvers>
-  <Mesh>
-  <InternalMesh
-  name="mesh"
-  elementTypes="{ C3D8 }"
-  xCoords="{ 0, 20 }"
-  yCoords="{ 0, 1 }"
-  zCoords="{ 0, 1 }"
-  nx="{ 5 }"
-  ny="{ 1 }"
-  nz="{ 1 }"
-  cellBlockNames="{ cb }"/>
-  </Mesh>
-  <Geometry>
-  <Box
-  name="sink"
-  xMin="{ -0.01, -0.01, -0.01 }"
-  xMax="{ 4.01, 1.01, 1.01 }"/>
-  <Box
-  name="source"
-  xMin="{ -0.01, -0.01, -0.01 }"
-  xMax="{ 4.01, 1.01, 1.01 }"/>
-  </Geometry>
-  <Events
-  maxTime="1000">
-  <PeriodicEvent
-  name="solverApplications"
-  maxEventDt="1000"
-  target="/Solvers/compflow"/>
-  </Events>
-  <NumericalMethods>
-  <FiniteVolume>
-  <TwoPointFluxApproximation
-  name="fluidTPFA"/>
-  </FiniteVolume>
-  </NumericalMethods>
-  <ElementRegions>
-  <CellElementRegion
-  name="region"
-  cellBlocks="{ cb }"
-  materialList="{ fluid, rock, relperm, thermalCond }"/>
-  </ElementRegions>
-  <Constitutive>
-  <CompressibleSolidConstantPermeability
-  name="rock"
-  solidModelName="nullSolid"
-  porosityModelName="rockPorosity"
-  permeabilityModelName="rockPerm"
-  solidInternalEnergyModelName="rockInternalEnergy"/>
-  <NullModel
-  name="nullSolid"/>
-  <PressurePorosity
-  name="rockPorosity"
-  defaultReferencePorosity="0.2"
-  referencePressure="0.0"
-  compressibility="1.0e-9"/>
-  <SolidInternalEnergy
-  name="rockInternalEnergy"
-  volumetricHeatCapacity="1.95e6"
-  referenceTemperature="368.15"
-  referenceInternalEnergy="0"/>
-  <ConstantPermeability
-  name="rockPerm"
-  permeabilityComponents="{ 1.0e-13, 1.0e-13, 1.0e-13 }"/>
-  <CO2BrinePhillipsThermalFluid
-  name="fluid"
-  phaseNames="{ gas, water }"
-  componentNames="{ co2, water }"
-  componentMolarWeight="{ 44e-3, 18e-3 }"
-  phasePVTParaFiles="{ pvtgas.txt, pvtliquid.txt }"
-  flashModelParaFile="co2flash.txt"/>
-  <BrooksCoreyRelativePermeability
-  name="relperm"
-  phaseNames="{ gas, water }"
-  phaseMinVolumeFraction="{ 0.0, 0.0 }"
-  phaseRelPermExponent="{ 1.5, 1.5 }"
-  phaseRelPermMaxValue="{ 0.9, 0.9 }"/>
-  <MultiPhaseConstantThermalConductivity
-  name="thermalCond"
-  phaseNames="{ gas, water }"
-  thermalConductivityComponents="{ 0.6, 0.6, 0.6 }"/>
-  </Constitutive>
-  <FieldSpecifications>
-  <FieldSpecification
-  name="initialPressure"
-  initialCondition="1"
-  setNames="{ all }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="pressure"
-  scale="9e6"/>
-  <FieldSpecification
-  name="initialTemperature"
-  initialCondition="1"
-  setNames="{ all }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="temperature"
-  scale="368.15"/>
-  <FieldSpecification
-  name="initialComposition_co2"
-  initialCondition="1"
-  setNames="{ all }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="globalCompFraction"
-  component="0"
-  scale="0.1"/>
-  <FieldSpecification
-  name="initialComposition_water"
-  initialCondition="1"
-  setNames="{ all }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="globalCompFraction"
-  component="1"
-  scale="0.9"/>
-  <FieldSpecification
-  name="sinkPressure"
-  setNames="{ sink }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="pressure"
-  scale="7e6"/>
-  <FieldSpecification
-  name="sinkTemperature"
-  setNames="{ sink }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="temperature"
-  scale="368.15"/>
-  <FieldSpecification
-  name="sinkTermComposition_co2"
-  setNames="{ sink }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="globalCompFraction"
-  component="0"
-  scale="0.1"/>
-  <FieldSpecification
-  name="sinkTermComposition_water"
-  setNames="{ sink }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="globalCompFraction"
-  component="1"
-  scale="0.9"/>
-  <FieldSpecification
-  name="sourcePressure"
-  setNames="{ source }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="pressure"
-  scale="1.45e7"/>
-  <FieldSpecification
-  name="sourceTemperature"
-  setNames="{ source }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="temperature"
-  scale="300.15"/>
-  <FieldSpecification
-  name="sourceTermComposition_co2"
-  setNames="{ source }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="globalCompFraction"
-  component="0"
-  scale="0.9"/>
-  <FieldSpecification
-  name="sourceTermComposition_water"
-  setNames="{ source }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="globalCompFraction"
-  component="1"
-  scale="0.1"/>
-  </FieldSpecifications>
+    <Solvers>
+      <CompositionalMultiphaseFVM name="compflow"
+                                  logLevel="1"
+                                  discretization="fluidTPFA"
+                                  temperature="368.15"
+                                  useMass="1"
+                                  isThermal="1"
+                                  initialDt="1000"
+                                  maxCompFractionChange="0.5"
+                                  targetRegions="{ region }">
+        <NonlinearSolverParameters newtonTol="1.0e-6"
+                                   newtonMaxIter="100"
+                                   lineSearchAction="None"
+                                   maxTimeStepCuts="5" />
+        <LinearSolverParameters directParallel="0" />
+      </CompositionalMultiphaseFVM>
+    </Solvers>
+    <Mesh>
+      <InternalMesh name="mesh"
+                    elementTypes="{ C3D8 }"
+                    xCoords="{ 0, 20 }"
+                    yCoords="{ 0, 1 }"
+                    zCoords="{ 0, 1 }"
+                    nx="{ 5 }"
+                    ny="{ 1 }"
+                    nz="{ 1 }"
+                    cellBlockNames="{ cb }" />
+    </Mesh>
+    <Geometry>
+      <Box name="sink"
+           xMin="{ -0.01, -0.01, -0.01 }"
+           xMax="{ 4.01, 1.01, 1.01 }" />
+      <Box name="source"
+           xMin="{ -0.01, -0.01, -0.01 }"
+           xMax="{ 4.01, 1.01, 1.01 }" />
+    </Geometry>
+    <Events maxTime="1000">
+      <PeriodicEvent name="solverApplications"
+                     maxEventDt="1000"
+                     target="/Solvers/compflow" />
+    </Events>
+    <NumericalMethods>
+      <FiniteVolume>
+        <TwoPointFluxApproximation name="fluidTPFA" />
+      </FiniteVolume>
+    </NumericalMethods>
+    <ElementRegions>
+      <CellElementRegion name="region"
+                         cellBlocks="{ cb }"
+                         materialList="{ fluid, rock, relperm, thermalCond }" />
+    </ElementRegions>
+    <Constitutive>
+      <CompressibleSolidConstantPermeability name="rock"
+                                             solidModelName="nullSolid"
+                                             porosityModelName="rockPorosity"
+                                             permeabilityModelName="rockPerm"
+                                             solidInternalEnergyModelName="rockInternalEnergy" />
+      <NullModel name="nullSolid" />
+      <PressurePorosity name="rockPorosity"
+                        defaultReferencePorosity="0.2"
+                        referencePressure="0.0"
+                        compressibility="1.0e-9" />
+      <SolidInternalEnergy name="rockInternalEnergy"
+                           volumetricHeatCapacity="1.95e6"
+                           referenceTemperature="368.15"
+                           referenceInternalEnergy="0" />
+      <ConstantPermeability name="rockPerm"
+                            permeabilityComponents="{ 1.0e-13, 1.0e-13, 1.0e-13 }" />
+      <CO2BrinePhillipsThermalFluid name="fluid"
+                                    phaseNames="{ gas, water }"
+                                    componentNames="{ co2, water }"
+                                    componentMolarWeight="{ 44e-3, 18e-3 }"
+                                    phasePVTParaFiles="{ pvtgas.txt, pvtliquid.txt }"
+                                    flashModelParaFile="co2flash.txt" />
+      <BrooksCoreyRelativePermeability name="relperm"
+                                       phaseNames="{ gas, water }"
+                                       phaseMinVolumeFraction="{ 0.0, 0.0 }"
+                                       phaseRelPermExponent="{ 1.5, 1.5 }"
+                                       phaseRelPermMaxValue="{ 0.9, 0.9 }" />
+      <MultiPhaseConstantThermalConductivity name="thermalCond"
+                                             phaseNames="{ gas, water }"
+                                             thermalConductivityComponents="{ 0.6, 0.6, 0.6 }" />
+    </Constitutive>
+    <FieldSpecifications>
+      <FieldSpecification name="initialPressure"
+                          initialCondition="1"
+                          setNames="{ all }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="pressure"
+                          scale="9e6" />
+      <FieldSpecification name="initialTemperature"
+                          initialCondition="1"
+                          setNames="{ all }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="temperature"
+                          scale="368.15" />
+      <FieldSpecification name="initialComposition_co2"
+                          initialCondition="1"
+                          setNames="{ all }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="globalCompFraction"
+                          component="0"
+                          scale="0.1" />
+      <FieldSpecification name="initialComposition_water"
+                          initialCondition="1"
+                          setNames="{ all }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="globalCompFraction"
+                          component="1"
+                          scale="0.9" />
+      <FieldSpecification name="sinkPressure"
+                          setNames="{ sink }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="pressure"
+                          scale="7e6" />
+      <FieldSpecification name="sinkTemperature"
+                          setNames="{ sink }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="temperature"
+                          scale="368.15" />
+      <FieldSpecification name="sinkTermComposition_co2"
+                          setNames="{ sink }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="globalCompFraction"
+                          component="0"
+                          scale="0.1" />
+      <FieldSpecification name="sinkTermComposition_water"
+                          setNames="{ sink }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="globalCompFraction"
+                          component="1"
+                          scale="0.9" />
+      <FieldSpecification name="sourcePressure"
+                          setNames="{ source }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="pressure"
+                          scale="1.45e7" />
+      <FieldSpecification name="sourceTemperature"
+                          setNames="{ source }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="temperature"
+                          scale="300.15" />
+      <FieldSpecification name="sourceTermComposition_co2"
+                          setNames="{ source }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="globalCompFraction"
+                          component="0"
+                          scale="0.9" />
+      <FieldSpecification name="sourceTermComposition_water"
+                          setNames="{ source }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="globalCompFraction"
+                          component="1"
+                          scale="0.1" />
+    </FieldSpecifications>
   </Problem>
   )xml";
 

--- a/src/coreComponents/unitTests/fluidFlowTests/testThermalCompMultiphaseFlow.cpp
+++ b/src/coreComponents/unitTests/fluidFlowTests/testThermalCompMultiphaseFlow.cpp
@@ -44,193 +44,195 @@ char const * pvtGas = "DensityFun SpanWagnerCO2Density 1e6 7.5e7 5e5 295.15 370.
 char const * co2flash = "FlashModel CO2Solubility  1e6 7.5e7 5e5 295.15 370.15 25 0";
 
 char const * xmlInput =
-  "<Problem>\n"
-  "<Solvers>\n"
-  "<CompositionalMultiphaseFVM\n"
-  "name=\"compflow\"\n"
-  "logLevel=\"1\"\n"
-  "discretization=\"fluidTPFA\"\n"
-  "temperature=\"368.15\"\n"
-  "useMass=\"1\"\n"
-  "isThermal=\"1\"\n"
-  "initialDt=\"1000\"\n"
-  "maxCompFractionChange=\"0.5\"\n"
-  "targetRegions=\"{ region }\">\n"
-  "<NonlinearSolverParameters\n"
-  "newtonTol=\"1.0e-6\"\n"
-  "newtonMaxIter=\"100\"\n"
-  "lineSearchAction=\"None\"\n"
-  "maxTimeStepCuts=\"5\"/>\n"
-  "<LinearSolverParameters\n"
-  "directParallel=\"0\"/>\n"
-  "</CompositionalMultiphaseFVM>\n"
-  "</Solvers>\n"
-  "<Mesh>\n"
-  "<InternalMesh\n"
-  "name=\"mesh\"\n"
-  "elementTypes=\"{ C3D8 }\"\n"
-  "xCoords=\"{ 0, 20 }\"\n"
-  "yCoords=\"{ 0, 1 }\"\n"
-  "zCoords=\"{ 0, 1 }\"\n"
-  "nx=\"{ 5 }\"\n"
-  "ny=\"{ 1 }\"\n"
-  "nz=\"{ 1 }\"\n"
-  "cellBlockNames=\"{ cb }\"/>\n"
-  "</Mesh>\n"
-  "<Geometry>\n"
-  "<Box\n"
-  "name=\"sink\"\n"
-  "xMin=\"{ -0.01, -0.01, -0.01 }\"\n"
-  "xMax=\"{ 4.01, 1.01, 1.01 }\"/>\n"
-  "<Box\n"
-  "name=\"source\"\n"
-  "xMin=\"{ -0.01, -0.01, -0.01 }\"\n"
-  "xMax=\"{ 4.01, 1.01, 1.01 }\"/>\n"
-  "</Geometry>\n"
-  "<Events\n"
-  "maxTime=\"1000\">\n"
-  "<PeriodicEvent\n"
-  "name=\"solverApplications\"\n"
-  "maxEventDt=\"1000\"\n"
-  "target=\"/Solvers/compflow\"/>\n"
-  "</Events>\n"
-  "<NumericalMethods>\n"
-  "<FiniteVolume>\n"
-  "<TwoPointFluxApproximation\n"
-  "name=\"fluidTPFA\"/>\n"
-  "</FiniteVolume>\n"
-  "</NumericalMethods>\n"
-  "<ElementRegions>\n"
-  "<CellElementRegion\n"
-  "name=\"region\"\n"
-  "cellBlocks=\"{ cb }\"\n"
-  "materialList=\"{ fluid, rock, relperm, thermalCond }\"/>\n"
-  "</ElementRegions>\n"
-  "<Constitutive>\n"
-  "<CompressibleSolidConstantPermeability\n"
-  "name=\"rock\"\n"
-  "solidModelName=\"nullSolid\"\n"
-  "porosityModelName=\"rockPorosity\"\n"
-  "permeabilityModelName=\"rockPerm\"\n"
-  "solidInternalEnergyModelName=\"rockInternalEnergy\"/>\n"
-  "<NullModel\n"
-  "name=\"nullSolid\"/>\n"
-  "<PressurePorosity\n"
-  "name=\"rockPorosity\"\n"
-  "defaultReferencePorosity=\"0.2\"\n"
-  "referencePressure=\"0.0\"\n"
-  "compressibility=\"1.0e-9\"/>\n"
-  "<SolidInternalEnergy\n"
-  "name=\"rockInternalEnergy\"\n"
-  "volumetricHeatCapacity=\"1.95e6\"\n"
-  "referenceTemperature=\"368.15\"\n"
-  "referenceInternalEnergy=\"0\"/>\n"
-  "<ConstantPermeability\n"
-  "name=\"rockPerm\"\n"
-  "permeabilityComponents=\"{ 1.0e-13, 1.0e-13, 1.0e-13 }\"/>\n"
-  "<CO2BrinePhillipsThermalFluid\n"
-  "name=\"fluid\"\n"
-  "phaseNames=\"{ gas, water }\"\n"
-  "componentNames=\"{ co2, water }\"\n"
-  "componentMolarWeight=\"{ 44e-3, 18e-3 }\"\n"
-  "phasePVTParaFiles=\"{ pvtgas.txt, pvtliquid.txt }\"\n"
-  "flashModelParaFile=\"co2flash.txt\"/>\n"
-  "<BrooksCoreyRelativePermeability\n"
-  "name=\"relperm\"\n"
-  "phaseNames=\"{ gas, water }\"\n"
-  "phaseMinVolumeFraction=\"{ 0.0, 0.0 }\"\n"
-  "phaseRelPermExponent=\"{ 1.5, 1.5 }\"\n"
-  "phaseRelPermMaxValue=\"{ 0.9, 0.9 }\"/>\n"
-  "<MultiPhaseConstantThermalConductivity\n"
-  "name=\"thermalCond\"\n"
-  "phaseNames=\"{ gas, water }\"\n"
-  "thermalConductivityComponents=\"{ 0.6, 0.6, 0.6 }\"/>\n"
-  "</Constitutive>\n"
-  "<FieldSpecifications>\n"
-  "<FieldSpecification\n"
-  "name=\"initialPressure\"\n"
-  "initialCondition=\"1\"\n"
-  "setNames=\"{ all }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"pressure\"\n"
-  "scale=\"9e6\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"initialTemperature\"\n"
-  "initialCondition=\"1\"\n"
-  "setNames=\"{ all }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"temperature\"\n"
-  "scale=\"368.15\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"initialComposition_co2\"\n"
-  "initialCondition=\"1\"\n"
-  "setNames=\"{ all }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"globalCompFraction\"\n"
-  "component=\"0\"\n"
-  "scale=\"0.1\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"initialComposition_water\"\n"
-  "initialCondition=\"1\"\n"
-  "setNames=\"{ all }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"globalCompFraction\"\n"
-  "component=\"1\"\n"
-  "scale=\"0.9\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sinkPressure\"\n"
-  "setNames=\"{ sink }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"pressure\"\n"
-  "scale=\"7e6\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sinkTemperature\"\n"
-  "setNames=\"{ sink }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"temperature\"\n"
-  "scale=\"368.15\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sinkTermComposition_co2\"\n"
-  "setNames=\"{ sink }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"globalCompFraction\"\n"
-  "component=\"0\"\n"
-  "scale=\"0.1\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sinkTermComposition_water\"\n"
-  "setNames=\"{ sink }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"globalCompFraction\"\n"
-  "component=\"1\"\n"
-  "scale=\"0.9\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sourcePressure\"\n"
-  "setNames=\"{ source }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"pressure\"\n"
-  "scale=\"1.45e7\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sourceTemperature\"\n"
-  "setNames=\"{ source }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"temperature\"\n"
-  "scale=\"300.15\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sourceTermComposition_co2\"\n"
-  "setNames=\"{ source }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"globalCompFraction\"\n"
-  "component=\"0\"\n"
-  "scale=\"0.9\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sourceTermComposition_water\"\n"
-  "setNames=\"{ source }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"globalCompFraction\"\n"
-  "component=\"1\"\n"
-  "scale=\"0.1\"/>\n"
-  "</FieldSpecifications>\n"
-  "</Problem>\n";
+  R"xml(
+  <Problem>
+  <Solvers>
+  <CompositionalMultiphaseFVM
+  name="compflow"
+  logLevel="1"
+  discretization="fluidTPFA"
+  temperature="368.15"
+  useMass="1"
+  isThermal="1"
+  initialDt="1000"
+  maxCompFractionChange="0.5"
+  targetRegions="{ region }">
+  <NonlinearSolverParameters
+  newtonTol="1.0e-6"
+  newtonMaxIter="100"
+  lineSearchAction="None"
+  maxTimeStepCuts="5"/>
+  <LinearSolverParameters
+  directParallel="0"/>
+  </CompositionalMultiphaseFVM>
+  </Solvers>
+  <Mesh>
+  <InternalMesh
+  name="mesh"
+  elementTypes="{ C3D8 }"
+  xCoords="{ 0, 20 }"
+  yCoords="{ 0, 1 }"
+  zCoords="{ 0, 1 }"
+  nx="{ 5 }"
+  ny="{ 1 }"
+  nz="{ 1 }"
+  cellBlockNames="{ cb }"/>
+  </Mesh>
+  <Geometry>
+  <Box
+  name="sink"
+  xMin="{ -0.01, -0.01, -0.01 }"
+  xMax="{ 4.01, 1.01, 1.01 }"/>
+  <Box
+  name="source"
+  xMin="{ -0.01, -0.01, -0.01 }"
+  xMax="{ 4.01, 1.01, 1.01 }"/>
+  </Geometry>
+  <Events
+  maxTime="1000">
+  <PeriodicEvent
+  name="solverApplications"
+  maxEventDt="1000"
+  target="/Solvers/compflow"/>
+  </Events>
+  <NumericalMethods>
+  <FiniteVolume>
+  <TwoPointFluxApproximation
+  name="fluidTPFA"/>
+  </FiniteVolume>
+  </NumericalMethods>
+  <ElementRegions>
+  <CellElementRegion
+  name="region"
+  cellBlocks="{ cb }"
+  materialList="{ fluid, rock, relperm, thermalCond }"/>
+  </ElementRegions>
+  <Constitutive>
+  <CompressibleSolidConstantPermeability
+  name="rock"
+  solidModelName="nullSolid"
+  porosityModelName="rockPorosity"
+  permeabilityModelName="rockPerm"
+  solidInternalEnergyModelName="rockInternalEnergy"/>
+  <NullModel
+  name="nullSolid"/>
+  <PressurePorosity
+  name="rockPorosity"
+  defaultReferencePorosity="0.2"
+  referencePressure="0.0"
+  compressibility="1.0e-9"/>
+  <SolidInternalEnergy
+  name="rockInternalEnergy"
+  volumetricHeatCapacity="1.95e6"
+  referenceTemperature="368.15"
+  referenceInternalEnergy="0"/>
+  <ConstantPermeability
+  name="rockPerm"
+  permeabilityComponents="{ 1.0e-13, 1.0e-13, 1.0e-13 }"/>
+  <CO2BrinePhillipsThermalFluid
+  name="fluid"
+  phaseNames="{ gas, water }"
+  componentNames="{ co2, water }"
+  componentMolarWeight="{ 44e-3, 18e-3 }"
+  phasePVTParaFiles="{ pvtgas.txt, pvtliquid.txt }"
+  flashModelParaFile="co2flash.txt"/>
+  <BrooksCoreyRelativePermeability
+  name="relperm"
+  phaseNames="{ gas, water }"
+  phaseMinVolumeFraction="{ 0.0, 0.0 }"
+  phaseRelPermExponent="{ 1.5, 1.5 }"
+  phaseRelPermMaxValue="{ 0.9, 0.9 }"/>
+  <MultiPhaseConstantThermalConductivity
+  name="thermalCond"
+  phaseNames="{ gas, water }"
+  thermalConductivityComponents="{ 0.6, 0.6, 0.6 }"/>
+  </Constitutive>
+  <FieldSpecifications>
+  <FieldSpecification
+  name="initialPressure"
+  initialCondition="1"
+  setNames="{ all }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="pressure"
+  scale="9e6"/>
+  <FieldSpecification
+  name="initialTemperature"
+  initialCondition="1"
+  setNames="{ all }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="temperature"
+  scale="368.15"/>
+  <FieldSpecification
+  name="initialComposition_co2"
+  initialCondition="1"
+  setNames="{ all }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="globalCompFraction"
+  component="0"
+  scale="0.1"/>
+  <FieldSpecification
+  name="initialComposition_water"
+  initialCondition="1"
+  setNames="{ all }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="globalCompFraction"
+  component="1"
+  scale="0.9"/>
+  <FieldSpecification
+  name="sinkPressure"
+  setNames="{ sink }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="pressure"
+  scale="7e6"/>
+  <FieldSpecification
+  name="sinkTemperature"
+  setNames="{ sink }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="temperature"
+  scale="368.15"/>
+  <FieldSpecification
+  name="sinkTermComposition_co2"
+  setNames="{ sink }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="globalCompFraction"
+  component="0"
+  scale="0.1"/>
+  <FieldSpecification
+  name="sinkTermComposition_water"
+  setNames="{ sink }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="globalCompFraction"
+  component="1"
+  scale="0.9"/>
+  <FieldSpecification
+  name="sourcePressure"
+  setNames="{ source }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="pressure"
+  scale="1.45e7"/>
+  <FieldSpecification
+  name="sourceTemperature"
+  setNames="{ source }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="temperature"
+  scale="300.15"/>
+  <FieldSpecification
+  name="sourceTermComposition_co2"
+  setNames="{ source }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="globalCompFraction"
+  component="0"
+  scale="0.9"/>
+  <FieldSpecification
+  name="sourceTermComposition_water"
+  setNames="{ source }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="globalCompFraction"
+  component="1"
+  scale="0.1"/>
+  </FieldSpecifications>
+  </Problem>
+  )xml";
 
 // Sphinx end before input XML
 

--- a/src/coreComponents/unitTests/fluidFlowTests/testThermalSinglePhaseFlow.cpp
+++ b/src/coreComponents/unitTests/fluidFlowTests/testThermalSinglePhaseFlow.cpp
@@ -35,139 +35,116 @@ CommandLineOptions g_commandLineOptions;
 char const * xmlInput =
   R"xml(
   <Problem>
-  <Solvers>
-  <SinglePhaseFVM
-  name="singleflow"
-  logLevel="1"
-  discretization="fluidTPFA"
-  temperature="368.15"
-  isThermal="1"
-  targetRegions="{ region }">
-  <NonlinearSolverParameters
-  newtonTol="1.0e-6"
-  newtonMaxIter="100"/>
-  <LinearSolverParameters
-  solverType="gmres"
-  krylovTol="1.0e-10"/>
-  </SinglePhaseFVM>
-  </Solvers>
-  <Mesh>
-  <InternalMesh
-  name="mesh"
-  elementTypes="{ C3D8 }"
-  xCoords="{ 0, 20 }"
-  yCoords="{ 0, 1 }"
-  zCoords="{ 0, 1 }"
-  nx="{ 5 }"
-  ny="{ 1 }"
-  nz="{ 1 }"
-  cellBlockNames="{ cb }"/>
-  </Mesh>
-  <Geometry>
-  <Box
-  name="sink"
-  xMin="{ -0.01, -0.01, -0.01 }"
-  xMax="{ 4.01, 1.01, 1.01 }"/>
-  <Box
-  name="source"
-  xMin="{ -0.01, -0.01, -0.01 }"
-  xMax="{ 4.01, 1.01, 1.01 }"/>
-  </Geometry>
-  <Events
-  maxTime="1000">
-  <PeriodicEvent
-  name="solverApplications"
-  maxEventDt="1000"
-  target="/Solvers/singleflow"/>
-  </Events>
-  <NumericalMethods>
-  <FiniteVolume>
-  <TwoPointFluxApproximation
-  name="fluidTPFA"/>
-  </FiniteVolume>
-  </NumericalMethods>
-  <ElementRegions>
-  <CellElementRegion
-  name="region"
-  cellBlocks="{ cb }"
-  materialList="{ water, rock, thermalCond }"/>
-  </ElementRegions>
-  <Constitutive>
-  <CompressibleSolidConstantPermeability
-  name="rock"
-  solidModelName="nullSolid"
-  porosityModelName="rockPorosity"
-  permeabilityModelName="rockPerm"
-  solidInternalEnergyModelName="rockInternalEnergy"/>
-  <NullModel
-  name="nullSolid"/>
-  <PressurePorosity
-  name="rockPorosity"
-  defaultReferencePorosity="0.05"
-  referencePressure="0.0"
-  compressibility="1.0e-9"/>
-  <SolidInternalEnergy
-  name="rockInternalEnergy"
-  volumetricHeatCapacity="1.95e6"
-  referenceTemperature="368.15"
-  referenceInternalEnergy="0"/>
-  <ConstantPermeability
-  name="rockPerm"
-  permeabilityComponents="{ 1.0e-13, 1.0e-13, 1.0e-13 }"/>
-  <ThermalCompressibleSinglePhaseFluid
-  name="water"
-  defaultDensity="1000"
-  defaultViscosity="0.001"
-  referencePressure="0.0"
-  referenceTemperature="0.0"
-  compressibility="5e-10"
-  thermalExpansionCoeff="7e-4"
-  viscosibility="0.0"
-  volumetricHeatCapacity="4.5e3"/>
-  <SinglePhaseConstantThermalConductivity
-  name="thermalCond"
-  thermalConductivityComponents="{ 0.6, 0.6, 0.6 }"/>
-  </Constitutive>
-  <FieldSpecifications>
-  <FieldSpecification
-  name="initialPressure"
-  initialCondition="1"
-  setNames="{ all }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="pressure"
-  scale="9e6"/>
-  <FieldSpecification
-  name="initialTemperature"
-  initialCondition="1"
-  setNames="{ all }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="temperature"
-  scale="368.15"/>
-  <FieldSpecification
-  name="sinkPressure"
-  setNames="{ sink }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="pressure"
-  scale="7e6"/>
-  <FieldSpecification
-  name="sinkTemperature"
-  setNames="{ sink }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="temperature"
-  scale="368.15"/>
-  <FieldSpecification
-  name="sourcePressure"
-  setNames="{ source }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="pressure"
-  scale="1.45e7"/>
-  <FieldSpecification
-  name="sourceTemperature"
-  setNames="{ source }"
-  objectPath="ElementRegions/region/cb"
-  fieldName="temperature"
-  scale="300.15"/>
-  </FieldSpecifications>
+    <Solvers>
+      <SinglePhaseFVM name="singleflow"
+                      logLevel="1"
+                      discretization="fluidTPFA"
+                      temperature="368.15"
+                      isThermal="1"
+                      targetRegions="{ region }">
+        <NonlinearSolverParameters newtonTol="1.0e-6"
+                                   newtonMaxIter="100" />
+        <LinearSolverParameters solverType="gmres"
+                                krylovTol="1.0e-10" />
+      </SinglePhaseFVM>
+    </Solvers>
+    <Mesh>
+      <InternalMesh name="mesh"
+                    elementTypes="{ C3D8 }"
+                    xCoords="{ 0, 20 }"
+                    yCoords="{ 0, 1 }"
+                    zCoords="{ 0, 1 }"
+                    nx="{ 5 }"
+                    ny="{ 1 }"
+                    nz="{ 1 }"
+                    cellBlockNames="{ cb }" />
+    </Mesh>
+    <Geometry>
+      <Box name="sink"
+           xMin="{ -0.01, -0.01, -0.01 }"
+           xMax="{ 4.01, 1.01, 1.01 }" />
+      <Box name="source"
+           xMin="{ -0.01, -0.01, -0.01 }"
+           xMax="{ 4.01, 1.01, 1.01 }" />
+    </Geometry>
+    <Events maxTime="1000">
+      <PeriodicEvent name="solverApplications"
+                     maxEventDt="1000"
+                     target="/Solvers/singleflow" />
+    </Events>
+    <NumericalMethods>
+      <FiniteVolume>
+        <TwoPointFluxApproximation name="fluidTPFA" />
+      </FiniteVolume>
+    </NumericalMethods>
+    <ElementRegions>
+      <CellElementRegion name="region"
+                         cellBlocks="{ cb }"
+                         materialList="{ water, rock, thermalCond }" />
+    </ElementRegions>
+    <Constitutive>
+      <CompressibleSolidConstantPermeability name="rock"
+                                             solidModelName="nullSolid"
+                                             porosityModelName="rockPorosity"
+                                             permeabilityModelName="rockPerm"
+                                             solidInternalEnergyModelName="rockInternalEnergy" />
+      <NullModel name="nullSolid" />
+      <PressurePorosity name="rockPorosity"
+                        defaultReferencePorosity="0.05"
+                        referencePressure="0.0"
+                        compressibility="1.0e-9" />
+      <SolidInternalEnergy name="rockInternalEnergy"
+                           volumetricHeatCapacity="1.95e6"
+                           referenceTemperature="368.15"
+                           referenceInternalEnergy="0" />
+      <ConstantPermeability name="rockPerm"
+                            permeabilityComponents="{ 1.0e-13, 1.0e-13, 1.0e-13 }" />
+      <ThermalCompressibleSinglePhaseFluid name="water"
+                                           defaultDensity="1000"
+                                           defaultViscosity="0.001"
+                                           referencePressure="0.0"
+                                           referenceTemperature="0.0"
+                                           compressibility="5e-10"
+                                           thermalExpansionCoeff="7e-4"
+                                           viscosibility="0.0"
+                                           volumetricHeatCapacity="4.5e3" />
+      <SinglePhaseConstantThermalConductivity name="thermalCond"
+                                              thermalConductivityComponents="{ 0.6, 0.6, 0.6 }" />
+    </Constitutive>
+    <FieldSpecifications>
+      <FieldSpecification name="initialPressure"
+                          initialCondition="1"
+                          setNames="{ all }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="pressure"
+                          scale="9e6" />
+      <FieldSpecification name="initialTemperature"
+                          initialCondition="1"
+                          setNames="{ all }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="temperature"
+                          scale="368.15" />
+      <FieldSpecification name="sinkPressure"
+                          setNames="{ sink }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="pressure"
+                          scale="7e6" />
+      <FieldSpecification name="sinkTemperature"
+                          setNames="{ sink }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="temperature"
+                          scale="368.15" />
+      <FieldSpecification name="sourcePressure"
+                          setNames="{ source }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="pressure"
+                          scale="1.45e7" />
+      <FieldSpecification name="sourceTemperature"
+                          setNames="{ source }"
+                          objectPath="ElementRegions/region/cb"
+                          fieldName="temperature"
+                          scale="300.15" />
+    </FieldSpecifications>
   </Problem>
   )xml";
 // Sphinx end before input XML

--- a/src/coreComponents/unitTests/fluidFlowTests/testThermalSinglePhaseFlow.cpp
+++ b/src/coreComponents/unitTests/fluidFlowTests/testThermalSinglePhaseFlow.cpp
@@ -33,142 +33,143 @@ CommandLineOptions g_commandLineOptions;
 // Sphinx start after input XML
 
 char const * xmlInput =
-  "<Problem>\n"
-  "<Solvers>\n"
-  "<SinglePhaseFVM\n"
-  "name=\"singleflow\"\n"
-  "logLevel=\"1\"\n"
-  "discretization=\"fluidTPFA\"\n"
-  "temperature=\"368.15\"\n"
-  "isThermal=\"1\"\n"
-  "targetRegions=\"{ region }\">\n"
-  "<NonlinearSolverParameters\n"
-  "newtonTol=\"1.0e-6\"\n"
-  "newtonMaxIter=\"100\"/>\n"
-  "<LinearSolverParameters\n"
-  "solverType=\"gmres\"\n"
-  "krylovTol=\"1.0e-10\"/>\n"
-  "</SinglePhaseFVM>\n"
-  "</Solvers>\n"
-  "<Mesh>\n"
-  "<InternalMesh\n"
-  "name=\"mesh\"\n"
-  "elementTypes=\"{ C3D8 }\"\n"
-  "xCoords=\"{ 0, 20 }\"\n"
-  "yCoords=\"{ 0, 1 }\"\n"
-  "zCoords=\"{ 0, 1 }\"\n"
-  "nx=\"{ 5 }\"\n"
-  "ny=\"{ 1 }\"\n"
-  "nz=\"{ 1 }\"\n"
-  "cellBlockNames=\"{ cb }\"/>\n"
-  "</Mesh>\n"
-  "<Geometry>\n"
-  "<Box\n"
-  "name=\"sink\"\n"
-  "xMin=\"{ -0.01, -0.01, -0.01 }\"\n"
-  "xMax=\"{ 4.01, 1.01, 1.01 }\"/>\n"
-  "<Box\n"
-  "name=\"source\"\n"
-  "xMin=\"{ -0.01, -0.01, -0.01 }\"\n"
-  "xMax=\"{ 4.01, 1.01, 1.01 }\"/>\n"
-  "</Geometry>\n"
-  "<Events\n"
-  "maxTime=\"1000\">\n"
-  "<PeriodicEvent\n"
-  "name=\"solverApplications\"\n"
-  "maxEventDt=\"1000\"\n"
-  "target=\"/Solvers/singleflow\"/>\n"
-  "</Events>\n"
-  "<NumericalMethods>\n"
-  "<FiniteVolume>\n"
-  "<TwoPointFluxApproximation\n"
-  "name=\"fluidTPFA\"/>\n"
-  "</FiniteVolume>\n"
-  "</NumericalMethods>\n"
-  "<ElementRegions>\n"
-  "<CellElementRegion\n"
-  "name=\"region\"\n"
-  "cellBlocks=\"{ cb }\"\n"
-  "materialList=\"{ water, rock, thermalCond }\"/>\n"
-  "</ElementRegions>\n"
-  "<Constitutive>\n"
-  "<CompressibleSolidConstantPermeability\n"
-  "name=\"rock\"\n"
-  "solidModelName=\"nullSolid\"\n"
-  "porosityModelName=\"rockPorosity\"\n"
-  "permeabilityModelName=\"rockPerm\"\n"
-  "solidInternalEnergyModelName=\"rockInternalEnergy\"/>\n"
-  "<NullModel\n"
-  "name=\"nullSolid\"/>\n"
-  "<PressurePorosity\n"
-  "name=\"rockPorosity\"\n"
-  "defaultReferencePorosity=\"0.05\"\n"
-  "referencePressure=\"0.0\"\n"
-  "compressibility=\"1.0e-9\"/>\n"
-  "<SolidInternalEnergy\n"
-  "name=\"rockInternalEnergy\"\n"
-  "volumetricHeatCapacity=\"1.95e6\"\n"
-  "referenceTemperature=\"368.15\"\n"
-  "referenceInternalEnergy=\"0\"/>\n"
-  "<ConstantPermeability\n"
-  "name=\"rockPerm\"\n"
-  "permeabilityComponents=\"{ 1.0e-13, 1.0e-13, 1.0e-13 }\"/>\n"
-  "<ThermalCompressibleSinglePhaseFluid\n"
-  "name=\"water\"\n"
-  "defaultDensity=\"1000\"\n"
-  "defaultViscosity=\"0.001\"\n"
-  "referencePressure=\"0.0\"\n"
-  "referenceTemperature=\"0.0\"\n"
-  "compressibility=\"5e-10\"\n"
-  "thermalExpansionCoeff=\"7e-4\"\n"
-  "viscosibility=\"0.0\"\n"
-  "volumetricHeatCapacity=\"4.5e3\"/>\n"
-  "<SinglePhaseConstantThermalConductivity\n"
-  "name=\"thermalCond\"\n"
-  "thermalConductivityComponents=\"{ 0.6, 0.6, 0.6 }\"/>\n"
-  "</Constitutive>\n"
-  "<FieldSpecifications>\n"
-  "<FieldSpecification\n"
-  "name=\"initialPressure\"\n"
-  "initialCondition=\"1\"\n"
-  "setNames=\"{ all }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"pressure\"\n"
-  "scale=\"9e6\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"initialTemperature\"\n"
-  "initialCondition=\"1\"\n"
-  "setNames=\"{ all }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"temperature\"\n"
-  "scale=\"368.15\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sinkPressure\"\n"
-  "setNames=\"{ sink }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"pressure\"\n"
-  "scale=\"7e6\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sinkTemperature\"\n"
-  "setNames=\"{ sink }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"temperature\"\n"
-  "scale=\"368.15\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sourcePressure\"\n"
-  "setNames=\"{ source }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"pressure\"\n"
-  "scale=\"1.45e7\"/>\n"
-  "<FieldSpecification\n"
-  "name=\"sourceTemperature\"\n"
-  "setNames=\"{ source }\"\n"
-  "objectPath=\"ElementRegions/region/cb\"\n"
-  "fieldName=\"temperature\"\n"
-  "scale=\"300.15\"/>\n"
-  "</FieldSpecifications>\n"
-  "</Problem>\n";
-
+  R"xml(
+  <Problem>
+  <Solvers>
+  <SinglePhaseFVM
+  name="singleflow"
+  logLevel="1"
+  discretization="fluidTPFA"
+  temperature="368.15"
+  isThermal="1"
+  targetRegions="{ region }">
+  <NonlinearSolverParameters
+  newtonTol="1.0e-6"
+  newtonMaxIter="100"/>
+  <LinearSolverParameters
+  solverType="gmres"
+  krylovTol="1.0e-10"/>
+  </SinglePhaseFVM>
+  </Solvers>
+  <Mesh>
+  <InternalMesh
+  name="mesh"
+  elementTypes="{ C3D8 }"
+  xCoords="{ 0, 20 }"
+  yCoords="{ 0, 1 }"
+  zCoords="{ 0, 1 }"
+  nx="{ 5 }"
+  ny="{ 1 }"
+  nz="{ 1 }"
+  cellBlockNames="{ cb }"/>
+  </Mesh>
+  <Geometry>
+  <Box
+  name="sink"
+  xMin="{ -0.01, -0.01, -0.01 }"
+  xMax="{ 4.01, 1.01, 1.01 }"/>
+  <Box
+  name="source"
+  xMin="{ -0.01, -0.01, -0.01 }"
+  xMax="{ 4.01, 1.01, 1.01 }"/>
+  </Geometry>
+  <Events
+  maxTime="1000">
+  <PeriodicEvent
+  name="solverApplications"
+  maxEventDt="1000"
+  target="/Solvers/singleflow"/>
+  </Events>
+  <NumericalMethods>
+  <FiniteVolume>
+  <TwoPointFluxApproximation
+  name="fluidTPFA"/>
+  </FiniteVolume>
+  </NumericalMethods>
+  <ElementRegions>
+  <CellElementRegion
+  name="region"
+  cellBlocks="{ cb }"
+  materialList="{ water, rock, thermalCond }"/>
+  </ElementRegions>
+  <Constitutive>
+  <CompressibleSolidConstantPermeability
+  name="rock"
+  solidModelName="nullSolid"
+  porosityModelName="rockPorosity"
+  permeabilityModelName="rockPerm"
+  solidInternalEnergyModelName="rockInternalEnergy"/>
+  <NullModel
+  name="nullSolid"/>
+  <PressurePorosity
+  name="rockPorosity"
+  defaultReferencePorosity="0.05"
+  referencePressure="0.0"
+  compressibility="1.0e-9"/>
+  <SolidInternalEnergy
+  name="rockInternalEnergy"
+  volumetricHeatCapacity="1.95e6"
+  referenceTemperature="368.15"
+  referenceInternalEnergy="0"/>
+  <ConstantPermeability
+  name="rockPerm"
+  permeabilityComponents="{ 1.0e-13, 1.0e-13, 1.0e-13 }"/>
+  <ThermalCompressibleSinglePhaseFluid
+  name="water"
+  defaultDensity="1000"
+  defaultViscosity="0.001"
+  referencePressure="0.0"
+  referenceTemperature="0.0"
+  compressibility="5e-10"
+  thermalExpansionCoeff="7e-4"
+  viscosibility="0.0"
+  volumetricHeatCapacity="4.5e3"/>
+  <SinglePhaseConstantThermalConductivity
+  name="thermalCond"
+  thermalConductivityComponents="{ 0.6, 0.6, 0.6 }"/>
+  </Constitutive>
+  <FieldSpecifications>
+  <FieldSpecification
+  name="initialPressure"
+  initialCondition="1"
+  setNames="{ all }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="pressure"
+  scale="9e6"/>
+  <FieldSpecification
+  name="initialTemperature"
+  initialCondition="1"
+  setNames="{ all }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="temperature"
+  scale="368.15"/>
+  <FieldSpecification
+  name="sinkPressure"
+  setNames="{ sink }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="pressure"
+  scale="7e6"/>
+  <FieldSpecification
+  name="sinkTemperature"
+  setNames="{ sink }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="temperature"
+  scale="368.15"/>
+  <FieldSpecification
+  name="sourcePressure"
+  setNames="{ source }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="pressure"
+  scale="1.45e7"/>
+  <FieldSpecification
+  name="sourceTemperature"
+  setNames="{ source }"
+  objectPath="ElementRegions/region/cb"
+  fieldName="temperature"
+  scale="300.15"/>
+  </FieldSpecifications>
+  </Problem>
+  )xml";
 // Sphinx end before input XML
 
 template< typename LAMBDA >

--- a/src/coreComponents/unitTests/linearAlgebraTests/testDofManager.cpp
+++ b/src/coreComponents/unitTests/linearAlgebraTests/testDofManager.cpp
@@ -37,25 +37,27 @@ using namespace geos::testing;
 using namespace geos::dataRepository;
 
 char const * xmlInput =
-  "<Problem>"
-  "  <Mesh>"
-  "    <InternalMesh name=\"mesh\""
-  "                  elementTypes=\"{C3D8}\""
-  "                  xCoords=\"{0, 1, 2, 3, 4}\""
-  "                  yCoords=\"{0, 1}\""
-  "                  zCoords=\"{0, 1}\""
-  "                  nx=\"{4, 4, 4, 4}\""
-  "                  ny=\"{4}\""
-  "                  nz=\"{5}\""
-  "                  cellBlockNames=\"{block1, block2, block3, block4}\"/>"
-  "  </Mesh>"
-  "  <ElementRegions>"
-  "    <CellElementRegion name=\"region1\" cellBlocks=\"{block1}\" materialList=\"{}\" />"
-  "    <CellElementRegion name=\"region2\" cellBlocks=\"{block2}\" materialList=\"{}\" />"
-  "    <CellElementRegion name=\"region3\" cellBlocks=\"{block3}\" materialList=\"{}\" />"
-  "    <CellElementRegion name=\"region4\" cellBlocks=\"{block4}\" materialList=\"{}\" />"
-  "  </ElementRegions>"
-  "</Problem>";
+  R"xml(
+  <Problem>
+    <Mesh>
+      <InternalMesh name="mesh"
+                    elementTypes="{C3D8}"
+                    xCoords="{0, 1, 2, 3, 4}"
+                    yCoords="{0, 1}"
+                    zCoords="{0, 1}"
+                    nx="{4, 4, 4, 4}"
+                    ny="{4}"
+                    nz="{5}"
+                    cellBlockNames="{block1, block2, block3, block4}"/>
+    </Mesh>
+    <ElementRegions>
+      <CellElementRegion name="region1" cellBlocks="{block1}" materialList="{}" />
+      <CellElementRegion name="region2" cellBlocks="{block2}" materialList="{}" />
+      <CellElementRegion name="region3" cellBlocks="{block3}" materialList="{}" />
+      <CellElementRegion name="region4" cellBlocks="{block4}" materialList="{}" />
+    </ElementRegions>
+  </Problem>
+  )xml";
 
 /**
  * @brief Base class for all DofManager test fixtures.

--- a/src/coreComponents/unitTests/linearAlgebraTests/testLAIHelperFunctions.cpp
+++ b/src/coreComponents/unitTests/linearAlgebraTests/testLAIHelperFunctions.cpp
@@ -32,22 +32,24 @@
 using namespace geos;
 
 char const * xmlInput =
-  "<Problem>"
-  "  <Mesh>"
-  "    <InternalMesh name=\"mesh1\""
-  "                  elementTypes=\"{C3D8}\""
-  "                  xCoords=\"{0, 1}\""
-  "                  yCoords=\"{0, 1}\""
-  "                  zCoords=\"{0, 1}\""
-  "                  nx=\"{6}\""
-  "                  ny=\"{9}\""
-  "                  nz=\"{5}\""
-  "                  cellBlockNames=\"{block1}\"/>"
-  "  </Mesh>"
-  "  <ElementRegions>"
-  "    <CellElementRegion name=\"region1\" cellBlocks=\"{block1}\" materialList=\"{dummy}\" />"
-  "  </ElementRegions>"
-  "</Problem>";
+  R"xml(
+  <Problem>
+    <Mesh>
+      <InternalMesh name="mesh1"
+                    elementTypes="{C3D8}"
+                    xCoords="{0, 1}"
+                    yCoords="{0, 1}"
+                    zCoords="{0, 1}"
+                    nx="{6}"
+                    ny="{9}"
+                    nz="{5}"
+                    cellBlockNames="{block1}"/>
+    </Mesh>
+    <ElementRegions>
+      <CellElementRegion name="region1" cellBlocks="{block1}" materialList="{dummy}"/>
+    </ElementRegions>
+  </Problem>
+  )xml";
 
 template< typename LAI >
 class LAIHelperFunctionsTest : public ::testing::Test

--- a/src/coreComponents/unitTests/wavePropagationTests/testWavePropagation.cpp
+++ b/src/coreComponents/unitTests/wavePropagationTests/testWavePropagation.cpp
@@ -35,120 +35,121 @@ CommandLineOptions g_commandLineOptions;
 // This unit test checks the interpolation done to extract seismic traces from a wavefield.
 // It computes a seismogram at a receiver co-located with the source and compares it to the surrounding receivers.
 char const * xmlInput =
-  "<?xml version=\"1.0\" ?>\n"
-  "<Problem>\n"
-  "  <Solvers>\n"
-  "    <AcousticSEM\n"
-  "      name=\"acousticSolver\"\n"
-  "      cflFactor=\"0.25\"\n"
-  "      discretization=\"FE1\"\n"
-  "      targetRegions=\"{ Region }\"\n"
-  "      sourceCoordinates=\"{ { 50, 50, 50 } }\"\n"
-  "      timeSourceFrequency=\"2\"\n"
-  "      receiverCoordinates=\"{ { 0.1, 0.1, 0.1 }, { 0.1, 0.1, 99.9 }, { 0.1, 99.9, 0.1 }, { 0.1, 99.9, 99.9 },\n"
-  "                              { 99.9, 0.1, 0.1 }, { 99.9, 0.1, 99.9 }, { 99.9, 99.9, 0.1 }, { 99.9, 99.9, 99.9 },\n"
-  "                              { 50, 50, 50 } }\"\n"
-  "      outputSeismoTrace=\"0\"\n"
-  "      dtSeismoTrace=\"0.1\"/>\n"
-  "  </Solvers>\n"
-  "  <Mesh>\n"
-  "    <InternalMesh\n"
-  "      name=\"mesh\"\n"
-  "      elementTypes=\"{ C3D8 }\"\n"
-  "      xCoords=\"{ 0, 100 }\"\n"
-  "      yCoords=\"{ 0, 100 }\"\n"
-  "      zCoords=\"{ 0, 100 }\"\n"
-  "      nx=\"{ 1 }\"\n"
-  "      ny=\"{ 1 }\"\n"
-  "      nz=\"{ 1 }\"\n"
-  "      cellBlockNames=\"{ cb }\"/>\n"
-  "  </Mesh>\n"
-  "  <Events\n"
-  "    maxTime=\"1\">\n"
-  "    <PeriodicEvent\n"
-  "      name=\"solverApplications\"\n"
-  "      forceDt=\"0.1\"\n"
-  "      targetExactStartStop=\"0\"\n"
-  "      targetExactTimestep=\"0\"\n"
-  "      target=\"/Solvers/acousticSolver\"/>\n"
-  "    <PeriodicEvent\n"
-  "      name=\"waveFieldNp1Collection\"\n"
-  "      timeFrequency=\"0.1\"\n"
-  "      targetExactTimestep=\"0\"\n"
-  "      target=\"/Tasks/waveFieldNp1Collection\" />\n"
-  "    <PeriodicEvent\n"
-  "      name=\"waveFieldNCollection\"\n"
-  "      timeFrequency=\"0.1\"\n"
-  "      targetExactTimestep=\"0\"\n"
-  "      target=\"/Tasks/waveFieldNCollection\" />\n"
-  "    <PeriodicEvent\n"
-  "      name=\"waveFieldNm1Collection\"\n"
-  "      timeFrequency=\"0.1\"\n"
-  "      targetExactTimestep=\"0\"\n"
-  "      target=\"/Tasks/waveFieldNm1Collection\" />\n"
-  "  </Events>\n"
-  "  <NumericalMethods>\n"
-  "    <FiniteElements>\n"
-  "      <FiniteElementSpace\n"
-  "        name=\"FE1\"\n"
-  "        order=\"1\"\n"
-  "        formulation=\"SEM\"/>\n"
-  "    </FiniteElements>\n"
-  "  </NumericalMethods>\n"
-  "  <ElementRegions>\n"
-  "    <CellElementRegion\n"
-  "      name=\"Region\"\n"
-  "      cellBlocks=\"{ cb }\"\n"
-  "      materialList=\"{ nullModel }\"/>\n"
-  "  </ElementRegions>\n"
-  "  <Constitutive>\n"
-  "    <NullModel\n"
-  "      name=\"nullModel\"/>\n"
-  "  </Constitutive>\n"
-  "  <FieldSpecifications>\n"
-  "    <FieldSpecification\n"
-  "      name=\"initialPressureN\"\n"
-  "      initialCondition=\"1\"\n"
-  "      setNames=\"{ all }\"\n"
-  "      objectPath=\"nodeManager\"\n"
-  "      fieldName=\"pressure_n\"\n"
-  "      scale=\"0.0\"/>\n"
-  "    <FieldSpecification\n"
-  "      name=\"initialPressureNm1\"\n"
-  "      initialCondition=\"1\"\n"
-  "      setNames=\"{ all }\"\n"
-  "      objectPath=\"nodeManager\"\n"
-  "      fieldName=\"pressure_nm1\"\n"
-  "      scale=\"0.0\"/>\n"
-  "    <FieldSpecification\n"
-  "      name=\"cellVelocity\"\n"
-  "      initialCondition=\"1\"\n"
-  "      objectPath=\"ElementRegions/Region/cb\"\n"
-  "      fieldName=\"mediumVelocity\"\n"
-  "      scale=\"1500\"\n"
-  "      setNames=\"{ all }\"/>\n"
-  "    <FieldSpecification\n"
-  "      name=\"zposFreeSurface\"\n"
-  "      objectPath=\"faceManager\"\n"
-  "      fieldName=\"FreeSurface\"\n"
-  "      scale=\"0.0\"\n"
-  "      setNames=\"{ zpos }\"/>\n"
-  "  </FieldSpecifications>\n"
-  "  <Tasks>\n"
-  "    <PackCollection\n"
-  "      name=\"waveFieldNp1Collection\"\n"
-  "      objectPath=\"nodeManager\"\n"
-  "      fieldName=\"pressure_np1\"/>\n"
-  "    <PackCollection\n"
-  "      name=\"waveFieldNCollection\"\n"
-  "      objectPath=\"nodeManager\"\n"
-  "      fieldName=\"pressure_n\"/>\n"
-  "    <PackCollection\n"
-  "      name=\"waveFieldNm1Collection\"\n"
-  "      objectPath=\"nodeManager\"\n"
-  "      fieldName=\"pressure_nm1\"/>\n"
-  "  </Tasks>\n"
-  "</Problem>\n";
+  R"xml(
+  <Problem>
+    <Solvers>
+      <AcousticSEM
+        name="acousticSolver"
+        cflFactor="0.25"
+        discretization="FE1"
+        targetRegions="{ Region }"
+        sourceCoordinates="{ { 50, 50, 50 } }"
+        timeSourceFrequency="2"
+        receiverCoordinates="{ { 0.1, 0.1, 0.1 }, { 0.1, 0.1, 99.9 }, { 0.1, 99.9, 0.1 }, { 0.1, 99.9, 99.9 },
+                                { 99.9, 0.1, 0.1 }, { 99.9, 0.1, 99.9 }, { 99.9, 99.9, 0.1 }, { 99.9, 99.9, 99.9 },
+                                { 50, 50, 50 } }"
+        outputSeismoTrace="0"
+        dtSeismoTrace="0.1"/>
+    </Solvers>
+    <Mesh>
+      <InternalMesh
+        name="mesh"
+        elementTypes="{ C3D8 }"
+        xCoords="{ 0, 100 }"
+        yCoords="{ 0, 100 }"
+        zCoords="{ 0, 100 }"
+        nx="{ 1 }"
+        ny="{ 1 }"
+        nz="{ 1 }"
+        cellBlockNames="{ cb }"/>
+    </Mesh>
+    <Events
+      maxTime="1">
+      <PeriodicEvent
+        name="solverApplications"
+        forceDt="0.1"
+        targetExactStartStop="0"
+        targetExactTimestep="0"
+        target="/Solvers/acousticSolver"/>
+      <PeriodicEvent
+        name="waveFieldNp1Collection"
+        timeFrequency="0.1"
+        targetExactTimestep="0"
+        target="/Tasks/waveFieldNp1Collection" />
+      <PeriodicEvent
+        name="waveFieldNCollection"
+        timeFrequency="0.1"
+        targetExactTimestep="0"
+        target="/Tasks/waveFieldNCollection" />
+      <PeriodicEvent
+        name="waveFieldNm1Collection"
+        timeFrequency="0.1"
+        targetExactTimestep="0"
+        target="/Tasks/waveFieldNm1Collection" />
+    </Events>
+    <NumericalMethods>
+      <FiniteElements>
+        <FiniteElementSpace
+          name="FE1"
+          order="1"
+          formulation="SEM"/>
+      </FiniteElements>
+    </NumericalMethods>
+    <ElementRegions>
+      <CellElementRegion
+        name="Region"
+        cellBlocks="{ cb }"
+        materialList="{ nullModel }"/>
+    </ElementRegions>
+    <Constitutive>
+      <NullModel
+        name="nullModel"/>
+    </Constitutive>
+    <FieldSpecifications>
+      <FieldSpecification
+        name="initialPressureN"
+        initialCondition="1"
+        setNames="{ all }"
+        objectPath="nodeManager"
+        fieldName="pressure_n"
+        scale="0.0"/>
+      <FieldSpecification
+        name="initialPressureNm1"
+        initialCondition="1"
+        setNames="{ all }"
+        objectPath="nodeManager"
+        fieldName="pressure_nm1"
+        scale="0.0"/>
+      <FieldSpecification
+        name="cellVelocity"
+        initialCondition="1"
+        objectPath="ElementRegions/Region/cb"
+        fieldName="mediumVelocity"
+        scale="1500"
+        setNames="{ all }"/>
+      <FieldSpecification
+        name="zposFreeSurface"
+        objectPath="faceManager"
+        fieldName="FreeSurface"
+        scale="0.0"
+        setNames="{ zpos }"/>
+    </FieldSpecifications>
+    <Tasks>
+      <PackCollection
+        name="waveFieldNp1Collection"
+        objectPath="nodeManager"
+        fieldName="pressure_np1"/>
+      <PackCollection
+        name="waveFieldNCollection"
+        objectPath="nodeManager"
+        fieldName="pressure_n"/>
+      <PackCollection
+        name="waveFieldNm1Collection"
+        objectPath="nodeManager"
+        fieldName="pressure_nm1"/>
+    </Tasks>
+  </Problem>
+  )xml";
 
 class AcousticWaveEquationSEMTest : public ::testing::Test
 {

--- a/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAcousticFirstOrder.cpp
+++ b/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAcousticFirstOrder.cpp
@@ -36,118 +36,119 @@ CommandLineOptions g_commandLineOptions;
 // This unit test checks the interpolation done to extract seismic traces from a wavefield.
 // It computes a seismogram at a receiver co-located with the source and compares it to the surrounding receivers.
 char const * xmlInput =
-  "<?xml version=\"1.0\" ?>\n"
-  "<Problem>\n"
-  "  <Solvers>\n"
-  "    <AcousticFirstOrderSEM\n"
-  "      name=\"acousticFirstOrderSolver\"\n"
-  "      cflFactor=\"0.25\"\n"
-  "      discretization=\"FE1\"\n"
-  "      targetRegions=\"{ Region }\"\n"
-  "      sourceCoordinates=\"{ { 30, 30, 30 } }\"\n"
-  "      timeSourceFrequency=\"2\"\n"
-  "      receiverCoordinates=\"{ { 0.1, 0.1, 0.1 }, { 0.1, 0.1, 99.9 }, { 0.1, 99.9, 0.1 }, { 0.1, 99.9, 99.9 },\n"
-  "                              { 99.9, 0.1, 0.1 }, { 99.9, 0.1, 99.9 }, { 99.9, 99.9, 0.1 }, { 99.9, 99.9, 99.9 },\n"
-  "                              { 50, 50, 50 } }\"\n"
-  "      outputSeismoTrace=\"0\"\n"
-  "      dtSeismoTrace=\"0.05\"\n"
-  "      rickerOrder=\"1\"/>\n"
-  "  </Solvers>\n"
-  "  <Mesh>\n"
-  "    <InternalMesh\n"
-  "      name=\"mesh\"\n"
-  "      elementTypes=\"{ C3D8 }\"\n"
-  "      xCoords=\"{ 0, 100 }\"\n"
-  "      yCoords=\"{ 0, 100 }\"\n"
-  "      zCoords=\"{ 0, 100 }\"\n"
-  "      nx=\"{ 1 }\"\n"
-  "      ny=\"{ 1 }\"\n"
-  "      nz=\"{ 1 }\"\n"
-  "      cellBlockNames=\"{ cb }\"/>\n"
-  "  </Mesh>\n"
-  "  <Events\n"
-  "    maxTime=\"1\">\n"
-  "    <PeriodicEvent\n"
-  "      name=\"solverApplications\"\n"
-  "      forceDt=\"0.05\"\n"
-  "      targetExactStartStop=\"0\"\n"
-  "      targetExactTimestep=\"0\"\n"
-  "      target=\"/Solvers/acousticFirstOrderSolver\"/>\n"
-  "    <PeriodicEvent\n"
-  "      name=\"waveFieldUxCollection\"\n"
-  "      timeFrequency=\"0.05\"\n"
-  "      targetExactTimestep=\"0\"\n"
-  "      target=\"/Tasks/waveFieldUxCollection\" />\n"
-  "    <PeriodicEvent\n"
-  "      name=\"waveFieldUyCollection\"\n"
-  "      timeFrequency=\"0.05\"\n"
-  "      targetExactTimestep=\"0\"\n"
-  "      target=\"/Tasks/waveFieldUyCollection\" />\n"
-  "    <PeriodicEvent\n"
-  "      name=\"waveFieldUzCollection\"\n"
-  "      timeFrequency=\"0.05\"\n"
-  "      targetExactTimestep=\"0\"\n"
-  "      target=\"/Tasks/waveFieldUzCollection\" />\n"
-  "    <PeriodicEvent\n"
-  "      name=\"waveFieldPressureCollection\"\n"
-  "      timeFrequency=\"0.05\"\n"
-  "      targetExactTimestep=\"0\"\n"
-  "      target=\"/Tasks/waveFieldPressureCollection\" />\n"
-  "  </Events>\n"
-  "  <NumericalMethods>\n"
-  "    <FiniteElements>\n"
-  "      <FiniteElementSpace\n"
-  "        name=\"FE1\"\n"
-  "        order=\"1\"\n"
-  "        formulation=\"SEM\" />\n"
-  "    </FiniteElements>\n"
-  "  </NumericalMethods>\n"
-  "  <ElementRegions>\n"
-  "    <CellElementRegion\n"
-  "      name=\"Region\"\n"
-  "      cellBlocks=\"{ cb }\"\n"
-  "      materialList=\"{ nullModel }\"/>\n"
-  "  </ElementRegions>\n"
-  "  <Constitutive>\n"
-  "    <NullModel\n"
-  "      name=\"nullModel\"/>\n"
-  "  </Constitutive>\n"
-  "  <FieldSpecifications>\n"
-  "    <FieldSpecification\n"
-  "      name=\"cellVelocity\"\n"
-  "      initialCondition=\"1\"\n"
-  "      objectPath=\"ElementRegions/Region/cb\"\n"
-  "      fieldName=\"mediumVelocity\"\n"
-  "      scale=\"1500\"\n"
-  "      setNames=\"{ all }\"/>\n"
-  "    <FieldSpecification\n"
-  "      name=\"cellDensity\"\n"
-  "      initialCondition=\"1\"\n"
-  "      objectPath=\"ElementRegions/Region/cb\"\n"
-  "      fieldName=\"mediumDensity\"\n"
-  "      scale=\"1\"\n"
-  "      setNames=\"{ all }\"/>\n"
-  "  </FieldSpecifications>\n"
-  "  <Tasks>\n"
-  "    <PackCollection\n"
-  "      name=\"waveFieldPressureCollection\"\n"
-  "      objectPath=\"nodeManager\"\n"
-  "      fieldName=\"pressure_np1\"/>\n"
-  "    <PackCollection\n"
-  "      name=\"waveFieldUxCollection\"\n"
-  "      objectPath=\"ElementRegions/Region/cb\"\n"
-  "      fieldName=\"velocity_x\"/>\n"
-  "    <PackCollection\n"
-  "      name=\"waveFieldUyCollection\"\n"
-  "      objectPath=\"ElementRegions/Region/cb\"\n"
-  "      fieldName=\"velocity_y\"/>\n"
-  "    <PackCollection\n"
-  "      name=\"waveFieldUzCollection\"\n"
-  "      objectPath=\"ElementRegions/Region/cb\"\n"
-  "      fieldName=\"velocity_z\"/>\n"
-
-  "  </Tasks>\n"
-  "</Problem>\n";
+  R"xml(
+  <?xml version="1.0" ?>
+  <Problem>
+    <Solvers>
+      <AcousticFirstOrderSEM
+        name="acousticFirstOrderSolver"
+        cflFactor="0.25"
+        discretization="FE1"
+        targetRegions="{ Region }"
+        sourceCoordinates="{ { 30, 30, 30 } }"
+        timeSourceFrequency="2"
+        receiverCoordinates="{ { 0.1, 0.1, 0.1 }, { 0.1, 0.1, 99.9 }, { 0.1, 99.9, 0.1 }, { 0.1, 99.9, 99.9 },
+                                { 99.9, 0.1, 0.1 }, { 99.9, 0.1, 99.9 }, { 99.9, 99.9, 0.1 }, { 99.9, 99.9, 99.9 },
+                                { 50, 50, 50 } }"
+        outputSeismoTrace="0"
+        dtSeismoTrace="0.05"
+        rickerOrder="1"/>
+    </Solvers>
+    <Mesh>
+      <InternalMesh
+        name="mesh"
+        elementTypes="{ C3D8 }"
+        xCoords="{ 0, 100 }"
+        yCoords="{ 0, 100 }"
+        zCoords="{ 0, 100 }"
+        nx="{ 1 }"
+        ny="{ 1 }"
+        nz="{ 1 }"
+        cellBlockNames="{ cb }"/>
+    </Mesh>
+    <Events
+      maxTime="1">
+      <PeriodicEvent
+        name="solverApplications"
+        forceDt="0.05"
+        targetExactStartStop="0"
+        targetExactTimestep="0"
+        target="/Solvers/acousticFirstOrderSolver"/>
+      <PeriodicEvent
+        name="waveFieldUxCollection"
+        timeFrequency="0.05"
+        targetExactTimestep="0"
+        target="/Tasks/waveFieldUxCollection" />
+      <PeriodicEvent
+        name="waveFieldUyCollection"
+        timeFrequency="0.05"
+        targetExactTimestep="0"
+        target="/Tasks/waveFieldUyCollection" />
+      <PeriodicEvent
+        name="waveFieldUzCollection"
+        timeFrequency="0.05"
+        targetExactTimestep="0"
+        target="/Tasks/waveFieldUzCollection" />
+      <PeriodicEvent
+        name="waveFieldPressureCollection"
+        timeFrequency="0.05"
+        targetExactTimestep="0"
+        target="/Tasks/waveFieldPressureCollection" />
+    </Events>
+    <NumericalMethods>
+      <FiniteElements>
+        <FiniteElementSpace
+          name="FE1"
+          order="1"
+          formulation="SEM" />
+      </FiniteElements>
+    </NumericalMethods>
+    <ElementRegions>
+      <CellElementRegion
+        name="Region"
+        cellBlocks="{ cb }"
+        materialList="{ nullModel }"/>
+    </ElementRegions>
+    <Constitutive>
+      <NullModel
+        name="nullModel"/>
+    </Constitutive>
+    <FieldSpecifications>
+      <FieldSpecification
+        name="cellVelocity"
+        initialCondition="1"
+        objectPath="ElementRegions/Region/cb"
+        fieldName="mediumVelocity"
+        scale="1500"
+        setNames="{ all }"/>
+      <FieldSpecification
+        name="cellDensity"
+        initialCondition="1"
+        objectPath="ElementRegions/Region/cb"
+        fieldName="mediumDensity"
+        scale="1"
+        setNames="{ all }"/>
+    </FieldSpecifications>
+    <Tasks>
+      <PackCollection
+        name="waveFieldPressureCollection"
+        objectPath="nodeManager"
+        fieldName="pressure_np1"/>
+      <PackCollection
+        name="waveFieldUxCollection"
+        objectPath="ElementRegions/Region/cb"
+        fieldName="velocity_x"/>
+      <PackCollection
+        name="waveFieldUyCollection"
+        objectPath="ElementRegions/Region/cb"
+        fieldName="velocity_y"/>
+      <PackCollection
+        name="waveFieldUzCollection"
+        objectPath="ElementRegions/Region/cb"
+        fieldName="velocity_z"/>
+    </Tasks>
+  </Problem>
+  )xml";
 
 class AcousticFirstOrderWaveEquationSEMTest : public ::testing::Test
 {

--- a/src/coreComponents/unitTests/wellsTests/testReservoirCompositionalMultiphaseMSWells.cpp
+++ b/src/coreComponents/unitTests/wellsTests/testReservoirCompositionalMultiphaseMSWells.cpp
@@ -37,163 +37,164 @@ using namespace geos::testing;
 CommandLineOptions g_commandLineOptions;
 
 char const * xmlInput =
-  "<Problem>\n"
-  "  <Solvers gravityVector=\"{ 0.0, 0.0, -9.81 }\">\n"
-  "    <CompositionalMultiphaseReservoir name=\"reservoirSystem\"\n"
-  "               flowSolverName=\"compositionalMultiphaseFlow\"\n"
-  "               wellSolverName=\"compositionalMultiphaseWell\"\n"
-  "               logLevel=\"1\"\n"
-  "               targetRegions=\"{Region1,wellRegion1,wellRegion2}\">\n"
-  "      <NonlinearSolverParameters newtonMaxIter=\"40\"/>\n"
-  "      <LinearSolverParameters solverType=\"direct\"\n"
-  "                              logLevel=\"2\"/>\n"
-  "    </CompositionalMultiphaseReservoir>\n"
-  "    <CompositionalMultiphaseFVM name=\"compositionalMultiphaseFlow\"\n"
-  "                                logLevel=\"1\"\n"
-  "                                discretization=\"fluidTPFA\"\n"
-  "                                targetRegions=\"{Region1}\"\n"
-  "                                temperature=\"297.15\"\n"
-  "                                useMass=\"0\">\n"
-  "    </CompositionalMultiphaseFVM>\n"
-  "    <CompositionalMultiphaseWell name=\"compositionalMultiphaseWell\"\n"
-  "                                 logLevel=\"1\"\n"
-  "                                 targetRegions=\"{wellRegion1,wellRegion2}\"\n"
-  "                                 useMass=\"0\">\n"
-  "        <WellControls name=\"wellControls1\"\n"
-  "                      type=\"producer\"\n"
-  "                      referenceElevation=\"1.25\"\n"
-  "                      control=\"BHP\"\n"
-  "                      targetBHP=\"2e6\"\n"
-  "                      targetPhaseRate=\"1\"\n"
-  "                      targetPhaseName=\"oil\"/>\n"
-  "        <WellControls name=\"wellControls2\"\n"
-  "                      type=\"injector\"\n"
-  "                      referenceElevation=\"1.25\"\n"
-  "                      control=\"totalVolRate\" \n"
-  "                      targetBHP=\"6e7\"\n"
-  "                      targetTotalRate=\"1e-5\" \n"
-  "                      injectionTemperature=\"297.15\"\n"
-  "                      injectionStream=\"{0.1, 0.1, 0.1, 0.7}\"/>\n"
-  "    </CompositionalMultiphaseWell>\n"
-  "  </Solvers>\n"
-  "  <Mesh>\n"
-  "    <InternalMesh name=\"mesh1\"\n"
-  "                  elementTypes=\"{C3D8}\" \n"
-  "                  xCoords=\"{0, 5}\"\n"
-  "                  yCoords=\"{0, 1}\"\n"
-  "                  zCoords=\"{0, 1}\"\n"
-  "                  nx=\"{3}\"\n"
-  "                  ny=\"{1}\"\n"
-  "                  nz=\"{1}\"\n"
-  "                  cellBlockNames=\"{cb1}\"/>\n"
-  "    <InternalWell name=\"well_producer1\"\n"
-  "                  wellRegionName=\"wellRegion1\"\n"
-  "                  wellControlsName=\"wellControls1\"\n"
-  "                  meshName=\"mesh1\"\n"
-  "                  polylineNodeCoords=\"{ {4.5, 0,  2  },\n"
-  "                                         {4.5, 0,  0.5} }\"\n"
-  "                  polylineSegmentConn=\"{ {0, 1} }\"\n"
-  "                  radius=\"0.1\"\n"
-  "                  numElementsPerSegment=\"1\">\n"
-  "        <Perforation name=\"producer1_perf1\"\n"
-  "                     distanceFromHead=\"1.45\"/> \n"
-  "    </InternalWell>\n"
-  "    <InternalWell name=\"well_injector1\"\n"
-  "                  wellRegionName=\"wellRegion2\"\n"
-  "                  wellControlsName=\"wellControls2\"\n"
-  "                  meshName=\"mesh1\"\n"
-  "                  polylineNodeCoords=\"{ {0.5, 0, 2  },\n"
-  "                                         {0.5, 0, 0.5} }\"\n"
-  "                  polylineSegmentConn=\"{ {0, 1} }\"\n"
-  "                  radius=\"0.1\"\n"
-  "                  numElementsPerSegment=\"1\">\n"
-  "        <Perforation name=\"injector1_perf1\"\n"
-  "                     distanceFromHead=\"1.45\"/> \n"
-  "    </InternalWell>\n"
-  "  </Mesh>\n"
-  "  <NumericalMethods>\n"
-  "    <FiniteVolume>\n"
-  "      <TwoPointFluxApproximation name=\"fluidTPFA\"/>\n"
-  "    </FiniteVolume>\n"
-  "  </NumericalMethods>\n"
-  "  <ElementRegions>\n"
-  "    <CellElementRegion name=\"Region1\"\n"
-  "                       cellBlocks=\"{cb1}\"\n"
-  "                       materialList=\"{fluid1, rock, relperm}\"/>\n"
-  "    <WellElementRegion name=\"wellRegion1\"\n"
-  "                       materialList=\"{fluid1, relperm}\"/> \n"
-  "    <WellElementRegion name=\"wellRegion2\"\n"
-  "                       materialList=\"{fluid1, relperm}\"/> \n"
-  "  </ElementRegions>\n"
-  "  <Constitutive>\n"
-  "    <CompositionalMultiphaseFluid name=\"fluid1\"\n"
-  "                                  phaseNames=\"{oil, gas}\"\n"
-  "                                  equationsOfState=\"{PR, PR}\"\n"
-  "                                  componentNames=\"{N2, C10, C20, H2O}\"\n"
-  "                                  componentCriticalPressure=\"{34e5, 25.3e5, 14.6e5, 220.5e5}\"\n"
-  "                                  componentCriticalTemperature=\"{126.2, 622.0, 782.0, 647.0}\"\n"
-  "                                  componentAcentricFactor=\"{0.04, 0.443, 0.816, 0.344}\"\n"
-  "                                  componentMolarWeight=\"{28e-3, 134e-3, 275e-3, 18e-3}\"\n"
-  "                                  componentVolumeShift=\"{0, 0, 0, 0}\"\n"
-  "                                  componentBinaryCoeff=\"{ {0, 0, 0, 0},\n"
-  "                                                          {0, 0, 0, 0},\n"
-  "                                                          {0, 0, 0, 0},\n"
-  "                                                          {0, 0, 0, 0} }\"/>\n"
-  "    <CompressibleSolidConstantPermeability name=\"rock\"\n"
-  "        solidModelName=\"nullSolid\"\n"
-  "        porosityModelName=\"rockPorosity\"\n"
-  "        permeabilityModelName=\"rockPerm\"/>\n"
-  "   <NullModel name=\"nullSolid\"/> \n"
-  "   <PressurePorosity name=\"rockPorosity\"\n"
-  "                     defaultReferencePorosity=\"0.05\"\n"
-  "                     referencePressure = \"0.0\"\n"
-  "                     compressibility=\"1.0e-9\"/>\n"
-  "  <ConstantPermeability name=\"rockPerm\"\n"
-  "                        permeabilityComponents=\"{2.0e-16, 2.0e-16, 2.0e-16}\"/> \n"
-  "    <BrooksCoreyRelativePermeability name=\"relperm\"\n"
-  "                                     phaseNames=\"{oil, gas}\"\n"
-  "                                     phaseMinVolumeFraction=\"{0.1, 0.15}\"\n"
-  "                                     phaseRelPermExponent=\"{2.0, 2.0}\"\n"
-  "                                     phaseRelPermMaxValue=\"{0.8, 0.9}\"/>\n"
-  "  </Constitutive>\n"
-  "  <FieldSpecifications>\n"
-  "    <FieldSpecification name=\"initialPressure\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/Region1/cb1\"\n"
-  "               fieldName=\"pressure\"\n"
-  "               scale=\"5e6\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_N2\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/Region1/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"0\"\n"
-  "               scale=\"0.099\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_C10\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/Region1/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"1\"\n"
-  "               scale=\"0.3\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_C20\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/Region1/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"2\"\n"
-  "               scale=\"0.6\"/>\n"
-  "    <FieldSpecification name=\"initialComposition_H20\"\n"
-  "               initialCondition=\"1\"\n"
-  "               setNames=\"{all}\"\n"
-  "               objectPath=\"ElementRegions/Region1/cb1\"\n"
-  "               fieldName=\"globalCompFraction\"\n"
-  "               component=\"3\"\n"
-  "               scale=\"0.001\"/>\n"
-  "  </FieldSpecifications>\n"
-  "</Problem>";
-
+  R"xml(
+  <Problem>
+    <Solvers gravityVector="{ 0.0, 0.0, -9.81 }">
+      <CompositionalMultiphaseReservoir name="reservoirSystem"
+                 flowSolverName="compositionalMultiphaseFlow"
+                 wellSolverName="compositionalMultiphaseWell"
+                 logLevel="1"
+                 targetRegions="{Region1,wellRegion1,wellRegion2}">
+        <NonlinearSolverParameters newtonMaxIter="40"/>
+        <LinearSolverParameters solverType="direct"
+                                logLevel="2"/>
+      </CompositionalMultiphaseReservoir>
+      <CompositionalMultiphaseFVM name="compositionalMultiphaseFlow"
+                                  logLevel="1"
+                                  discretization="fluidTPFA"
+                                  targetRegions="{Region1}"
+                                  temperature="297.15"
+                                  useMass="0">
+      </CompositionalMultiphaseFVM>
+      <CompositionalMultiphaseWell name="compositionalMultiphaseWell"
+                                   logLevel="1"
+                                   targetRegions="{wellRegion1,wellRegion2}"
+                                   useMass="0">
+          <WellControls name="wellControls1"
+                        type="producer"
+                        referenceElevation="1.25"
+                        control="BHP"
+                        targetBHP="2e6"
+                        targetPhaseRate="1"
+                        targetPhaseName="oil"/>
+          <WellControls name="wellControls2"
+                        type="injector"
+                        referenceElevation="1.25"
+                        control="totalVolRate"
+                        targetBHP="6e7"
+                        targetTotalRate="1e-5"
+                        injectionTemperature="297.15"
+                        injectionStream="{0.1, 0.1, 0.1, 0.7}"/>
+      </CompositionalMultiphaseWell>
+    </Solvers>
+    <Mesh>
+      <InternalMesh name="mesh1"
+                    elementTypes="{C3D8}"
+                    xCoords="{0, 5}"
+                    yCoords="{0, 1}"
+                    zCoords="{0, 1}"
+                    nx="{3}"
+                    ny="{1}"
+                    nz="{1}"
+                    cellBlockNames="{cb1}"/>
+      <InternalWell name="well_producer1"
+                    wellRegionName="wellRegion1"
+                    wellControlsName="wellControls1"
+                    meshName="mesh1"
+                    polylineNodeCoords="{ {4.5, 0,  2  },
+                                           {4.5, 0,  0.5} }"
+                    polylineSegmentConn="{ {0, 1} }"
+                    radius="0.1"
+                    numElementsPerSegment="1">
+          <Perforation name="producer1_perf1"
+                       distanceFromHead="1.45"/>
+      </InternalWell>
+      <InternalWell name="well_injector1"
+                    wellRegionName="wellRegion2"
+                    wellControlsName="wellControls2"
+                    meshName="mesh1"
+                    polylineNodeCoords="{ {0.5, 0, 2  },
+                                           {0.5, 0, 0.5} }"
+                    polylineSegmentConn="{ {0, 1} }"
+                    radius="0.1"
+                    numElementsPerSegment="1">
+          <Perforation name="injector1_perf1"
+                       distanceFromHead="1.45"/>
+      </InternalWell>
+    </Mesh>
+    <NumericalMethods>
+      <FiniteVolume>
+        <TwoPointFluxApproximation name="fluidTPFA"/>
+      </FiniteVolume>
+    </NumericalMethods>
+    <ElementRegions>
+      <CellElementRegion name="Region1"
+                         cellBlocks="{cb1}"
+                         materialList="{fluid1, rock, relperm}"/>
+      <WellElementRegion name="wellRegion1"
+                         materialList="{fluid1, relperm}"/>
+      <WellElementRegion name="wellRegion2"
+                         materialList="{fluid1, relperm}"/>
+    </ElementRegions>
+    <Constitutive>
+      <CompositionalMultiphaseFluid name="fluid1"
+                                    phaseNames="{oil, gas}"
+                                    equationsOfState="{PR, PR}"
+                                    componentNames="{N2, C10, C20, H2O}"
+                                    componentCriticalPressure="{34e5, 25.3e5, 14.6e5, 220.5e5}"
+                                    componentCriticalTemperature="{126.2, 622.0, 782.0, 647.0}"
+                                    componentAcentricFactor="{0.04, 0.443, 0.816, 0.344}"
+                                    componentMolarWeight="{28e-3, 134e-3, 275e-3, 18e-3}"
+                                    componentVolumeShift="{0, 0, 0, 0}"
+                                    componentBinaryCoeff="{ {0, 0, 0, 0},
+                                                            {0, 0, 0, 0},
+                                                            {0, 0, 0, 0},
+                                                            {0, 0, 0, 0} }"/>
+      <CompressibleSolidConstantPermeability name="rock"
+          solidModelName="nullSolid"
+          porosityModelName="rockPorosity"
+          permeabilityModelName="rockPerm"/>
+     <NullModel name="nullSolid"/>
+     <PressurePorosity name="rockPorosity"
+                       defaultReferencePorosity="0.05"
+                       referencePressure = "0.0"
+                       compressibility="1.0e-9"/>
+    <ConstantPermeability name="rockPerm"
+                          permeabilityComponents="{2.0e-16, 2.0e-16, 2.0e-16}"/>
+      <BrooksCoreyRelativePermeability name="relperm"
+                                       phaseNames="{oil, gas}"
+                                       phaseMinVolumeFraction="{0.1, 0.15}"
+                                       phaseRelPermExponent="{2.0, 2.0}"
+                                       phaseRelPermMaxValue="{0.8, 0.9}"/>
+    </Constitutive>
+    <FieldSpecifications>
+      <FieldSpecification name="initialPressure"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/Region1/cb1"
+                 fieldName="pressure"
+                 scale="5e6"/>
+      <FieldSpecification name="initialComposition_N2"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/Region1/cb1"
+                 fieldName="globalCompFraction"
+                 component="0"
+                 scale="0.099"/>
+      <FieldSpecification name="initialComposition_C10"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/Region1/cb1"
+                 fieldName="globalCompFraction"
+                 component="1"
+                 scale="0.3"/>
+      <FieldSpecification name="initialComposition_C20"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/Region1/cb1"
+                 fieldName="globalCompFraction"
+                 component="2"
+                 scale="0.6"/>
+      <FieldSpecification name="initialComposition_H20"
+                 initialCondition="1"
+                 setNames="{all}"
+                 objectPath="ElementRegions/Region1/cb1"
+                 fieldName="globalCompFraction"
+                 component="3"
+                 scale="0.001"/>
+    </FieldSpecifications>
+  </Problem>
+  )xml";
 
 template< typename LAMBDA >
 void testNumericalJacobian( CompositionalMultiphaseReservoirAndWells< CompositionalMultiphaseBase > & solver,

--- a/src/coreComponents/unitTests/wellsTests/testReservoirSinglePhaseMSWells.cpp
+++ b/src/coreComponents/unitTests/wellsTests/testReservoirSinglePhaseMSWells.cpp
@@ -38,118 +38,120 @@ using namespace geos::testing;
 CommandLineOptions g_commandLineOptions;
 
 char const * xmlInput =
-  "<Problem>\n"
-  "  <Solvers gravityVector=\"{ 0.0, 0.0, -9.81 }\">\n"
-  "    <SinglePhaseReservoir name=\"reservoirSystem\"\n"
-  "               flowSolverName=\"singlePhaseFlow\"\n"
-  "               wellSolverName=\"singlePhaseWell\"\n"
-  "               logLevel=\"1\"\n"
-  "               targetRegions=\"{Region1,wellRegion1,wellRegion2}\">\n"
-  "      <NonlinearSolverParameters newtonMaxIter=\"40\"/>\n"
-  "      <LinearSolverParameters solverType=\"direct\"\n"
-  "                              logLevel=\"2\"/>\n"
-  "    </SinglePhaseReservoir>\n"
-  "    <SinglePhaseFVM name=\"singlePhaseFlow\"\n"
-  "                             logLevel=\"1\"\n"
-  "                             discretization=\"singlePhaseTPFA\"\n"
-  "                             targetRegions=\"{Region1}\">\n"
-  "    </SinglePhaseFVM>\n"
-  "    <SinglePhaseWell name=\"singlePhaseWell\"\n"
-  "                     logLevel=\"1\"\n"
-  "                     targetRegions=\"{wellRegion1,wellRegion2}\">\n"
-  "        <WellControls name=\"wellControls1\"\n"
-  "                      type=\"producer\"\n"
-  "                      referenceElevation=\"2\"\n"
-  "                      control=\"BHP\"\n"
-  "                      targetBHP=\"5e5\"\n"
-  "                      targetTotalRate=\"1e-3\"/>\n"
-  "        <WellControls name=\"wellControls2\"\n"
-  "                      type=\"injector\"\n"
-  "                      referenceElevation=\"2\"\n"
-  "                      control=\"totalVolRate\" \n"
-  "                      targetBHP=\"2e7\"\n"
-  "                      targetTotalRate=\"1e-4\"/>\n"
-  "    </SinglePhaseWell>\n"
-  "  </Solvers>\n"
-  "  <Mesh>\n"
-  "    <InternalMesh name=\"mesh1\"\n"
-  "                  elementTypes=\"{C3D8}\" \n"
-  "                  xCoords=\"{0, 5}\"\n"
-  "                  yCoords=\"{0, 1}\"\n"
-  "                  zCoords=\"{0, 1}\"\n"
-  "                  nx=\"{3}\"\n"
-  "                  ny=\"{1}\"\n"
-  "                  nz=\"{1}\"\n"
-  "                  cellBlockNames=\"{cb1}\"/>\n"
-  "    <InternalWell name=\"well_producer1\"\n"
-  "                  wellRegionName=\"wellRegion1\"\n"
-  "                  wellControlsName=\"wellControls1\"\n"
-  "                  meshName=\"mesh1\"\n"
-  "                  polylineNodeCoords=\"{ {4.5, 0,  2  },\n"
-  "                                         {4.5, 0,  0.5} }\"\n"
-  "                  polylineSegmentConn=\"{ {0, 1} }\"\n"
-  "                  radius=\"0.1\"\n"
-  "                  numElementsPerSegment=\"1\">\n"
-  "        <Perforation name=\"producer1_perf1\"\n"
-  "                     distanceFromHead=\"1.45\"/> \n"
-  "    </InternalWell> \n"
-  "    <InternalWell name=\"well_injector1\"\n"
-  "                  wellRegionName=\"wellRegion2\"\n"
-  "                  wellControlsName=\"wellControls2\"\n"
-  "                  meshName=\"mesh1\"\n"
-  "                  polylineNodeCoords=\"{ {0.5, 0, 2  },\n"
-  "                                         {0.5, 0, 0.5} }\"\n"
-  "                  polylineSegmentConn=\"{ {0, 1} }\"\n"
-  "                  radius=\"0.1\"\n"
-  "                  numElementsPerSegment=\"1\">\n"
-  "        <Perforation name=\"injector1_perf1\"\n"
-  "                     distanceFromHead=\"1.45\"/> \n"
-  "    </InternalWell>\n"
-  "  </Mesh>\n"
-  "  <NumericalMethods>\n"
-  "    <FiniteVolume>\n"
-  "      <TwoPointFluxApproximation name=\"singlePhaseTPFA\"/>\n"
-  "    </FiniteVolume>\n"
-  "  </NumericalMethods>\n"
-  "  <ElementRegions>\n"
-  "    <CellElementRegion name=\"Region1\"\n"
-  "                       cellBlocks=\"{cb1}\"\n"
-  "                       materialList=\"{water, rock}\"/>\n"
-  "    <WellElementRegion name=\"wellRegion1\"\n"
-  "                       materialList=\"{water}\"/> \n"
-  "    <WellElementRegion name=\"wellRegion2\"\n"
-  "                       materialList=\"{water}\"/> \n"
-  "  </ElementRegions>\n"
-  "  <Constitutive>\n"
-  "    <CompressibleSinglePhaseFluid name=\"water\"\n"
-  "                                  defaultDensity=\"1000\"\n"
-  "                                  defaultViscosity=\"0.001\"\n"
-  "                                  referencePressure=\"0.0\"\n"
-  "                                  referenceDensity=\"1000\"\n"
-  "                                  compressibility=\"5e-10\"\n"
-  "                                  referenceViscosity=\"0.001\"\n"
-  "                                  viscosibility=\"0.0\"/>\n"
-  "    <CompressibleSolidConstantPermeability name=\"rock\"\n"
-  "        solidModelName=\"nullSolid\"\n"
-  "        porosityModelName=\"rockPorosity\"\n"
-  "        permeabilityModelName=\"rockPerm\"/>\n"
-  "   <NullModel name=\"nullSolid\"/> \n"
-  "   <PressurePorosity name=\"rockPorosity\"\n"
-  "                     defaultReferencePorosity=\"0.05\"\n"
-  "                     referencePressure = \"0.0\"\n"
-  "                     compressibility=\"1.0e-9\"/>\n"
-  "  <ConstantPermeability name=\"rockPerm\"\n"
-  "                        permeabilityComponents=\"{2.0e-16, 2.0e-16, 2.0e-16}\"/> \n"
-  "  </Constitutive>\n"
-  "  <FieldSpecifications>\n"
-  "    <FieldSpecification name=\"initialPressure\"\n"
-  "                        initialCondition=\"1\"\n"
-  "                        setNames=\"{all}\"\n"
-  "                        objectPath=\"ElementRegions/Region1/cb1\"\n"
-  "                        fieldName=\"pressure\"\n"
-  "                        scale=\"5e6\"/>\n"
-  "  </FieldSpecifications>\n"
-  "</Problem>";
+  R"xml(
+  <Problem>
+    <Solvers gravityVector="{ 0.0, 0.0, -9.81 }">
+      <SinglePhaseReservoir name="reservoirSystem"
+                 flowSolverName="singlePhaseFlow"
+                 wellSolverName="singlePhaseWell"
+                 logLevel="1"
+                 targetRegions="{Region1,wellRegion1,wellRegion2}">
+        <NonlinearSolverParameters newtonMaxIter="40"/>
+        <LinearSolverParameters solverType="direct"
+                                logLevel="2"/>
+      </SinglePhaseReservoir>
+      <SinglePhaseFVM name="singlePhaseFlow"
+                               logLevel="1"
+                               discretization="singlePhaseTPFA"
+                               targetRegions="{Region1}">
+      </SinglePhaseFVM>
+      <SinglePhaseWell name="singlePhaseWell"
+                       logLevel="1"
+                       targetRegions="{wellRegion1,wellRegion2}">
+          <WellControls name="wellControls1"
+                        type="producer"
+                        referenceElevation="2"
+                        control="BHP"
+                        targetBHP="5e5"
+                        targetTotalRate="1e-3"/>
+          <WellControls name="wellControls2"
+                        type="injector"
+                        referenceElevation="2"
+                        control="totalVolRate"
+                        targetBHP="2e7"
+                        targetTotalRate="1e-4"/>
+      </SinglePhaseWell>
+    </Solvers>
+    <Mesh>
+      <InternalMesh name="mesh1"
+                    elementTypes="{C3D8}"
+                    xCoords="{0, 5}"
+                    yCoords="{0, 1}"
+                    zCoords="{0, 1}"
+                    nx="{3}"
+                    ny="{1}"
+                    nz="{1}"
+                    cellBlockNames="{cb1}"/>
+      <InternalWell name="well_producer1"
+                    wellRegionName="wellRegion1"
+                    wellControlsName="wellControls1"
+                    meshName="mesh1"
+                    polylineNodeCoords="{ {4.5, 0,  2  },
+                                           {4.5, 0,  0.5} }"
+                    polylineSegmentConn="{ {0, 1} }"
+                    radius="0.1"
+                    numElementsPerSegment="1">
+          <Perforation name="producer1_perf1"
+                       distanceFromHead="1.45"/>
+      </InternalWell>
+      <InternalWell name="well_injector1"
+                    wellRegionName="wellRegion2"
+                    wellControlsName="wellControls2"
+                    meshName="mesh1"
+                    polylineNodeCoords="{ {0.5, 0, 2  },
+                                           {0.5, 0, 0.5} }"
+                    polylineSegmentConn="{ {0, 1} }"
+                    radius="0.1"
+                    numElementsPerSegment="1">
+          <Perforation name="injector1_perf1"
+                       distanceFromHead="1.45"/>
+      </InternalWell>
+    </Mesh>
+    <NumericalMethods>
+      <FiniteVolume>
+        <TwoPointFluxApproximation name="singlePhaseTPFA"/>
+      </FiniteVolume>
+    </NumericalMethods>
+    <ElementRegions>
+      <CellElementRegion name="Region1"
+                         cellBlocks="{cb1}"
+                         materialList="{water, rock}"/>
+      <WellElementRegion name="wellRegion1"
+                         materialList="{water}"/>
+      <WellElementRegion name="wellRegion2"
+                         materialList="{water}"/>
+    </ElementRegions>
+    <Constitutive>
+      <CompressibleSinglePhaseFluid name="water"
+                                    defaultDensity="1000"
+                                    defaultViscosity="0.001"
+                                    referencePressure="0.0"
+                                    referenceDensity="1000"
+                                    compressibility="5e-10"
+                                    referenceViscosity="0.001"
+                                    viscosibility="0.0"/>
+      <CompressibleSolidConstantPermeability name="rock"
+          solidModelName="nullSolid"
+          porosityModelName="rockPorosity"
+          permeabilityModelName="rockPerm"/>
+     <NullModel name="nullSolid"/>
+     <PressurePorosity name="rockPorosity"
+                       defaultReferencePorosity="0.05"
+                       referencePressure = "0.0"
+                       compressibility="1.0e-9"/>
+    <ConstantPermeability name="rockPerm"
+                          permeabilityComponents="{2.0e-16, 2.0e-16, 2.0e-16}"/>
+    </Constitutive>
+    <FieldSpecifications>
+      <FieldSpecification name="initialPressure"
+                          initialCondition="1"
+                          setNames="{all}"
+                          objectPath="ElementRegions/Region1/cb1"
+                          fieldName="pressure"
+                          scale="5e6"/>
+    </FieldSpecifications>
+  </Problem>
+  )xml";
 
 template< typename LAMBDA >
 void testNumericalJacobian( SinglePhaseReservoirAndWells< SinglePhaseBase > & solver,

--- a/src/coreComponents/unitTests/xmlTests/testXML.cpp
+++ b/src/coreComponents/unitTests/xmlTests/testXML.cpp
@@ -23,67 +23,71 @@
 
 TEST( testXML, testXMLString )
 {
-  char const *  xmlInput =
-    "<?xml version=\"1.0\" ?>\n"
-    "<Problem>\n"
-    "  <Solvers>\n"
-    "    <SolidMechanics_LagrangianFEM\n"
-    "      name=\"lagsolve\"\n"
-    "      cflFactor=\"0.25\"\n"
-    "      discretization=\"FE1\"\n"
-    "      targetRegions=\"{ Region2 }\"/>\n"
-    "  </Solvers>\n"
-    "  <Mesh>\n"
-    "    <InternalMesh\n"
-    "      name=\"mesh1\"\n"
-    "      elementTypes=\"{ C3D8 }\"\n"
-    "      xCoords=\"{ 0, 3 }\"\n"
-    "      yCoords=\"{ 0, 1 }\"\n"
-    "      zCoords=\"{ 0, 1 }\"\n"
-    "      nx=\"{ 4 }\"\n"
-    "      ny=\"{ 1 }\"\n"
-    "      nz=\"{ 1 }\"\n"
-    "      cellBlockNames=\"{ cb1 }\"/>\n"
-    "  </Mesh>\n"
-    "  <Events\n"
-    "    maxTime=\"1.0e-3\">\n"
-    "    <PeriodicEvent\n"
-    "      name=\"solverApplications\"\n"
-    "      forceDt=\"1.0e-3\"\n"
-    "      target=\"/Solvers/lagsolve\"/>\n"
-    "  </Events>\n"
-    "  <NumericalMethods>\n"
-    "    <FiniteElements>\n"
-    "      <FiniteElementSpace\n"
-    "        name=\"FE1\"\n"
-    "        order=\"1\"/>\n"
-    "    </FiniteElements>\n"
-    "  </NumericalMethods>\n"
-    "  <ElementRegions>\n"
-    "    <CellElementRegion\n"
-    "      name=\"Region2\"\n"
-    "      cellBlocks=\"{ cb1 }\"\n"
-    "      materialList=\"{ shale }\"/>\n"
-    "  </ElementRegions>\n"
-    "  <Constitutive>\n"
-    "    <ElasticIsotropic\n"
-    "      name=\"shale\"\n"
-    "      defaultDensity=\"2700\"\n"
-    "      defaultBulkModulus=\"5.5556e9\"\n"
-    "      defaultShearModulus=\"4.16667e9\"/>\n"
-    "  </Constitutive>\n"
-    "</Problem>";
+  char const * xmlInput =
+    R"xml(
+    <?xml version="1.0" ?>
+    <Problem>
+      <Solvers>
+        <SolidMechanics_LagrangianFEM
+          name="lagsolve"
+          cflFactor="0.25"
+          discretization="FE1"
+          targetRegions="{ Region2 }"/>
+      </Solvers>
+      <Mesh>
+        <InternalMesh
+          name="mesh1"
+          elementTypes="{ C3D8 }"
+          xCoords="{ 0, 3 }"
+          yCoords="{ 0, 1 }"
+          zCoords="{ 0, 1 }"
+          nx="{ 4 }"
+          ny="{ 1 }"
+          nz="{ 1 }"
+          cellBlockNames="{ cb1 }"/>
+      </Mesh>
+      <Events
+        maxTime="1.0e-3">
+        <PeriodicEvent
+          name="solverApplications"
+          forceDt="1.0e-3"
+          target="/Solvers/lagsolve"/>
+      </Events>
+      <NumericalMethods>
+        <FiniteElements>
+          <FiniteElementSpace
+            name="FE1"
+            order="1"/>
+        </FiniteElements>
+      </NumericalMethods>
+      <ElementRegions>
+        <CellElementRegion
+          name="Region2"
+          cellBlocks="{ cb1 }"
+          materialList="{ shale }"/>
+      </ElementRegions>
+      <Constitutive>
+        <ElasticIsotropic
+          name="shale"
+          defaultDensity="2700"
+          defaultBulkModulus="5.5556e9"
+          defaultShearModulus="4.16667e9"/>
+      </Constitutive>
+    </Problem>
+    )xml";
 
   geos::getGlobalState().getProblemManager().parseInputString( xmlInput );
 }
 
 TEST( testXML, testXMLStringExpectedFail )
 {
-  char const *  xmlInput =
-    "<?xml version=\"1.0\" ?>\n"
-    "<Problem>\n"
-    "  <Solvers>\n"
-    "</Problem>";
+  char const * xmlInput =
+    R"xml(
+    <?xml version="1.0" ?>
+    <Problem>
+      <Solvers>
+    </Problem>
+    )xml";
 
   EXPECT_THROW( geos::getGlobalState().getProblemManager().parseInputString( xmlInput ), geos::InputError );
 }


### PR DESCRIPTION
This PR is a proposal to enhance clarity of embedded `xml` input in unit tests.
Raw [string literals](https://en.cppreference.com/w/cpp/language/string_literal) is supported by most compilers since [c++11 standard](https://en.cppreference.com/w/cpp/compiler_support/11).

I've limited changes to `xml` data as a proof of concept but it could be extended to other multi-line embedded strings such as [oblInput](https://github.com/GEOS-DEV/GEOS/blob/develop/src/coreComponents/unitTests/fluidFlowTests/testReactiveCompositionalMultiphaseOBL.cpp#L126-L138).