### PR TITLE
Fix device build

### DIFF
--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/functions/RachfordRice.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/functions/RachfordRice.cpp
@@ -24,6 +24,7 @@ namespace geos
 namespace constitutive
 {
 
+GEOS_HOST_DEVICE
 real64
 RachfordRice::solve( arrayView1d< real64 const > const kValues,
                      arrayView1d< real64 const > const feed,
@@ -151,6 +152,7 @@ RachfordRice::solve( arrayView1d< real64 const > const kValues,
   return gasPhaseMoleFraction = newtonValue;
 }
 
+GEOS_HOST_DEVICE
 real64
 RachfordRice::evaluate( arrayView1d< real64 const > const kValues,
                         arrayView1d< real64 const > const feed,
@@ -166,6 +168,7 @@ RachfordRice::evaluate( arrayView1d< real64 const > const kValues,
   return value;
 }
 
+GEOS_HOST_DEVICE
 real64
 RachfordRice::evaluateDerivative( arrayView1d< real64 const > const kValues,
                                   arrayView1d< real64 const > const feed,


### PR DESCRIPTION
This PR fixes the following compilation errors when building for GPUs:
```
[ 28%] Building CXX object coreComponents/constitutive/CMakeFiles/constitutive.dir/fluid/multifluid/reactive/chemicalReactions/EquilibriumReactions.cpp.o
/autofs/nccs-svm1_home1/victorapm/projects/geos-dev/src/coreComponents/constitutive/fluid/multifluid/compositional/functions/RachfordRice.cpp:28:15: error: __host__ function 'solve' cannot overload __host__ __device__ function 'solve'
RachfordRice::solve( arrayView1d< real64 const > const kValues,
              ^
/autofs/nccs-svm1_home1/victorapm/projects/geos-dev/src/coreComponents/constitutive/fluid/multifluid/compositional/functions/RachfordRice.hpp:54:3: note: previous declaration is here
  solve( arrayView1d< real64 const > const kValues,
  ^
/autofs/nccs-svm1_home1/victorapm/projects/geos-dev/src/coreComponents/constitutive/fluid/multifluid/compositional/functions/RachfordRice.cpp:155:15: error: __host__ function 'evaluate' cannot overload __host__ __device__ function 'evaluate'
RachfordRice::evaluate( arrayView1d< real64 const > const kValues,
              ^
/autofs/nccs-svm1_home1/victorapm/projects/geos-dev/src/coreComponents/constitutive/fluid/multifluid/compositional/functions/RachfordRice.hpp:70:3: note: previous declaration is here
  evaluate( arrayView1d< real64 const > const kValues,
  ^
/autofs/nccs-svm1_home1/victorapm/projects/geos-dev/src/coreComponents/constitutive/fluid/multifluid/compositional/functions/RachfordRice.cpp:170:15: error: __host__ function 'evaluateDerivative' cannot overload __host__ __device__ function 'evaluateDerivative'
RachfordRice::evaluateDerivative( arrayView1d< real64 const > const kValues,
              ^
/autofs/nccs-svm1_home1/victorapm/projects/geos-dev/src/coreComponents/constitutive/fluid/multifluid/compositional/functions/RachfordRice.hpp:85:3: note: previous declaration is here
  evaluateDerivative( arrayView1d< real64 const > const kValues,
  ^
```