### PR TITLE
Add anisotropy factors to Carman-Kozeny

### DIFF
--- a/src/coreComponents/constitutive/permeability/CarmanKozenyPermeability.cpp
+++ b/src/coreComponents/constitutive/permeability/CarmanKozenyPermeability.cpp
@@ -28,7 +28,8 @@ namespace constitutive
 
 
 CarmanKozenyPermeability::CarmanKozenyPermeability( string const & name, Group * const parent ):
-  PermeabilityBase( name, parent )
+  PermeabilityBase( name, parent ),
+  m_anisotropy{ 1.0, 1.0, 1.0 }
 {
   registerWrapper( viewKeyStruct::particleDiameterString(), &m_particleDiameter ).
     setInputFlag( InputFlags::REQUIRED ).
@@ -37,6 +38,11 @@ CarmanKozenyPermeability::CarmanKozenyPermeability( string const & name, Group *
   registerWrapper( viewKeyStruct::sphericityString(), &m_sphericity ).
     setInputFlag( InputFlags::REQUIRED ).
     setDescription( "Sphericity of the particles." );
+
+  registerWrapper( viewKeyStruct::anisotropyString(), &m_anisotropy ).
+    setInputFlag( InputFlags::OPTIONAL ).
+    setDefaultValue( m_anisotropy ).
+    setDescription( "Anisotropy factors for three permeability components." );
 
   registerWrapper( viewKeyStruct::dPerm_dPorosityString(), &m_dPerm_dPorosity );
 }

--- a/src/coreComponents/constitutive/permeability/CarmanKozenyPermeability.hpp
+++ b/src/coreComponents/constitutive/permeability/CarmanKozenyPermeability.hpp
@@ -35,11 +35,13 @@ public:
                                   arrayView3d< real64 > const & dPerm_dPressure,
                                   arrayView3d< real64 > const & dPerm_dPorosity,
                                   real64 const particleDiameter,
-                                  real64 const sphericity )
+                                  real64 const sphericity,
+                                  R1Tensor const anisotropy )
     : PermeabilityBaseUpdate( permeability, dPerm_dPressure ),
     m_dPerm_dPorosity( dPerm_dPorosity ),
     m_particleDiameter( particleDiameter ),
-    m_sphericity( sphericity )
+    m_sphericity( sphericity ),
+    m_anisotropy( anisotropy )
   {}
 
   GEOS_HOST_DEVICE
@@ -68,6 +70,8 @@ private:
   /// Sphericity of the particles
   real64 m_sphericity;
 
+  /// Anisotropy factors for three dimensions
+  R1Tensor m_anisotropy;
 };
 
 
@@ -100,7 +104,8 @@ public:
                           m_dPerm_dPressure,
                           m_dPerm_dPorosity,
                           m_particleDiameter,
-                          m_sphericity );
+                          m_sphericity,
+                          m_anisotropy );
   }
 
 
@@ -109,6 +114,7 @@ public:
     static constexpr char const * dPerm_dPorosityString() { return "dPerm_dPorosity"; }
     static constexpr char const * particleDiameterString() { return "particleDiameter"; }
     static constexpr char const * sphericityString() { return "sphericity"; }
+    static constexpr char const * anisotropyString() { return "anisotropy"; }
   } viewKeys;
 
 private:
@@ -121,11 +127,14 @@ private:
 
   /// Sphericity of the particles
   real64 m_sphericity;
+
+  /// Anisotropy factors for three dimensions
+  R1Tensor m_anisotropy;
 };
 
 
 GEOS_HOST_DEVICE
-GEOS_FORCE_INLINE
+inline
 void CarmanKozenyPermeabilityUpdate::compute( real64 const & porosity,
                                               arraySlice1d< real64 > const & permeability,
                                               arraySlice1d< real64 > const & dPerm_dPorosity ) const
@@ -136,10 +145,10 @@ void CarmanKozenyPermeabilityUpdate::compute( real64 const & porosity,
 
   real64 const dPerm_dPorValue = -constant * ( (porosity - 3) *  pow( porosity, 2 ) / pow( (1-porosity), 3 )  );
 
-  for( localIndex i=0; i < permeability.size(); i++ )
+  for( localIndex i = 0; i < permeability.size(); ++i )
   {
-    permeability[i] = permValue;
-    dPerm_dPorosity[i] = dPerm_dPorValue;
+    permeability[i] = permValue * m_anisotropy[i];
+    dPerm_dPorosity[i] = dPerm_dPorValue * m_anisotropy[i];
   }
 }
 

--- a/src/coreComponents/schema/docs/CarmanKozenyPermeability.rst
+++ b/src/coreComponents/schema/docs/CarmanKozenyPermeability.rst
@@ -1,11 +1,12 @@
 
 
-================ ====== ======== =========================================== 
-Name             Type   Default  Description                                 
-================ ====== ======== =========================================== 
-name             string required A name is required for any non-unique nodes 
-particleDiameter real64 required Diameter of the spherical particles.        
-sphericity       real64 required Sphericity of the particles.                
-================ ====== ======== =========================================== 
+================ ======== ======== ===================================================== 
+Name             Type     Default  Description                                           
+================ ======== ======== ===================================================== 
+anisotropy       R1Tensor {1,1,1}  Anisotropy factors for three permeability components. 
+name             string   required A name is required for any non-unique nodes           
+particleDiameter real64   required Diameter of the spherical particles.                  
+sphericity       real64   required Sphericity of the particles.                          
+================ ======== ======== ===================================================== 
 
 

--- a/src/coreComponents/schema/schema.xsd
+++ b/src/coreComponents/schema/schema.xsd
@@ -3248,6 +3248,8 @@ The expected format is "{ waterMax, oilMax }", in that order-->
 		<xsd:attribute name="name" type="string" use="required" />
 	</xsd:complexType>
 	<xsd:complexType name="CarmanKozenyPermeabilityType">
+		<!--anisotropy => Anisotropy factors for three permeability components.-->
+		<xsd:attribute name="anisotropy" type="R1Tensor" default="{1,1,1}" />
 		<!--particleDiameter => Diameter of the spherical particles.-->
 		<xsd:attribute name="particleDiameter" type="real64" use="required" />
 		<!--sphericity => Sphericity of the particles.-->


### PR DESCRIPTION
This small PR adds optional scaling factors for the components of Carman-Kozeny permeability. This is useful if one wants to have anisotropic pressure-dependent permeability in the matrix. I used it in one of the models for my thesis.

Requires rebaseline for one test that uses this model: https://github.com/GEOS-DEV/integratedTests/pull/330