### PR TITLE
Allow for embedded fractures of arbitrary planar shapes

### DIFF
--- a/src/coreComponents/mesh/CMakeLists.txt
+++ b/src/coreComponents/mesh/CMakeLists.txt
@@ -53,10 +53,13 @@ set( mesh_headers
      mpiCommunications/PartitionBase.hpp
      mpiCommunications/SpatialPartition.hpp
      simpleGeometricObjects/BoundedPlane.hpp
+     simpleGeometricObjects/Circle.hpp
+     simpleGeometricObjects/RTheta.hpp
      simpleGeometricObjects/Box.hpp
      simpleGeometricObjects/Cylinder.hpp
      simpleGeometricObjects/GeometricObjectManager.hpp
      simpleGeometricObjects/SimpleGeometricObjectBase.hpp
+     simpleGeometricObjects/BoundedPlanarObject.hpp
      simpleGeometricObjects/ThickPlane.hpp
      utilities/CIcomputationKernel.hpp
      utilities/ComputationalGeometry.hpp
@@ -108,10 +111,13 @@ set( mesh_sources
      mpiCommunications/PartitionBase.cpp
      mpiCommunications/SpatialPartition.cpp
      simpleGeometricObjects/BoundedPlane.cpp
+     simpleGeometricObjects/Circle.cpp
+     simpleGeometricObjects/RTheta.cpp
      simpleGeometricObjects/Box.cpp
      simpleGeometricObjects/Cylinder.cpp
      simpleGeometricObjects/GeometricObjectManager.cpp
      simpleGeometricObjects/SimpleGeometricObjectBase.cpp
+     simpleGeometricObjects/BoundedPlanarObject.cpp
      simpleGeometricObjects/ThickPlane.cpp
      utilities/ComputationalGeometry.cpp
      )

--- a/src/coreComponents/mesh/EmbeddedSurfaceSubRegion.cpp
+++ b/src/coreComponents/mesh/EmbeddedSurfaceSubRegion.cpp
@@ -113,18 +113,18 @@ bool EmbeddedSurfaceSubRegion::addNewEmbeddedSurface( localIndex const cellIndex
                                                       EmbeddedSurfaceNodeManager & embSurfNodeManager,
                                                       EdgeManager const & edgeManager,
                                                       FixedOneToManyRelation const & cellToEdges,
-                                                      BoundedPlane const * fracture )
+                                                      BoundedPlanarObject const * fracture )
 {
-  /* The goal is to add an embeddedSurfaceElem if it is contained within the BoundedPlane
+  /* The goal is to add an embeddedSurfaceElem if it is contained within the BoundedPlanarObject
    *
-   * A. Identify whether the cell falls within the bounded plane or not
+   * A. Identify whether the cell falls within the bounded planar object or not
    *
    * we loop over each edge:
    *
-   *   1. check if it is cut by the plane using the Dot product between the distance of each node
+   *   1. check if it is cut by the planar object using the Dot product between the distance of each node
    *   from the origin and the normal vector.
-   *   2. If an edge is cut by the plane we look for the intersection between a line and a plane.
-   *   3. Once we have the intersection we check if it falls inside the bounded plane.
+   *   2. If an edge is cut by the planar object we look for the intersection between a line and a plane.
+   *   3. Once we have the intersection we check if it falls inside the bounded planar object.
    *
    * Only elements for which all intersection points fall within the fracture plane limits will be added.
    * If the fracture does not cut through the entire element we will just chop it (it's a discretization error).

--- a/src/coreComponents/mesh/EmbeddedSurfaceSubRegion.hpp
+++ b/src/coreComponents/mesh/EmbeddedSurfaceSubRegion.hpp
@@ -25,6 +25,7 @@
 #include "EdgeManager.hpp"
 #include "EmbeddedSurfaceNodeManager.hpp"
 #include "CellElementSubRegion.hpp"
+//Do we really need this include BoundedPlane?
 #include "simpleGeometricObjects/BoundedPlane.hpp"
 
 namespace geos
@@ -142,7 +143,7 @@ public:
                               EmbeddedSurfaceNodeManager & embSurfNodeManager,
                               EdgeManager const & edgeManager,
                               FixedOneToManyRelation const & cellToEdges,
-                              BoundedPlane const * fracture );
+                              BoundedPlanarObject const * fracture );
 
   /**
    * @brief inherit ghost rank from cell elements.

--- a/src/coreComponents/mesh/simpleGeometricObjects/BoundedPlanarObject.cpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/BoundedPlanarObject.cpp
@@ -1,0 +1,50 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file BoundedPlanarObject.cpp
+ */
+
+#include "BoundedPlanarObject.hpp"
+#include "LvArray/src/tensorOps.hpp"
+
+namespace geosx
+{
+using namespace dataRepository;
+
+BoundedPlanarObject::BoundedPlanarObject( const string & name, Group * const parent ):
+  SimpleGeometricObjectBase( name, parent ),
+  m_normal{ 0.0, 0.0, 1.0 },
+  m_lengthVector{ 0.0, 0.0, 0.0 },
+  m_widthVector{ 0.0, 0.0, 0.0 }
+{
+  registerWrapper( viewKeyStruct::normalString(), &m_normal ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Normal (n_x,n_y,n_z) to the plane (will be normalized automatically)" );
+
+  registerWrapper( viewKeyStruct::mLengthVectorString(), &m_lengthVector ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Tangent vector defining the orthonormal basis along with the normal." );
+
+  registerWrapper( viewKeyStruct::mWidthVectorString(), &m_widthVector ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Tangent vector defining the orthonormal basis along with the normal." );  
+}
+
+BoundedPlanarObject::~BoundedPlanarObject()
+{}
+
+//REGISTER_CATALOG_ENTRY( SimpleGeometricObjectBase, BoundedPlanarObject, string const &, Group * const )
+
+} /* namespace geosx */

--- a/src/coreComponents/mesh/simpleGeometricObjects/BoundedPlanarObject.hpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/BoundedPlanarObject.hpp
@@ -1,0 +1,149 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file BoundedPlanarObject.hpp
+ */
+
+#ifndef GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_BOUNDEDPLANAROBJECT_HPP_
+#define GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_BOUNDEDPLANAROBJECT_HPP_
+
+#include "SimpleGeometricObjectBase.hpp"
+
+namespace geosx
+{
+
+/**
+ * @class BoundedPlanarObject
+ * @brief Abstract class to implement functions used by all bounded geometric objects in GEOSX, such as disc or plane.
+ */
+class BoundedPlanarObject : public SimpleGeometricObjectBase
+{
+public:
+
+  /**
+   * @name Constructor / Destructor
+   */
+  ///@{
+
+  /**
+   * @brief Constructor.
+   * @param name name of the object in the data hierarchy.
+   * @param parent pointer to the parent group in the data hierarchy.
+   */
+  BoundedPlanarObject( const string & name,
+                Group * const parent );
+
+  /**
+   * @brief Default destructor.
+   */
+  virtual ~BoundedPlanarObject() override;
+
+  ///@}
+
+  /**
+   * @name Static Factory Catalog Functions
+   */
+  ///@{
+
+  /**
+   * @brief Get the catalog name.
+   * @return the name of this class in the catalog
+   */
+  static string catalogName() { return "BoundedPlanarObject"; }
+
+  ///@}
+
+    /**
+   * @brief Check if the input coordinates are in the object.
+   * @param[in] coord the coordinates to test
+   * @return true if the coordinates are in the object, false otherwise
+   */
+  virtual bool isCoordInObject( real64 const ( &coord ) [3] ) const override = 0;
+
+  /**
+   * @name Getters
+   */
+  ///@{
+
+  /**
+   * @brief Get the normal to the plane.
+   * @return the normal vector
+   */
+  R1Tensor & getNormal() {return m_normal;}
+
+  /**
+   * @copydoc getNormal()
+   */
+  R1Tensor const & getNormal() const {return m_normal;}
+
+  /**
+   * @brief Get one of the tangent vectors defining the orthonormal basis along with the normal.
+   * @return the tangent vector
+   */
+  R1Tensor & getWidthVector() {return m_widthVector;}
+
+  /**
+   * @copydoc getWidthVector()
+   */
+  R1Tensor const & getWidthVector() const {return m_widthVector;}
+
+  /**
+   * @brief Get one of the tangent vectors defining the orthonormal basis along with the normal.
+   * @return the length vector
+   */
+  R1Tensor & getLengthVector() {return m_lengthVector;}
+
+  /**
+   * @copydoc getLengthVector()
+   */
+  R1Tensor const & getLengthVector() const {return m_lengthVector;}
+
+  /**
+   * @brief Get the origin of the plane.
+   * @return the origin of the plane
+   */
+  virtual R1Tensor & getCenter() = 0;
+
+  /**
+   * @copydoc getCenter()
+   */
+  virtual R1Tensor const & getCenter() const = 0;
+
+protected:
+
+  /// Normal (n_x,n_y,n_z) to the plane (will be normalized automatically)
+  R1Tensor m_normal;
+  /// Length vector in the orthonormal basis along with the normal
+  R1Tensor m_lengthVector;
+  /// Width vector in the orthonormal basis along with the normal
+  R1Tensor m_widthVector;
+  /// tolerance to determine if a point sits on the BoundedPlanarObject or not
+  real64 m_tolerance;
+
+  /// @cond DO_NOT_DOCUMENT
+
+  struct viewKeyStruct
+  {
+    static constexpr char const * normalString() { return "normal"; }
+    static constexpr char const * mLengthVectorString() { return "lengthVector"; }
+    static constexpr char const * mWidthVectorString() { return "widthVector"; }
+  };
+
+  /// @endcond
+
+};
+} /* namespace geosx */
+
+#endif /* GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_BOUNDEDPLANAROBJECT_HPP_*/

--- a/src/coreComponents/mesh/simpleGeometricObjects/Circle.cpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Circle.cpp
@@ -1,0 +1,84 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file Circle.cpp
+ */
+
+#include "Circle.hpp"
+#include "LvArray/src/tensorOps.hpp"
+
+namespace geosx
+{
+using namespace dataRepository;
+
+Circle::Circle( const string & name, Group * const parent ):
+  BoundedPlanarObject( name, parent ),
+  m_center{ 0.0, 0.0, 0.0 },
+  m_radius(1.0),
+  m_tolerance()
+{
+  registerWrapper( viewKeyStruct::centerString(), &m_center ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "(x,y,z) coordinates of the center of the circle" );
+
+  registerWrapper( viewKeyStruct::radiusString(), &m_radius ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "Radius of the circle." );
+
+  registerWrapper( viewKeyStruct::toleranceString(), &m_tolerance ).
+    setInputFlag( InputFlags::OPTIONAL ).
+    setDefaultValue( 1e-5 ).
+    setDescription( "Tolerance to determine if a point sits on the circle or not. "
+                    "It is relative to the maximum dimension of the circle." );
+
+}
+
+Circle::~Circle()
+{}
+
+void Circle::postProcessInput()
+{
+  // Make sure that you have an orthonormal basis.
+  LvArray::tensorOps::normalize< 3 >( m_normal );
+  m_tolerance = m_tolerance * m_radius;
+
+}
+
+bool Circle::isCoordInObject( real64 const ( &coord ) [3] ) const
+{
+  bool isInside = true;
+
+  //gets the vector from coord to the center
+  real64 dummy[ 3 ] = LVARRAY_TENSOROPS_INIT_LOCAL_3( coord );
+  LvArray::tensorOps::subtract< 3 >( dummy, m_center );
+
+  // 1. Check if point is on the plane of the circle
+  if( std::abs( LvArray::tensorOps::AiBi< 3 >( dummy, m_normal ) ) > m_tolerance )
+  {
+    isInside = false;
+  }
+
+  // 2. Check if it is inside the circle
+  if( LvArray::tensorOps::l2NormSquared< 3 >( dummy ) > m_radius*m_radius )
+  {
+    isInside = false;
+  }
+
+  return isInside;
+}
+
+REGISTER_CATALOG_ENTRY( SimpleGeometricObjectBase, Circle, string const &, Group * const )
+
+} /* namespace geosx */

--- a/src/coreComponents/mesh/simpleGeometricObjects/Circle.hpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Circle.hpp
@@ -13,11 +13,11 @@
  */
 
 /**
- * @file BoundedPlane.hpp
+ * @file Circle.hpp
  */
 
-#ifndef GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_BOUNDEDPLANE_HPP_
-#define GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_BOUNDEDPLANE_HPP_
+#ifndef GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_CIRCLE_HPP_
+#define GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_CIRCLE_HPP_
 
 #include "SimpleGeometricObjectBase.hpp"
 #include "BoundedPlanarObject.hpp"
@@ -26,10 +26,10 @@ namespace geosx
 {
 
 /**
- * @class BoundedPlane
- * @brief Class to represent a geometric box in GEOSX.
+ * @class Circle
+ * @brief Class to represent a geometric disc in GEOSX.
  */
-class BoundedPlane : public BoundedPlanarObject
+class Circle : public BoundedPlanarObject
 {
 public:
 
@@ -43,26 +43,13 @@ public:
    * @param name name of the object in the data hierarchy.
    * @param parent pointer to the parent group in the data hierarchy.
    */
-  BoundedPlane( const string & name,
+  Circle( const string & name,
                 Group * const parent );
-
-  /**
-   * @brief Internal constructor. This is used to make planar cuts from point (oldX, oldY) to (newX, newY)
-   * in 2.5D problems.
-   * @param oldX x-coordinate of first point
-   * @param oldY y-coordinate of first point
-   * @param newX x-coordinate of second point
-   * @param newY y-coordinate of second point
-   * @param name name of the object in the data hierarchy.
-   * @param parent pointer to the parent group in the data hierarchy.
-   */
-  BoundedPlane( const real64 oldX, const real64 oldY, const real64 newX,
-                const real64 newY, const string & name, Group * const parent );
 
   /**
    * @brief Default destructor.
    */
-  virtual ~BoundedPlane() override;
+  virtual ~Circle() override;
 
   ///@}
 
@@ -75,16 +62,11 @@ public:
    * @brief Get the catalog name.
    * @return the name of this class in the catalog
    */
-  static string catalogName() { return "BoundedPlane"; }
+  static string catalogName() { return "Circle"; }
 
   ///@}
 
   bool isCoordInObject( real64 const ( &coord ) [3] ) const override final;
-
-  /**
-   * @brief Find the bounds of the plane.
-   */
-  void findRectangleLimits();
 
   /**
    * @name Getters
@@ -92,18 +74,15 @@ public:
   ///@{
 
   /**
-   * @brief Get the origin of the plane.
-   * @return the origin of the plane
+   * @brief Get the center of the circle.
+   * @return the center of the circle
    */
-  virtual R1Tensor & getCenter() override final {return m_origin;}
+  virtual R1Tensor & getCenter() override final {return m_center;}
 
   /**
    * @copydoc getCenter()
    */
-  virtual R1Tensor const & getCenter() const override final {return m_origin;}
-
-
-
+  virtual R1Tensor const & getCenter() const override final {return m_center;}
 
 protected:
 
@@ -115,21 +94,19 @@ protected:
 
 private:
 
-  /// Origin point (x,y,z) of the plane (basically, any point on the plane)
-  R1Tensor m_origin;
-  /// Dimensions of the bounded plane
-  array1d< real64 > m_dimensions;
-  /// Length and width of the bounded plane
-  array2d< real64 > m_points;
-  /// tolerance to determine if a point sits on the plane or not
+  /// center of the circle in (x,y,z) coordinates
+  R1Tensor m_center;
+  /// Dimensions of the circle's radius
+  real64 m_radius;
+  /// tolerance to determine if a point sits on the circle or not
   real64 m_tolerance;
 
   /// @cond DO_NOT_DOCUMENT
 
   struct viewKeyStruct
   {
-    static constexpr char const * originString() { return "origin"; }
-    static constexpr char const * dimensionsString() { return "dimensions"; }
+    static constexpr char const * centerString() { return "center"; }
+    static constexpr char const * radiusString() { return "radius"; }
     static constexpr char const * toleranceString() { return "tolerance"; }
   };
 
@@ -138,4 +115,4 @@ private:
 };
 } /* namespace geosx */
 
-#endif /* GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_BOUNDEDPLANE_HPP_*/
+#endif /* GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_CIRCLE_HPP_*/

--- a/src/coreComponents/mesh/simpleGeometricObjects/RTheta.cpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/RTheta.cpp
@@ -1,0 +1,87 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file RTheta.cpp
+ */
+
+#include "RTheta.hpp"
+#include "LvArray/src/tensorOps.hpp"
+
+namespace geosx
+{
+using namespace dataRepository;
+
+RTheta::RTheta( const string & name, Group * const parent ):
+  BoundedPlanarObject( name, parent ),
+  m_center{ 0.0, 0.0, 0.0 },
+  m_tolerance()
+{
+  registerWrapper( viewKeyStruct::centerString(), &m_center ).
+    setInputFlag( InputFlags::REQUIRED ).
+    setDescription( "(x,y,z) coordinates of the center of the RTheta" );
+
+  // registerWrapper( viewKeyStruct::radiusString(), &m_radius ).
+  //   setInputFlag( InputFlags::OPTIONAL ).
+  //   setDescription( "Coefficients of the RTheta function." );
+
+  registerWrapper( viewKeyStruct::toleranceString(), &m_tolerance ).
+    setInputFlag( InputFlags::OPTIONAL ).
+    setDefaultValue( 1e-5 ).
+    setDescription( "Tolerance to determine if a point sits on the RTheta or not. "
+                    "It is relative to the maximum dimension of the RTheta." );
+
+}
+
+RTheta::~RTheta()
+{}
+
+void RTheta::postProcessInput()
+{
+  // Make sure that you have an orthonormal basis.
+  LvArray::tensorOps::normalize< 3 >( m_normal );
+
+}
+
+bool RTheta::isCoordInObject( real64 const ( &coord ) [3] ) const
+{
+  bool isInside = true;
+
+  //gets the vector from coord to the center
+  real64 dummy[ 3 ] = LVARRAY_TENSOROPS_INIT_LOCAL_3( coord );
+  LvArray::tensorOps::subtract< 3 >( dummy, m_center );
+
+  // 1. Check if point is on the plane of the RTheta
+  if( std::abs( LvArray::tensorOps::AiBi< 3 >( dummy, m_normal ) ) > m_tolerance )
+  {
+    isInside = false;
+  }
+
+  // 2. Get angle with the plane's length vector
+  real64 dummyNorm = sqrt(LvArray::tensorOps::l2NormSquared< 3 >( dummy ));
+  real64 cosTheta = LvArray::tensorOps::AiBi< 3 >( dummy, getLengthVector() )/(dummyNorm + 1e-15); //assume lengthVector is unitary
+  real64 theta = acos(cosTheta);
+
+  // 2. Check if it is inside the RTheta
+  if( LvArray::tensorOps::l2NormSquared< 3 >( dummy ) > getRadius(theta)*getRadius(theta) )
+  {
+    isInside = false;
+  }
+
+  return isInside;
+}
+
+REGISTER_CATALOG_ENTRY( SimpleGeometricObjectBase, RTheta, string const &, Group * const )
+
+} /* namespace geosx */

--- a/src/coreComponents/mesh/simpleGeometricObjects/RTheta.hpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/RTheta.hpp
@@ -1,0 +1,188 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file RTheta.hpp
+ */
+
+#ifndef GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_RTHETA_HPP_
+#define GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_RTHETA_HPP_
+
+#include "SimpleGeometricObjectBase.hpp"
+#include "BoundedPlanarObject.hpp"
+
+namespace geosx
+{
+
+/**
+ * @class RTheta
+ * @brief Class to represent a geometric disc in GEOSX.
+ */
+class RTheta : public BoundedPlanarObject
+{
+public:
+
+  /**
+   * @name Constructor / Destructor
+   */
+  ///@{
+
+  /**
+   * @brief Constructor.
+   * @param name name of the object in the data hierarchy.
+   * @param parent pointer to the parent group in the data hierarchy.
+   */
+  RTheta( const string & name,
+                Group * const parent );
+
+  /**
+   * @brief Default destructor.
+   */
+  virtual ~RTheta() override;
+
+  ///@}
+
+  /**
+   * @name Static Factory Catalog Functions
+   */
+  ///@{
+
+  /**
+   * @brief Get the catalog name.
+   * @return the name of this class in the catalog
+   */
+  static string catalogName() { return "RTheta"; }
+
+  ///@}
+
+  bool isCoordInObject( real64 const ( &coord ) [3] ) const override final;
+
+  /**
+   * @name Getters
+   */
+  ///@{
+
+  /**
+   * @brief Get the center of the RTheta.
+   * @return the center of the RTheta
+   */
+  virtual R1Tensor & getCenter() override final {return m_center;}
+
+  /**
+   * @copydoc getCenter()
+   */
+  virtual R1Tensor const & getCenter() const override final {return m_center;}
+
+  /**
+   * @brief Update the geometric function describing the boundary of the object.
+   * @param coefficients define all the coefficients of the radius function.
+   * @return void
+   */
+  void setRThetaFunction(array1d<real64> & coefficients)
+  {
+    m_radius.m_coefficients = coefficients;
+  }
+
+  /**
+   * @brief Update a single coeff. of the geometric function describing the boundary of the object.
+   * @param entry define the entry to be modified
+   * @param value the new value for that entry
+   * @return void
+   */
+  void setRThetaFunction(integer const entry, real64 const value)
+  {
+    if(m_radius.m_coefficients.size() < entry+1){
+      std::cout<<"ERROR - COEFF VECTOR NOT LARGE ENOUGH\n";
+      return;
+      //GEOSX_ERROR("Vector of coefficients in the RTheta object is not large enough. Requested change to entry "<<entry<<" array size: "<<m_radius.m_coefficients.size()<<"\n");
+    }
+    m_radius.m_coefficients[entry] = value;
+  }
+
+  real64 getRadius(real64 angle) const
+  {
+    return m_radius.getRadius(angle);
+  }
+
+
+
+  class VariableRadius
+  {  
+    public: 
+
+    VariableRadius()
+    {
+      m_coefficients.resize(6);
+      m_coefficients[0] = 1.0;
+      m_coefficients[1] = 0.0;
+      m_coefficients[2] = 0.15;
+      m_coefficients[3] = 0.0;
+      m_coefficients[4] = 0.0;
+      m_coefficients[5] = 0.0;
+    }
+  
+    real64 getRadius(real64 angle) const
+    {
+      real64 radius = 0;
+      integer count = 0;
+      for(auto coeff:m_coefficients)
+      {
+        radius = radius + coeff*cos(count*angle);
+        count++;
+      }
+      return radius;
+    }
+
+    void updateCoefficients(integer index, real64 value)
+    {
+      m_coefficients[index]=value;
+    }
+
+    array1d<real64> m_coefficients;
+  
+  };  
+
+
+protected:
+
+  /**
+   * @brief This function provides the capability to post process input values prior to
+   * any other initialization operations.
+   */
+  virtual void postProcessInput() override final;
+
+private:
+
+  /// center of the RTheta in (x,y,z) coordinates
+  R1Tensor m_center;
+  /// Dimensions of the RTheta's radius (as a function of theta)
+  VariableRadius m_radius;
+  /// tolerance to determine if a point sits on the RTheta or not
+  real64 m_tolerance;
+
+  /// @cond DO_NOT_DOCUMENT
+
+  struct viewKeyStruct
+  {
+    static constexpr char const * centerString() { return "center"; }
+    // static constexpr char const * radiusString() { return "radius"; }
+    static constexpr char const * toleranceString() { return "tolerance"; }
+  };
+
+  /// @endcond
+
+};
+} /* namespace geosx */
+
+#endif /* GEOSX_MESH_SIMPLEGEOMETRICOBJECTS_RTheta_HPP_*/

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/EmbeddedSurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/EmbeddedSurfaceGenerator.cpp
@@ -128,7 +128,7 @@ void EmbeddedSurfaceGenerator::initializePostSubGroups()
   NewObjectLists newObjects;
 
   // Loop over all the fracture planes
-  geometricObjManager.forSubGroups< BoundedPlane >( [&]( BoundedPlane & fracture )
+  geometricObjManager.forSubGroups< BoundedPlanarObject >( [&]( BoundedPlanarObject & fracture )
   {
     /* 1. Find out if an element is cut by the fracture or not.
      * Loop over all the elements and for each one of them loop over the nodes and compute the


### PR DESCRIPTION
This PR extends the embedded fracture solver with the ability to handle fractures of arbitrary planar shapes (circles, ellipses, etc). Currently, only bounded planes are supported.