### PR TITLE
Implement STONE II model for three phase relperm interpolation

### DIFF
--- a/inputFiles/compositionalMultiphaseFlow/deadoil_3ph_staircase_3d_stone2.xml
+++ b/inputFiles/compositionalMultiphaseFlow/deadoil_3ph_staircase_3d_stone2.xml
@@ -1,0 +1,313 @@
+<?xml version="1.0" ?>
+
+<Problem>
+  <!-- START_SPHINX_INCLUDE_SOLVER_BLOCK -->
+  <Solvers>
+    <CompositionalMultiphaseFVM
+      name="compflow"
+      logLevel="1"
+      discretization="fluidTPFA"
+      targetRelativePressureChangeInTimeStep="1"
+      targetPhaseVolFractionChangeInTimeStep="1"      
+      targetRegions="{ Channel }"
+      temperature="300">
+      <NonlinearSolverParameters
+        newtonTol="1.0e-10"
+        newtonMaxIter="40"/>
+      <LinearSolverParameters
+        directParallel="0"/>
+    </CompositionalMultiphaseFVM>
+  </Solvers>
+
+  <!-- END_SPHINX_INCLUDE_SOLVER_BLOCK -->
+  <!-- START_SPHINX_INCLUDE_MESH_BLOCK -->
+  <Mesh>
+    <InternalMesh
+      name="mesh"
+      elementTypes="{ C3D8 }"
+      xCoords="{ 0, 5, 10 }"
+      yCoords="{ 0, 5, 10 }"
+      zCoords="{ 0, 2.5, 5, 7.5, 10 }"
+      nx="{ 5, 5 }"
+      ny="{ 5, 5 }"
+      nz="{ 3, 3, 3, 3 }"
+      cellBlockNames="{ b00, b01, b02, b03, b04, b05, b06, b07, b08, b09, b10, b11, b12, b13, b14, b15 }"/>
+  </Mesh>
+
+  <!-- END_SPHINX_INCLUDE_MESH_BLOCK -->
+  <!-- START_SPHINX_INCLUDE_GEOM_BLOCK -->
+  <Geometry>
+    <Box
+      name="source"
+      xMin="{ 7.99, -0.01, 9.99 }"
+      xMax="{ 10.01, 2.01, 10.01 }"/>
+
+    <Box
+      name="sink"
+      xMin="{ 7.99, -0.01, -0.01 }"
+      xMax="{ 10.01, 2.01, 0.01 }"/>
+  </Geometry>
+
+  <!-- END_SPHINX_INCLUDE_GEOM_BLOCK -->
+  <!-- START_SPHINX_INCLUDE_EVENTS_BLOCK -->
+  <Events
+    maxTime="2e8">
+    <PeriodicEvent
+      name="siloOutputs"
+      timeFrequency="1e7"
+      target="/Outputs/siloOutput"/>
+    <PeriodicEvent
+      name="vtkOutputs"
+      timeFrequency="1e7"
+      target="/Outputs/vtkOutput"/>
+
+    <PeriodicEvent
+      name="solverApplications1"
+      forceDt="1e5"
+      endTime="1e6"
+      target="/Solvers/compflow"/>
+
+    <PeriodicEvent
+      name="solverApplications2"
+      forceDt="1e6"
+      beginTime="1e6"
+      endTime="1e7"
+      target="/Solvers/compflow"/>
+
+    <PeriodicEvent
+      name="solverApplications3"
+      forceDt="1e7"
+      beginTime="1e7"
+      target="/Solvers/compflow"/>
+
+    <PeriodicEvent
+      name="restarts"
+      timeFrequency="1e8"
+      targetExactTimestep="0"
+      target="/Outputs/restartOutput"/>
+  </Events>
+
+  <!-- END_SPHINX_INCLUDE_EVENTS_BLOCK -->
+  <!-- START_SPHINX_INCLUDE_ELEMREG_BLOCK -->
+  <ElementRegions>
+    <CellElementRegion
+      name="Channel"
+      cellBlocks="{ b08, b00, b01, b05, b06, b14, b15, b11 }"
+      materialList="{ fluid, rock, relperm }"/>
+
+    <CellElementRegion
+      name="Barrier"
+      cellBlocks="{ b04, b12, b13, b09, b10, b02, b03, b07 }"
+      materialList="{ }"/>
+  </ElementRegions>
+
+  <!-- END_SPHINX_INCLUDE_ELEMREG_BLOCK -->
+  <!-- START_SPHINX_INCLUDE_NUMMET_BLOCK -->
+  <NumericalMethods>
+    <FiniteVolume>
+      <TwoPointFluxApproximation
+        name="fluidTPFA"/>
+    </FiniteVolume>
+  </NumericalMethods>
+
+  <!-- END_SPHINX_INCLUDE_NUMMET_BLOCK -->
+  <!-- START_SPHINX_INCLUDE_CONST_BLOCK -->
+  <Constitutive>
+    <DeadOilFluid
+      name="fluid"
+      phaseNames="{ gas, water, oil }"
+      surfaceDensities="{ 0.9907, 1022.0, 800.0 }"
+      componentMolarWeight="{ 16e-3, 18e-3, 114e-3 }"
+      hydrocarbonFormationVolFactorTableNames="{ B_g_table, B_o_table }"
+      hydrocarbonViscosityTableNames="{ visc_g_table, visc_o_table }"
+      waterReferencePressure="30600000.1"
+      waterFormationVolumeFactor="1.03"
+      waterCompressibility="0.00000000041"
+      waterViscosity="0.0003"/>
+
+    <CompressibleSolidConstantPermeability
+      name="rock"
+      solidModelName="nullSolid"
+      porosityModelName="rockPorosity"
+      permeabilityModelName="rockPerm"/>
+
+    <NullModel
+      name="nullSolid"/>
+
+    <PressurePorosity
+      name="rockPorosity"
+      defaultReferencePorosity="0.2"
+      referencePressure="0.0"
+      compressibility="1.0e-9"/>
+
+    <BrooksCoreyStone2RelativePermeability
+      name="relperm"
+      phaseNames="{ gas, water, oil }"
+      phaseMinVolumeFraction="{ 0.05, 0.05, 0.05 }"
+      waterOilRelPermExponent="{ 2.5, 1.5 }"
+      waterOilRelPermMaxValue="{ 0.8, 0.9 }"
+      gasOilRelPermExponent="{ 3, 3 }"
+      gasOilRelPermMaxValue="{ 0.4, 0.9 }"/>
+
+    <ConstantPermeability
+      name="rockPerm"
+      permeabilityComponents="{ 1.0e-16, 1.0e-16, 1.0e-16 }"/>
+  </Constitutive>
+
+  <!-- END_SPHINX_INCLUDE_CONST_BLOCK -->
+  <!-- START_SPHINX_INCLUDE_PERM_BLOCK -->
+  <FieldSpecifications>
+    <!-- END_SPHINX_INCLUDE_PERM_BLOCK -->
+    <!-- Initial pressure: ~50 bar -->
+    <!-- START_SPHINX_INCLUDE_INIT_BLOCK -->
+    <FieldSpecification
+      name="initialPressure"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/Channel"
+      fieldName="pressure"
+      scale="7.5e6"/>
+
+    <!-- Initial composition -->
+    <FieldSpecification
+      name="initialComposition_oil"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/Channel"
+      fieldName="globalCompFraction"
+      component="0"
+      scale="0.6"/>
+    <FieldSpecification
+      name="initialComposition_gas"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/Channel"
+      fieldName="globalCompFraction"
+      component="1"
+      scale="0.399"/>
+    <FieldSpecification
+      name="initialComposition_water"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/Channel"
+      fieldName="globalCompFraction"
+      component="2"
+      scale="0.001"/>
+
+    <!-- END_SPHINX_INCLUDE_INIT_BLOCK -->
+    <!-- START_SPHINX_INCLUDE_BC_BLOCK -->
+    <!-- Injection pressure: ~100 bar -->
+    <FieldSpecification
+      name="sourceTermPressure"
+      logLevel="1"
+      objectPath="faceManager"
+      fieldName="pressure"
+      scale="1e7"
+      setNames="{ source }"/>
+    <!-- Injection temperature -->
+    <FieldSpecification
+      name="sourceTermTemperature"
+      objectPath="faceManager"
+      fieldName="temperature"
+      scale="300"
+      setNames="{ source }"/>
+    <!-- Injection stream: mostly water -->
+    <FieldSpecification
+      name="sourceTermComposition_oil"
+      setNames="{ source }"
+      objectPath="faceManager"
+      fieldName="globalCompFraction"
+      component="0"
+      scale="0.1"/>
+    <FieldSpecification
+      name="sourceTermComposition_gas"
+      setNames="{ source }"
+      objectPath="faceManager"
+      fieldName="globalCompFraction"
+      component="1"
+      scale="0.1"/>
+    <FieldSpecification
+      name="sourceTermComposition_water"
+      setNames="{ source }"
+      objectPath="faceManager"
+      fieldName="globalCompFraction"
+      component="2"
+      scale="0.8"/>
+
+    
+    <!-- Production pressure: ~50 bar, -->
+    <FieldSpecification
+      name="sinkTermPressure"
+      logLevel="1"
+      objectPath="faceManager"
+      fieldName="pressure"
+      scale="5e6"
+      setNames="{ sink }"/>
+    <!-- Production temperature -->
+    <FieldSpecification
+      name="sinkTermTemperature"
+      objectPath="faceManager"
+      fieldName="temperature"
+      scale="300"
+      setNames="{ sink }"/>
+    <!-- Production stream: same as initial (should not matter due to upwinding) -->
+    <FieldSpecification
+      name="sinkTermComposition_oil"
+      setNames="{ sink }"
+      objectPath="faceManager"
+      fieldName="globalCompFraction"
+      component="0"
+      scale="0.6"/>
+    <FieldSpecification
+      name="sinkTermComposition_gas"
+      setNames="{ sink }"
+      objectPath="faceManager"
+      fieldName="globalCompFraction"
+      component="1"
+      scale="0.399"/>
+    <FieldSpecification
+      name="sinkTermComposition_water"
+      setNames="{ sink }"
+      objectPath="faceManager"
+      fieldName="globalCompFraction"
+      component="2"
+      scale="0.001"/>
+  </FieldSpecifications>
+
+  <!-- END_SPHINX_INCLUDE_BC_BLOCK -->
+  <Functions>
+    <TableFunction
+      name="B_o_table"
+      coordinates="{ 2068000, 5516000, 55160000 }"
+      values="{ 1.05, 1.02, 1.01 }"/>
+
+    <TableFunction
+      name="visc_o_table"
+      coordinates="{ 2068000, 5516000, 55160000 }"
+      values="{ 0.00285, 0.00299, 0.003 }"/>
+
+    <TableFunction
+      name="B_g_table"
+      coordinateFiles="{ pres_pvdg.txt }"
+      voxelFile="B_g_pvdg.txt"/>
+
+    <TableFunction
+      name="visc_g_table"
+      coordinateFiles="{ pres_pvdg.txt }"
+      voxelFile="visc_pvdg.txt"/>
+  </Functions>
+
+  <!-- START_SPHINX_INCLUDE_OUTPUT_BLOCK -->
+  <Outputs>
+    <Silo
+      name="siloOutput"
+      plotLevel="3"/>
+    <VTK
+      name="vtkOutput"/>
+
+    <Restart
+      name="restartOutput"/>
+  </Outputs>
+
+  <!-- END_SPHINX_INCLUDE_OUTPUT_BLOCK -->
+</Problem>

--- a/inputFiles/compositionalMultiphaseFlow/deadoil_3ph_stone2_1d.xml
+++ b/inputFiles/compositionalMultiphaseFlow/deadoil_3ph_stone2_1d.xml
@@ -1,0 +1,249 @@
+<?xml version="1.0" ?>
+
+<Problem>
+  <Solvers>
+    <CompositionalMultiphaseFVM
+      name="compflow"
+      logLevel="1"
+      discretization="fluidTPFA"
+      targetRegions="{ region }"
+      temperature="300">
+      <NonlinearSolverParameters
+        newtonTol="1.0e-10"
+        newtonMaxIter="15"
+        lineSearchMaxCuts="2"/>
+      <LinearSolverParameters
+        directParallel="0"/>
+    </CompositionalMultiphaseFVM>
+  </Solvers>
+
+  <Mesh>
+    <InternalMesh
+      name="mesh"
+      elementTypes="{ C3D8 }"
+      xCoords="{ 0, 10 }"
+      yCoords="{ 0, 1 }"
+      zCoords="{ 0, 1 }"
+      nx="{ 10 }"
+      ny="{ 1 }"
+      nz="{ 1 }"
+      cellBlockNames="{ block1 }"/>
+  </Mesh>
+
+  <Geometry>
+    <Box
+      name="source"
+      xMin="{ -0.01, -0.01, -0.01 }"
+      xMax="{ 1.01, 1.01, 1.01 }"/>
+
+    <Box
+      name="sink"
+      xMin="{ 8.99, -0.01, -0.01 }"
+      xMax="{ 10.01, 1.01, 1.01 }"/>
+  </Geometry>
+
+  <Events
+    maxTime="2e7">
+    <PeriodicEvent
+      name="outputs"
+      timeFrequency="1e6"
+      target="/Outputs/siloOutput"/>
+
+    <PeriodicEvent
+      name="solverApplications1"
+      forceDt="1e4"
+      endTime="1e5"
+      target="/Solvers/compflow"/>
+
+    <PeriodicEvent
+      name="solverApplications2"
+      forceDt="1e5"
+      beginTime="1e5"
+      target="/Solvers/compflow"/>
+
+    <PeriodicEvent
+      name="statistics"
+      timeFrequency="1e6"
+      target="/Tasks/compflowStatistics"/>
+
+    <PeriodicEvent
+      name="restarts"
+      timeFrequency="1e7"
+      targetExactTimestep="0"
+      target="/Outputs/restartOutput"/>
+  </Events>
+
+  <NumericalMethods>
+    <FiniteVolume>
+      <TwoPointFluxApproximation
+        name="fluidTPFA"/>
+    </FiniteVolume>
+  </NumericalMethods>
+
+  <ElementRegions>
+    <CellElementRegion
+      name="region"
+      cellBlocks="{ block1 }"
+      materialList="{ fluid, rock, relperm }"/>
+  </ElementRegions>
+
+  <Constitutive>
+    <DeadOilFluid
+      name="fluid"
+      phaseNames="{ oil, gas, water }"
+      surfaceDensities="{ 800.0, 0.9907, 1022.0 }"
+      componentMolarWeight="{ 114e-3, 16e-3, 18e-3 }"
+      tableFiles="{ pvdo.txt, pvdg.txt, pvtw.txt }"/>
+
+    <CompressibleSolidConstantPermeability
+      name="rock"
+      solidModelName="nullSolid"
+      porosityModelName="rockPorosity"
+      permeabilityModelName="rockPerm"/>
+
+    <NullModel
+      name="nullSolid"/>
+
+    <PressurePorosity
+      name="rockPorosity"
+      defaultReferencePorosity="0.05"
+      referencePressure="0.0"
+      compressibility="1.0e-9"/>
+
+    <BrooksCoreyStone2RelativePermeability
+      name="relperm"
+      phaseNames="{ oil, gas, water }"
+      phaseMinVolumeFraction="{ 0.05, 0.05, 0.05 }"
+      waterOilRelPermExponent="{ 2.5, 1.5 }"
+      waterOilRelPermMaxValue="{ 0.8, 0.9 }"
+      gasOilRelPermExponent="{ 3, 3 }"
+      gasOilRelPermMaxValue="{ 0.4, 0.9 }"/>
+
+    <ConstantPermeability
+      name="rockPerm"
+      permeabilityComponents="{ 1.0e-16, 1.0e-16, 1.0e-16 }"/>
+  </Constitutive>
+
+  <FieldSpecifications>
+    <!-- Initial pressure: ~5 bar -->
+    <FieldSpecification
+      name="initialPressure"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/block1"
+      fieldName="pressure"
+      scale="7.5e6"/>
+
+    <!-- Initial composition: no water, only heavy hydrocarbon components and N2 -->
+    <FieldSpecification
+      name="initialComposition_oil"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/block1"
+      fieldName="globalCompFraction"
+      component="0"
+      scale="0.6"/>
+
+    <FieldSpecification
+      name="initialComposition_gas"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/block1"
+      fieldName="globalCompFraction"
+      component="1"
+      scale="0.399"/>
+
+    <FieldSpecification
+      name="initialComposition_water"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/block1"
+      fieldName="globalCompFraction"
+      component="2"
+      scale="0.001"/>
+
+    <!-- Injection pressure: ~10 bar -->
+    <FieldSpecification
+      name="sourceTermPressure"
+      objectPath="ElementRegions/region/block1"
+      fieldName="pressure"
+      scale="1e7"
+      setNames="{ source }"/>
+
+    <!-- Injection stream: mostly water -->
+    <FieldSpecification
+      name="sourceTermComposition_oil"
+      setNames="{ source }"
+      objectPath="ElementRegions/region/block1"
+      fieldName="globalCompFraction"
+      component="0"
+      scale="0.1"/>
+
+    <FieldSpecification
+      name="sourceTermComposition_gas"
+      setNames="{ source }"
+      objectPath="ElementRegions/region/block1"
+      fieldName="globalCompFraction"
+      component="1"
+      scale="0.1"/>
+
+    <FieldSpecification
+      name="sourceTermComposition_water"
+      setNames="{ source }"
+      objectPath="ElementRegions/region/block1"
+      fieldName="globalCompFraction"
+      component="2"
+      scale="0.8"/>
+
+    <!-- Production pressure: ~40 bar, -->
+    <FieldSpecification
+      name="sinkTerm"
+      objectPath="ElementRegions/region/block1"
+      fieldName="pressure"
+      scale="4e6"
+      setNames="{ sink }"/>
+
+    <!-- Production stream: same as initial (should not matter due to upwinding) -->
+    <FieldSpecification
+      name="sinkTermComposition_oil"
+      setNames="{ sink }"
+      objectPath="ElementRegions/region/block1"
+      fieldName="globalCompFraction"
+      component="0"
+      scale="0.6"/>
+
+    <FieldSpecification
+      name="sinkTermComposition_gas"
+      setNames="{ sink }"
+      objectPath="ElementRegions/region/block1"
+      fieldName="globalCompFraction"
+      component="1"
+      scale="0.399"/>
+
+    <FieldSpecification
+      name="sinkTermComposition_water"
+      setNames="{ sink }"
+      objectPath="ElementRegions/region/block1"
+      fieldName="globalCompFraction"
+      component="2"
+      scale="0.001"/>
+  </FieldSpecifications>
+
+  <Outputs>
+    <Silo
+      name="siloOutput"/>
+
+    <Restart
+      name="restartOutput"/>
+  </Outputs>
+  
+  <Tasks>
+    <CompositionalMultiphaseStatistics
+      name="compflowStatistics"
+      flowSolverName="compflow"
+      logLevel="1"
+      computeCFLNumbers="1"
+      computeRegionStatistics="1"/>
+  </Tasks>
+  
+</Problem>

--- a/inputFiles/compositionalMultiphaseWell/black_oil_wells_saturated_3d_stone2.xml
+++ b/inputFiles/compositionalMultiphaseWell/black_oil_wells_saturated_3d_stone2.xml
@@ -1,0 +1,306 @@
+<?xml version="1.0" ?>
+
+<Problem>
+  <Solvers>
+
+    <CompositionalMultiphaseReservoir
+      name="reservoirSystem"
+      wellSolverName="compositionalMultiphaseWell"
+      flowSolverName="compositionalMultiphaseFlow"
+      logLevel="1"
+      initialDt="86400"
+      targetRegions="{ region, wellRegion1, wellRegion2 }">
+      <NonlinearSolverParameters
+        maxTimeStepCuts="5"
+        newtonTol="1e-8"  
+        newtonMaxIter="20"/>
+       <LinearSolverParameters 
+         directParallel="0"/> 
+    </CompositionalMultiphaseReservoir>
+
+    <CompositionalMultiphaseFVM
+      name="compositionalMultiphaseFlow"
+      logLevel="1"
+      discretization="fluidTPFA"
+      targetRelativePressureChangeInTimeStep="1"
+      targetPhaseVolFractionChangeInTimeStep="1"
+      targetRegions="{ region }"
+      temperature="297.15"
+      useMass="1"/>
+
+    <CompositionalMultiphaseWell
+      name="compositionalMultiphaseWell"
+      logLevel="1"
+      targetRegions="{ wellRegion1, wellRegion2 }"
+      maxRelativePressureChange="0.1"
+      maxCompFractionChange="0.1"
+      useMass="1">
+      <WellControls
+        name="wellControls1"
+        type="producer"
+        control="BHP"
+        referenceElevation="9"
+        targetBHP="1.2e+7"
+        targetPhaseRate="5e-2" 
+        targetPhaseName="oil"/>
+      <WellControls
+        name="wellControls2"
+        type="injector"
+        control="BHP"
+        referenceElevation="9"
+        targetBHP="2e+7"
+        targetTotalRate="5e-2"
+        injectionTemperature="297.15"
+        injectionStream="{ 0.000, 0.000, 1. }"/>
+    </CompositionalMultiphaseWell>
+  </Solvers>
+
+  <Mesh>
+
+    <InternalMesh
+      name="mesh"
+      elementTypes="{ C3D8 }"
+      xCoords="{ 0, 200 }"
+      yCoords="{ 0, 200 }"
+      zCoords="{ 0, 10 }"
+      nx="{ 4 }"
+      ny="{ 4 }"
+      nz="{ 2 }"
+      cellBlockNames="{ cb }"/>
+
+    <InternalWell
+      name="wellProducer"
+      wellRegionName="wellRegion1"
+      wellControlsName="wellControls1"
+      meshName="mesh"
+      polylineNodeCoords="{ { 5.0, 5.0, 2.0 },
+                            { 5.0, 5.0, 0.0 } }"
+      polylineSegmentConn="{ { 0, 1 } }"
+      radius="0.1"
+      numElementsPerSegment="1">
+      <Perforation
+        name="producerPerf1"
+        distanceFromHead="1.00"/>
+    </InternalWell>
+    <InternalWell
+      name="wellInjector"
+      wellRegionName="wellRegion2"
+      wellControlsName="wellControls2"
+      meshName="mesh"
+      polylineNodeCoords="{ { 195.0, 195.0, 2.0 },
+                            { 195.0, 195.0, 0.0 } }"
+      polylineSegmentConn="{ { 0, 1 } }"
+      radius="0.1"
+      numElementsPerSegment="1">
+      <Perforation
+        name="injectorPerf1"
+        distanceFromHead="1.00"/>
+    </InternalWell>
+  </Mesh>
+
+  <Events 
+      maxTime="3153600">
+    
+    <PeriodicEvent
+      name="outputs"
+      timeFrequency="3153600"
+      targetExactTimestep="1"
+      target="/Outputs/vtkOutput"/>
+    
+    <PeriodicEvent
+      name="timeHistoryOutput"
+      timeFrequency="3153600"
+      targetExactTimestep="1"
+      target="/Outputs/timeHistoryOutput"/>
+
+    <PeriodicEvent
+      name="restarts"
+      timeFrequency="1576800"
+      targetExactTimestep="1"
+      target="/Outputs/restartOutput"/>
+
+    <PeriodicEvent
+      name="solverApplications"
+      maxEventDt="315360"      
+      target="/Solvers/reservoirSystem"/>
+
+    <PeriodicEvent
+      name="statistics"
+      timeFrequency="3153600"
+      target="/Tasks/compositionalMultiphaseFlowStatistics"/>
+    
+    <PeriodicEvent
+      name="timeHistoryCollection"
+      timeFrequency="315360"
+      targetExactTimestep="1"
+      target="/Tasks/wellRateCollection"/>
+
+  </Events>
+
+  <NumericalMethods>
+    <FiniteVolume>
+      <TwoPointFluxApproximation
+        name="fluidTPFA"/>
+    </FiniteVolume>
+  </NumericalMethods>
+
+  <ElementRegions>
+    <CellElementRegion
+      name="region"
+      cellBlocks="{ cb }"
+      materialList="{ fluid, rock, relperm, cappres }"/>
+    <WellElementRegion
+      name="wellRegion1"
+      materialList="{ fluid, relperm }"/>
+    <WellElementRegion
+      name="wellRegion2"
+      materialList="{ fluid, relperm }"/> 
+  </ElementRegions>
+
+  <Constitutive>
+    <BlackOilFluid
+      name="fluid"
+      phaseNames="{ oil, gas, water }"
+      surfaceDensities="{ 800.907131537, 0.856234902739, 1020.3440 }"
+      componentMolarWeight="{ 120e-3, 25e-3, 18e-3 }"
+      tableFiles="{ pvto_bo.txt, pvtg_norv_bo.txt, pvtw_bo.txt }"/>
+          
+    <CompressibleSolidConstantPermeability
+      name="rock"
+      solidModelName="nullSolid"
+      porosityModelName="rockPorosity"
+      permeabilityModelName="rockPerm"/>
+
+    <NullModel
+      name="nullSolid"/>
+
+    <PressurePorosity
+      name="rockPorosity"
+      defaultReferencePorosity="0.2"
+      referencePressure="4.1369e7"
+      compressibility="1.0e-9"/>
+
+    <TableRelativePermeability
+      name="relperm"
+      phaseNames="{ oil, gas, water }"
+      wettingIntermediateRelPermTableNames="{ waterRelPermTable, oilRelPermTableForOW }"
+      nonWettingIntermediateRelPermTableNames="{ gasRelPermTable, oilRelPermTableForOG }"
+      flagInterpolator="1"/>
+
+    <TableCapillaryPressure
+      name="cappres"
+      phaseNames="{ oil, gas, water }"
+      wettingIntermediateCapPressureTableName="waterCapPresTable"
+      nonWettingIntermediateCapPressureTableName="gasCapPresTable"/>
+    
+    <ConstantPermeability
+      name="rockPerm"
+      permeabilityComponents="{ 1.0e-14, 1.0e-14, 1.0e-14 }"/>
+
+  </Constitutive>
+
+  <FieldSpecifications>
+
+    <FieldSpecification
+      name="initialPressure"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="pressure"
+      scale="1.5e+7"/>
+    <FieldSpecification
+      name="initialComposition_oil"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="globalCompFraction"
+      component="0"
+      scale="0.79999"/>
+    <FieldSpecification
+      name="initialComposition_gas"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="globalCompFraction"
+      component="1"
+      scale="0.2"/>       
+    <FieldSpecification
+      name="initialComposition_water"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="globalCompFraction"
+      component="2"
+      scale="0.00001"/>
+  </FieldSpecifications>
+
+  <Functions>
+
+    <TableFunction
+      name="waterRelPermTable"
+      coordinates="{ 0.0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45,
+		     0.5, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1.00 }"
+      values="{ 0, 0.0025, 0.0100, 0.0225, 0.0400, 0.0625, 0.0900, 0.1225, 0.1600, 0.2025,
+	        0.2500, 0.3025, 0.3600, 0.4225, 0.4900, 0.5625, 0.6400, 0.7225, 0.8100, 0.9025, 1.0000 }"/>
+    <TableFunction
+      name="oilRelPermTableForOW"
+      coordinates="{ 0.0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45,
+		     0.5, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1.00 }"
+      values="{ 0, 0.0025, 0.0100, 0.0225, 0.0400, 0.0625, 0.0900, 0.1225, 0.1600, 0.2025,
+	        0.2500, 0.3025, 0.3600, 0.4225, 0.4900, 0.5625, 0.6400, 0.7225, 0.8100, 0.9025, 1.0000 }"/>
+    <TableFunction
+      name="gasRelPermTable"
+      coordinates="{ 0.0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45,
+		     0.5, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1.00 }"
+      values="{ 0, 0.0025, 0.0100, 0.0225, 0.0400, 0.0625, 0.0900, 0.1225, 0.1600, 0.2025,
+	        0.2500, 0.3025, 0.3600, 0.4225, 0.4900, 0.5625, 0.6400, 0.7225, 0.8100, 0.9025, 1.0000 }"/>
+    <TableFunction
+      name="oilRelPermTableForOG"
+      coordinates="{ 0.0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45,
+		     0.5, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1.00 }"
+      values="{ 0, 0.0025, 0.0100, 0.0225, 0.0400, 0.0625, 0.0900, 0.1225, 0.1600, 0.2025,
+	        0.2500, 0.3025, 0.3600, 0.4225, 0.4900, 0.5625, 0.6400, 0.7225, 0.8100, 0.9025, 1.0000 }"/>
+
+    <TableFunction
+      name="waterCapPresTable"
+      coordinates="{ 0.0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45,
+		     0.5, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1.00 }"
+      values="{ 10000, 9025, 8100, 7225, 6400, 5625, 4900, 4225, 3600, 3025,
+	        2500, 2025, 1600, 1225, 900, 625, 400, 225, 100, 25, 0 }"/>
+    <TableFunction
+      name="gasCapPresTable"
+      coordinates="{ 0.0, 0.05, 0.10, 0.15, 0.20, 0.25, 0.30, 0.35, 0.40, 0.45,
+		     0.5, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85, 0.90, 0.95, 1.00 }"
+      values="{ 0, 50, 200, 450, 800, 1250, 1800, 2450, 3200, 4050, 5000, 6050,
+  	       7200, 8450, 9800, 11250, 12800, 14450, 16200, 18050, 20000 }"/>
+    
+  </Functions>
+    
+  <Tasks>
+    <CompositionalMultiphaseStatistics
+      name="compositionalMultiphaseFlowStatistics"
+      flowSolverName="compositionalMultiphaseFlow"
+      logLevel="1"
+      computeCFLNumbers="1"
+      computeRegionStatistics="1"/>
+    
+    <PackCollection
+      name="wellRateCollection"
+      objectPath="ElementRegions/wellRegion1/wellRegion1UniqueSubRegion"
+      fieldName="wellElementMixtureConnectionRate"/>
+  </Tasks>
+
+  <Outputs>
+    <VTK
+      name="vtkOutput"/>
+    
+    <TimeHistory
+      name="timeHistoryOutput"
+      sources="{ /Tasks/wellRateCollection }"
+      filename="wellRateHistory"/>
+    
+    <Restart
+      name="restartOutput"/>
+  </Outputs>
+  
+</Problem>

--- a/inputFiles/compositionalMultiphaseWell/black_oil_wells_unsaturated_3d_stone2.xml
+++ b/inputFiles/compositionalMultiphaseWell/black_oil_wells_unsaturated_3d_stone2.xml
@@ -1,0 +1,261 @@
+<?xml version="1.0" ?>
+
+<Problem>
+    <Solvers>
+
+        <CompositionalMultiphaseReservoir
+                name="reservoirSystem"
+                wellSolverName="compositionalMultiphaseWell"
+                flowSolverName="compositionalMultiphaseFlow"
+                logLevel="1"
+                initialDt="86400"
+                targetRegions="{ region, wellRegion1, wellRegion2 }">
+            <NonlinearSolverParameters
+                    maxTimeStepCuts="5"
+                    newtonTol="1e-8"
+                    newtonMaxIter="20"/>
+            <LinearSolverParameters
+                    directParallel="0"/>
+        </CompositionalMultiphaseReservoir>
+
+        <CompositionalMultiphaseHybridFVM
+                name="compositionalMultiphaseFlow"
+                logLevel="1"
+                discretization="fluidHM"
+                targetRelativePressureChangeInTimeStep="1"
+                targetPhaseVolFractionChangeInTimeStep="1"
+                targetRegions="{ region }"
+                temperature="297.15"
+                useMass="1"/>
+        <CompositionalMultiphaseWell
+                name="compositionalMultiphaseWell"
+                logLevel="1"
+                targetRegions="{ wellRegion1, wellRegion2 }"
+                maxRelativePressureChange="0.1"
+                maxCompFractionChange="0.1"
+                useMass="1">
+            <WellControls
+                    name="wellControls1"
+                    type="producer"
+                    control="BHP"
+                    referenceElevation="9"
+                    targetBHP="1.2e+7"
+                    targetPhaseRate="5e-2"
+                    targetPhaseName="oil"/>
+            <WellControls
+                    name="wellControls2"
+                    type="injector"
+                    control="BHP"
+                    referenceElevation="9"
+                    targetBHP="2e+7"
+                    targetTotalRate="5e-2"
+                    injectionTemperature="297.15"
+                    injectionStream="{ 0.000, 0.000, 1. }"/>
+        </CompositionalMultiphaseWell>
+    </Solvers>
+
+    <Mesh>
+
+        <InternalMesh
+                name="mesh"
+                elementTypes="{ C3D8 }"
+                xCoords="{ 0, 200 }"
+                yCoords="{ 0, 200 }"
+                zCoords="{ 0, 10 }"
+                nx="{ 4 }"
+                ny="{ 4 }"
+                nz="{ 2 }"
+                cellBlockNames="{ cb }"/>
+
+        <InternalWell
+                name="wellProducer"
+                wellRegionName="wellRegion1"
+                wellControlsName="wellControls1"
+                meshName="mesh"
+                polylineNodeCoords="{ { 5.0, 5.0, 2.0 },
+                            { 5.0, 5.0, 0.0 } }"
+                polylineSegmentConn="{ { 0, 1 } }"
+                radius="0.1"
+                numElementsPerSegment="1">
+            <Perforation
+                    name="producerPerf1"
+                    distanceFromHead="1.00"/>
+        </InternalWell>
+        <InternalWell
+                name="wellInjector"
+                wellRegionName="wellRegion2"
+                wellControlsName="wellControls2"
+                meshName="mesh"
+                polylineNodeCoords="{ { 195.0, 195.0, 2.0 },
+                            { 195.0, 195.0, 0.0 } }"
+                polylineSegmentConn="{ { 0, 1 } }"
+                radius="0.1"
+                numElementsPerSegment="1">
+            <Perforation
+                    name="injectorPerf1"
+                    distanceFromHead="1.00"/>
+        </InternalWell>
+    </Mesh>
+
+    <Events
+            maxTime="3153600">
+
+        <PeriodicEvent
+                name="outputs"
+                timeFrequency="3153600"
+                targetExactTimestep="1"
+                target="/Outputs/vtkOutput"/>
+
+        <PeriodicEvent
+                name="timeHistoryOutput"
+                timeFrequency="3153600"
+                targetExactTimestep="1"
+                target="/Outputs/timeHistoryOutput"/>
+
+        <PeriodicEvent
+                name="restarts"
+                timeFrequency="1576800"
+                targetExactTimestep="1"
+                target="/Outputs/restartOutput"/>
+
+        <PeriodicEvent
+                name="solverApplications"
+                maxEventDt="315360"
+                target="/Solvers/reservoirSystem"/>
+
+        <PeriodicEvent
+                name="statistics"
+                timeFrequency="3153600"
+                target="/Tasks/compositionalMultiphaseFlowStatistics"/>
+
+        <PeriodicEvent
+                name="timeHistoryCollection"
+                timeFrequency="315360"
+                targetExactTimestep="1"
+                target="/Tasks/wellRateCollection"/>
+
+    </Events>
+
+    <NumericalMethods>
+        <FiniteVolume>
+            <HybridMimeticDiscretization
+                    name="fluidHM"
+                    innerProductType="TPFA"/>
+        </FiniteVolume>
+    </NumericalMethods>
+
+    <ElementRegions>
+        <CellElementRegion
+                name="region"
+                cellBlocks="{ cb }"
+                materialList="{ fluid, rock, relperm }"/>
+        <WellElementRegion
+                name="wellRegion1"
+                materialList="{ fluid, relperm }"/>
+        <WellElementRegion
+                name="wellRegion2"
+                materialList="{ fluid, relperm }"/>
+    </ElementRegions>
+
+    <Constitutive>
+        <BlackOilFluid
+                name="fluid"
+                phaseNames="{ oil, gas, water }"
+                surfaceDensities="{ 800.907131537, 0.856234902739, 1020.3440 }"
+                componentMolarWeight="{ 120e-3, 25e-3, 18e-3 }"
+                tableFiles="{ pvto_bo.txt, pvtg_norv_bo.txt, pvtw_bo.txt }"/>
+
+        <CompressibleSolidConstantPermeability
+                name="rock"
+                solidModelName="nullSolid"
+                porosityModelName="rockPorosity"
+                permeabilityModelName="rockPerm"/>
+
+        <NullModel
+                name="nullSolid"/>
+
+        <PressurePorosity
+                name="rockPorosity"
+                defaultReferencePorosity="0.2"
+                referencePressure="4.1369e7"
+                compressibility="1.0e-9"/>
+
+        <BrooksCoreyStone2RelativePermeability
+                name="relperm"
+                phaseNames="{ oil, gas, water }"
+                phaseMinVolumeFraction="{ 0.0, 0.0, 0.0}"
+                waterOilRelPermExponent="{ 2.0, 2.0}"
+                gasOilRelPermExponent="{ 2.0, 2.0 }"
+                waterOilRelPermMaxValue="{ 1.0, 1.0 }"
+                gasOilRelPermMaxValue="{ 1.0, 1.0 }"/>
+
+        <ConstantPermeability
+                name="rockPerm"
+                permeabilityComponents="{ 1.0e-14, 1.0e-14, 1.0e-14 }"/>
+
+    </Constitutive>
+
+    <FieldSpecifications>
+
+        <FieldSpecification
+                name="initialPressure"
+                initialCondition="1"
+                setNames="{ all }"
+                objectPath="ElementRegions/region/cb"
+                fieldName="pressure"
+                scale="1.5e+7"/>
+        <FieldSpecification
+                name="initialComposition_oil"
+                initialCondition="1"
+                setNames="{ all }"
+                objectPath="ElementRegions/region/cb"
+                fieldName="globalCompFraction"
+                component="0"
+                scale="0.89999"/>
+        <FieldSpecification
+                name="initialComposition_gas"
+                initialCondition="1"
+                setNames="{ all }"
+                objectPath="ElementRegions/region/cb"
+                fieldName="globalCompFraction"
+                component="1"
+                scale="0.1"/>
+        <FieldSpecification
+                name="initialComposition_water"
+                initialCondition="1"
+                setNames="{ all }"
+                objectPath="ElementRegions/region/cb"
+                fieldName="globalCompFraction"
+                component="2"
+                scale="0.00001"/>
+    </FieldSpecifications>
+
+    <Tasks>
+        <CompositionalMultiphaseStatistics
+                name="compositionalMultiphaseFlowStatistics"
+                flowSolverName="compositionalMultiphaseFlow"
+                logLevel="1"
+                computeCFLNumbers="0"
+                computeRegionStatistics="1"/>
+
+        <PackCollection
+                name="wellRateCollection"
+                objectPath="ElementRegions/wellRegion1/wellRegion1UniqueSubRegion"
+                fieldName="wellElementMixtureConnectionRate"/>
+    </Tasks>
+
+    <Outputs>
+        <VTK
+                name="vtkOutput"/>
+
+        <TimeHistory
+                name="timeHistoryOutput"
+                sources="{ /Tasks/wellRateCollection }"
+                filename="wellRateHistory"/>
+
+        <Restart
+                name="restartOutput"/>
+
+    </Outputs>
+
+</Problem>

--- a/src/coreComponents/constitutive/CMakeLists.txt
+++ b/src/coreComponents/constitutive/CMakeLists.txt
@@ -84,6 +84,7 @@ set( constitutive_headers
      relativePermeability/RelpermDriver.hpp
      relativePermeability/RelpermDriverRunTest.hpp
      relativePermeability/BrooksCoreyBakerRelativePermeability.hpp
+     relativePermeability/BrooksCoreyStone2RelativePermeability.hpp
      relativePermeability/BrooksCoreyRelativePermeability.hpp
      relativePermeability/RelativePermeabilityBase.hpp
      relativePermeability/RelativePermeabilityFields.hpp
@@ -205,16 +206,20 @@ set( constitutive_sources
      permeability/SlipDependentPermeability.cpp
      permeability/WillisRichardsPermeability.cpp
      relativePermeability/BrooksCoreyBakerRelativePermeability.cpp
+     relativePermeability/BrooksCoreyStone2RelativePermeability.cpp
      relativePermeability/BrooksCoreyRelativePermeability.cpp
      relativePermeability/RelativePermeabilityBase.cpp
      relativePermeability/TableRelativePermeability.cpp
      relativePermeability/TableRelativePermeabilityHelpers.cpp
      relativePermeability/TableRelativePermeabilityHysteresis.cpp
      relativePermeability/VanGenuchtenBakerRelativePermeability.cpp
+     relativePermeability/VanGenuchtenStone2RelativePermeability.cpp
      relativePermeability/RelpermDriver.cpp
      relativePermeability/RelpermDriverBrooksCoreyBakerRunTest.cpp
+        relativePermeability/RelpermDriverBrooksCoreyStone2RunTest.cpp
      relativePermeability/RelpermDriverBrooksCoreyRunTest.cpp
      relativePermeability/RelpermDriverVanGenuchtenBakerRunTest.cpp
+        relativePermeability/RelpermDriverVanGenuchtenStone2RunTest.cpp
      relativePermeability/RelpermDriverTableRelativeRunTest.cpp
      relativePermeability/RelpermDriverTableRelativeHysteresisRunTest.cpp
      solid/CompressibleSolid.cpp

--- a/src/coreComponents/constitutive/CMakeLists.txt
+++ b/src/coreComponents/constitutive/CMakeLists.txt
@@ -92,6 +92,7 @@ set( constitutive_headers
      relativePermeability/TableRelativePermeabilityHelpers.hpp
      relativePermeability/TableRelativePermeabilityHysteresis.hpp
      relativePermeability/VanGenuchtenBakerRelativePermeability.hpp
+     relativePermeability/VanGenuchtenStone2RelativePermeability.hpp
      relativePermeability/layouts.hpp
      relativePermeability/RelativePermeabilitySelector.hpp
      solid/CompressibleSolid.hpp

--- a/src/coreComponents/constitutive/docs/ThreePhaseRelativePermeability.rst
+++ b/src/coreComponents/constitutive/docs/ThreePhaseRelativePermeability.rst
@@ -37,6 +37,13 @@ by `Baker <http://dx.doi.org/10.2118/17369-MS>`__. Specifically, we compute:
 This procedure provides a simple but effective formula avoiding
 the problems associated with the other interpolation methods (negative values).
 
+Another option can be triggered using `FlagInterpolator` to set interpolation model to be STONEII described by:
+
+.. math::
+    k_ro = k_rocw ((k_row/k_rocw + k_rw)(k_rog/k_rocw + k_rg) - k_rw - k_rg)
+
+...
+
 Parameters
 ======================
 

--- a/src/coreComponents/constitutive/relativePermeability/BrooksCoreyStone2RelativePermeability.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/BrooksCoreyStone2RelativePermeability.cpp
@@ -69,14 +69,14 @@ namespace geos
         {
             RelativePermeabilityBase::postProcessInput();
 
-            GEOSX_THROW_IF( m_phaseOrder[PhaseType::OIL] < 0,
-                            GEOSX_FMT( "{}: reference oil phase has not been defined and must be included in model", getFullName() ),
+            GEOS_THROW_IF( m_phaseOrder[PhaseType::OIL] < 0,
+                            GEOS_FMT( "{}: reference oil phase has not been defined and must be included in model", getFullName() ),
                             InputError );
 
             auto const checkInputSize = [&]( auto const & array, localIndex const expected, auto const & attribute )
             {
-                GEOSX_THROW_IF_NE_MSG( array.size(), expected,
-                                       GEOSX_FMT( "{}: invalid number of values in attribute '{}'", getFullName(), attribute ),
+                GEOS_THROW_IF_NE_MSG( array.size(), expected,
+                                       GEOS_FMT( "{}: invalid number of values in attribute '{}'", getFullName(), attribute ),
                                        InputError );
             };
             checkInputSize( m_phaseMinVolumeFraction, numFluidPhases(), viewKeyStruct::phaseMinVolumeFractionString() );
@@ -98,19 +98,19 @@ namespace geos
             {
                 auto const errorMsg = [&]( auto const & attribute )
                 {
-                    return GEOSX_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
+                    return GEOS_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
                 };
-                GEOSX_THROW_IF_LT_MSG( m_phaseMinVolumeFraction[ip], 0.0,
+                GEOS_THROW_IF_LT_MSG( m_phaseMinVolumeFraction[ip], 0.0,
                                        errorMsg( viewKeyStruct::phaseMinVolumeFractionString() ),
                                        InputError );
-                GEOSX_THROW_IF_GT_MSG( m_phaseMinVolumeFraction[ip], 1.0,
+                GEOS_THROW_IF_GT_MSG( m_phaseMinVolumeFraction[ip], 1.0,
                                        errorMsg( viewKeyStruct::phaseMinVolumeFractionString() ),
                                        InputError );
                 m_volFracScale -= m_phaseMinVolumeFraction[ip];
             }
 
-            GEOSX_THROW_IF_LT_MSG( m_volFracScale, 0.0,
-                                   GEOSX_FMT( "{}: sum of min volume fractions exceeds 1.0", getFullName() ),
+            GEOS_THROW_IF_LT_MSG( m_volFracScale, 0.0,
+                                   GEOS_FMT( "{}: sum of min volume fractions exceeds 1.0", getFullName() ),
                                    InputError );
 
 
@@ -118,30 +118,30 @@ namespace geos
             {
                 auto const errorMsg = [&]( auto const & attribute )
                 {
-                    return GEOSX_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
+                    return GEOS_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
                 };
                 if( m_phaseOrder[PhaseType::WATER] >= 0 )
                 {
-                    GEOSX_THROW_IF_LT_MSG( m_waterOilRelPermExponent[ip], 0.0,
+                    GEOS_THROW_IF_LT_MSG( m_waterOilRelPermExponent[ip], 0.0,
                                            errorMsg( viewKeyStruct::waterOilRelPermExponentString() ),
                                            InputError );
-                    GEOSX_THROW_IF_LT_MSG( m_waterOilRelPermMaxValue[ip], 0.0,
+                    GEOS_THROW_IF_LT_MSG( m_waterOilRelPermMaxValue[ip], 0.0,
                                            errorMsg( viewKeyStruct::waterOilRelPermMaxValueString() ),
                                            InputError );
-                    GEOSX_THROW_IF_GT_MSG( m_waterOilRelPermMaxValue[ip], 1.0,
+                    GEOS_THROW_IF_GT_MSG( m_waterOilRelPermMaxValue[ip], 1.0,
                                            errorMsg( viewKeyStruct::waterOilRelPermMaxValueString() ),
                                            InputError );
                 }
 
                 if( m_phaseOrder[PhaseType::GAS] >= 0 )
                 {
-                    GEOSX_THROW_IF_LT_MSG( m_gasOilRelPermExponent[ip], 0.0,
+                    GEOS_THROW_IF_LT_MSG( m_gasOilRelPermExponent[ip], 0.0,
                                            errorMsg( viewKeyStruct::gasOilRelPermExponentString() ),
                                            InputError );
-                    GEOSX_THROW_IF_LT_MSG( m_gasOilRelPermMaxValue[ip], 0.0,
+                    GEOS_THROW_IF_LT_MSG( m_gasOilRelPermMaxValue[ip], 0.0,
                                            errorMsg( viewKeyStruct::gasOilRelPermMaxValueString() ),
                                            InputError );
-                    GEOSX_THROW_IF_GT_MSG( m_gasOilRelPermMaxValue[ip], 1.0,
+                    GEOS_THROW_IF_GT_MSG( m_gasOilRelPermMaxValue[ip], 1.0,
                                            errorMsg( viewKeyStruct::gasOilRelPermMaxValueString() ),
                                            InputError );
                 }

--- a/src/coreComponents/constitutive/relativePermeability/BrooksCoreyStone2RelativePermeability.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/BrooksCoreyStone2RelativePermeability.cpp
@@ -1,0 +1,178 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file BrooksCoreyStone2RelativePermeability.cpp
+ */
+
+#include "BrooksCoreyStone2RelativePermeability.hpp"
+
+namespace geos
+{
+
+    using namespace dataRepository;
+
+    namespace constitutive
+    {
+
+        BrooksCoreyStone2RelativePermeability::BrooksCoreyStone2RelativePermeability( string const & name,
+                                                                                    Group * const parent )
+                : RelativePermeabilityBase( name, parent )
+        {
+            registerWrapper( viewKeyStruct::phaseMinVolumeFractionString(), &m_phaseMinVolumeFraction ).
+                    setApplyDefaultValue( 0.0 ).
+                    setInputFlag( InputFlags::OPTIONAL ).
+                    setDescription( "Minimum volume fraction value for each phase" );
+
+            registerWrapper( viewKeyStruct::waterOilRelPermExponentString(), &m_waterOilRelPermExponent ).
+                    setApplyDefaultValue( 1.0 ).
+                    setInputFlag( InputFlags::OPTIONAL ).
+                    setDescription( "Rel perm power law exponent for the pair (water phase, oil phase) at residual gas saturation\n"
+                                    "The expected format is \"{ waterExp, oilExp }\", in that order" );
+
+            registerWrapper( viewKeyStruct::waterOilRelPermMaxValueString(), &m_waterOilRelPermMaxValue ).
+                    setApplyDefaultValue( 0.0 ).
+                    setInputFlag( InputFlags::OPTIONAL ).
+                    setDescription( "Maximum rel perm value for the pair (water phase, oil phase) at residual gas saturation\n"
+                                    "The expected format is \"{ waterMax, oilMax }\", in that order" );
+
+            registerWrapper( viewKeyStruct::gasOilRelPermExponentString(), &m_gasOilRelPermExponent ).
+                    setApplyDefaultValue( 1.0 ).
+                    setInputFlag( InputFlags::OPTIONAL ).
+                    setDescription( "Rel perm power law exponent for the pair (gas phase, oil phase) at residual water saturation\n"
+                                    "The expected format is \"{ gasExp, oilExp }\", in that order" );
+
+            registerWrapper( viewKeyStruct::gasOilRelPermMaxValueString(), &m_gasOilRelPermMaxValue ).
+                    setApplyDefaultValue( 0.0 ).
+                    setInputFlag( InputFlags::OPTIONAL ).
+                    setDescription( "Maximum rel perm value for the pair (gas phase, oil phase) at residual water saturation\n"
+                                    "The expected format is \"{ gasMax, oilMax }\", in that order" );
+
+            registerWrapper( viewKeyStruct::volFracScaleString(), &m_volFracScale ).
+                    setApplyDefaultValue( 1.0 ).
+                    setDescription( "Factor used to scale the phase capillary pressure, defined as: one minus the sum of the phase minimum volume fractions." );
+
+        }
+
+        void BrooksCoreyStone2RelativePermeability::postProcessInput()
+        {
+            RelativePermeabilityBase::postProcessInput();
+
+            GEOSX_THROW_IF( m_phaseOrder[PhaseType::OIL] < 0,
+                            GEOSX_FMT( "{}: reference oil phase has not been defined and must be included in model", getFullName() ),
+                            InputError );
+
+            auto const checkInputSize = [&]( auto const & array, localIndex const expected, auto const & attribute )
+            {
+                GEOSX_THROW_IF_NE_MSG( array.size(), expected,
+                                       GEOSX_FMT( "{}: invalid number of values in attribute '{}'", getFullName(), attribute ),
+                                       InputError );
+            };
+            checkInputSize( m_phaseMinVolumeFraction, numFluidPhases(), viewKeyStruct::phaseMinVolumeFractionString() );
+
+            if( m_phaseOrder[PhaseType::WATER] >= 0 )
+            {
+                checkInputSize( m_waterOilRelPermExponent, 2, viewKeyStruct::waterOilRelPermExponentString() );
+                checkInputSize( m_waterOilRelPermMaxValue, 2, viewKeyStruct::waterOilRelPermMaxValueString() );
+            }
+
+            if( m_phaseOrder[PhaseType::GAS] >=0 )
+            {
+                checkInputSize( m_gasOilRelPermExponent, 2, viewKeyStruct::gasOilRelPermExponentString() );
+                checkInputSize( m_gasOilRelPermMaxValue, 2, viewKeyStruct::gasOilRelPermMaxValueString() );
+            }
+
+            m_volFracScale = 1.0;
+            for( integer ip = 0; ip < numFluidPhases(); ++ip )
+            {
+                auto const errorMsg = [&]( auto const & attribute )
+                {
+                    return GEOSX_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
+                };
+                GEOSX_THROW_IF_LT_MSG( m_phaseMinVolumeFraction[ip], 0.0,
+                                       errorMsg( viewKeyStruct::phaseMinVolumeFractionString() ),
+                                       InputError );
+                GEOSX_THROW_IF_GT_MSG( m_phaseMinVolumeFraction[ip], 1.0,
+                                       errorMsg( viewKeyStruct::phaseMinVolumeFractionString() ),
+                                       InputError );
+                m_volFracScale -= m_phaseMinVolumeFraction[ip];
+            }
+
+            GEOSX_THROW_IF_LT_MSG( m_volFracScale, 0.0,
+                                   GEOSX_FMT( "{}: sum of min volume fractions exceeds 1.0", getFullName() ),
+                                   InputError );
+
+
+            for( integer ip = 0; ip < 2; ++ip )
+            {
+                auto const errorMsg = [&]( auto const & attribute )
+                {
+                    return GEOSX_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
+                };
+                if( m_phaseOrder[PhaseType::WATER] >= 0 )
+                {
+                    GEOSX_THROW_IF_LT_MSG( m_waterOilRelPermExponent[ip], 0.0,
+                                           errorMsg( viewKeyStruct::waterOilRelPermExponentString() ),
+                                           InputError );
+                    GEOSX_THROW_IF_LT_MSG( m_waterOilRelPermMaxValue[ip], 0.0,
+                                           errorMsg( viewKeyStruct::waterOilRelPermMaxValueString() ),
+                                           InputError );
+                    GEOSX_THROW_IF_GT_MSG( m_waterOilRelPermMaxValue[ip], 1.0,
+                                           errorMsg( viewKeyStruct::waterOilRelPermMaxValueString() ),
+                                           InputError );
+                }
+
+                if( m_phaseOrder[PhaseType::GAS] >= 0 )
+                {
+                    GEOSX_THROW_IF_LT_MSG( m_gasOilRelPermExponent[ip], 0.0,
+                                           errorMsg( viewKeyStruct::gasOilRelPermExponentString() ),
+                                           InputError );
+                    GEOSX_THROW_IF_LT_MSG( m_gasOilRelPermMaxValue[ip], 0.0,
+                                           errorMsg( viewKeyStruct::gasOilRelPermMaxValueString() ),
+                                           InputError );
+                    GEOSX_THROW_IF_GT_MSG( m_gasOilRelPermMaxValue[ip], 1.0,
+                                           errorMsg( viewKeyStruct::gasOilRelPermMaxValueString() ),
+                                           InputError );
+                }
+            }
+
+            if( m_phaseOrder[PhaseType::WATER] >= 0 && m_phaseOrder[PhaseType::GAS] >= 0 )
+            {
+                real64 const mean = 0.5 * ( m_gasOilRelPermMaxValue[GasOilPairPhaseType::OIL]
+                                            + m_waterOilRelPermMaxValue[WaterOilPairPhaseType::OIL] );
+                m_gasOilRelPermMaxValue[GasOilPairPhaseType::OIL]     = mean;
+                m_waterOilRelPermMaxValue[WaterOilPairPhaseType::OIL] = mean;
+            }
+        }
+
+        BrooksCoreyStone2RelativePermeability::KernelWrapper
+        BrooksCoreyStone2RelativePermeability::createKernelWrapper()
+        {
+            return KernelWrapper( m_phaseMinVolumeFraction,
+                                  m_waterOilRelPermExponent,
+                                  m_waterOilRelPermMaxValue,
+                                  m_gasOilRelPermExponent,
+                                  m_gasOilRelPermMaxValue,
+                                  m_volFracScale,
+                                  m_phaseTypes,
+                                  m_phaseOrder,
+                                  m_phaseRelPerm,
+                                  m_dPhaseRelPerm_dPhaseVolFrac,
+                                  m_phaseTrappedVolFrac );
+        }
+
+        REGISTER_CATALOG_ENTRY( ConstitutiveBase, BrooksCoreyStone2RelativePermeability, string const &, Group * const )
+    } // namespace constitutive
+
+} // namespace geos

--- a/src/coreComponents/constitutive/relativePermeability/BrooksCoreyStone2RelativePermeability.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/BrooksCoreyStone2RelativePermeability.hpp
@@ -13,25 +13,25 @@
  */
 
 /**
- * @file BrooksCoreyBakerRelativePermeability.hpp
+ * @file BrooksCoreyStone2RelativePermeability.hpp
  */
 
-#ifndef GEOS_CONSTITUTIVE_RELPERM_BROOKSCOREYBAKERRELATIVEPERMEABILITY_HPP
-#define GEOS_CONSTITUTIVE_RELPERM_BROOKSCOREYBAKERRELATIVEPERMEABILITY_HPP
+#ifndef GEOSX_CONSTITUTIVE_RELPERM_BROOKSCOREYSTONE2RELATIVEPERMEABILITY_HPP
+#define GEOSX_CONSTITUTIVE_RELPERM_BROOKSCOREYSTONE2RELATIVEPERMEABILITY_HPP
 
 #include "constitutive/relativePermeability/RelativePermeabilityBase.hpp"
 #include "constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp"
 
-namespace geos
+namespace geosx
 {
 namespace constitutive
 {
 
-class BrooksCoreyBakerRelativePermeabilityUpdate final : public RelativePermeabilityBaseUpdate
+class BrooksCoreyStone2RelativePermeabilityUpdate final : public RelativePermeabilityBaseUpdate
 {
 public:
 
-  BrooksCoreyBakerRelativePermeabilityUpdate( arrayView1d< real64 const > const & phaseMinVolumeFraction,
+  BrooksCoreyStone2RelativePermeabilityUpdate( arrayView1d< real64 const > const & phaseMinVolumeFraction,
                                               arrayView1d< real64 const > const & waterOilRelPermExponent,
                                               arrayView1d< real64 const > const & waterOilRelPermMaxValue,
                                               arrayView1d< real64 const > const & gasOilRelPermExponent,
@@ -40,13 +40,11 @@ public:
                                               arrayView1d< integer const > const & phaseTypes,
                                               arrayView1d< integer const > const & phaseOrder,
                                               arrayView3d< real64, relperm::USD_RELPERM > const & phaseRelPerm,
-                                              arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac,
-                                              arrayView3d< real64, relperm::USD_RELPERM > const & phaseTrappedVolFrac )
+                                              arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac )
     : RelativePermeabilityBaseUpdate( phaseTypes,
                                       phaseOrder,
                                       phaseRelPerm,
-                                      dPhaseRelPerm_dPhaseVolFrac,
-                                      phaseTrappedVolFrac ),
+                                      dPhaseRelPerm_dPhaseVolFrac),
     m_phaseMinVolumeFraction( phaseMinVolumeFraction ),
     m_waterOilRelPermExponent( waterOilRelPermExponent ),
     m_waterOilRelPermMaxValue( waterOilRelPermMaxValue ),
@@ -55,19 +53,17 @@ public:
     m_volFracScale( volFracScale )
   {}
 
-  GEOS_HOST_DEVICE
+  GEOSX_HOST_DEVICE
   void compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
-                arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseTrappedVolFrac,
                 arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseRelPerm,
                 arraySlice2d< real64, relperm::USD_RELPERM_DS - 2 > const & dPhaseRelPerm_dPhaseVolFrac ) const;
 
-  GEOS_HOST_DEVICE
+  GEOSX_HOST_DEVICE
   virtual void update( localIndex const k,
                        localIndex const q,
                        arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction ) const override
   {
     compute( phaseVolFraction,
-             m_phaseTrappedVolFrac[k][q],
              m_phaseRelPerm[k][q],
              m_dPhaseRelPerm_dPhaseVolFrac[k][q] );
   }
@@ -87,8 +83,8 @@ private:
    * This function evaluates the relperm function and its derivative at a given phase saturation
    * Reference: Eclipse technical description and Petrowiki
    */
-  GEOS_HOST_DEVICE
-  GEOS_FORCE_INLINE
+  GEOSX_HOST_DEVICE
+  GEOSX_FORCE_INLINE
   static void
   evaluateBrooksCoreyFunction( real64 const & scaledVolFrac,
                                real64 const & dScaledVolFrac_dVolFrac,
@@ -108,19 +104,18 @@ private:
   real64 m_volFracScale;
 };
 
-//template< class INTERPOLATOR>
-class BrooksCoreyBakerRelativePermeability : public RelativePermeabilityBase
+class BrooksCoreyStone2RelativePermeability : public RelativePermeabilityBase
 {
 public:
 
-  BrooksCoreyBakerRelativePermeability( string const & name, dataRepository::Group * const parent );
+  BrooksCoreyStone2RelativePermeability( string const & name, dataRepository::Group * const parent );
 
-  static string catalogName() { return "BrooksCoreyBakerRelativePermeability"; }
+  static string catalogName() { return "BrooksCoreyStone2RelativePermeability"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 
   /// Type of kernel wrapper for in-kernel update
-  using KernelWrapper = BrooksCoreyBakerRelativePermeabilityUpdate;
+  using KernelWrapper = BrooksCoreyStone2RelativePermeabilityUpdate;
 
   /**
    * @brief Create an update kernel wrapper.
@@ -137,9 +132,6 @@ public:
     static constexpr char const * gasOilRelPermMaxValueString() { return "gasOilRelPermMaxValue"; }
     static constexpr char const * volFracScaleString() { return "volFracScale"; }
   };
-
-
-  arrayView1d< real64 const > getPhaseMinVolumeFraction() const override { return m_phaseMinVolumeFraction; };
 
 protected:
 
@@ -159,11 +151,10 @@ protected:
 };
 
 
-GEOS_HOST_DEVICE
+GEOSX_HOST_DEVICE
 inline void
-BrooksCoreyBakerRelativePermeabilityUpdate::
+BrooksCoreyStone2RelativePermeabilityUpdate::
   compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
-           arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseTrappedVolFrac,
            arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseRelPerm,
            arraySlice2d< real64, relperm::USD_RELPERM_DS - 2 > const & dPhaseRelPerm_dPhaseVolFrac ) const
 {
@@ -264,53 +255,21 @@ BrooksCoreyBakerRelativePermeabilityUpdate::
     real64 const shiftedWaterVolFrac = (phaseVolFraction[ipWater] - m_phaseMinVolumeFraction[ipWater]);
 
     // TODO: change name of the class and add template to choose interpolation
-    relpermInterpolators::Baker::compute( shiftedWaterVolFrac,
+    relpermInterpolators::Stone2::compute(shiftedWaterVolFrac,
                                           phaseVolFraction[ipGas],
-                                          m_phaseOrder,
+                                          m_waterOilRelPermMaxValue[ipOil],
                                           oilRelPerm_wo,
-                                          dOilRelPerm_wo_dOilVolFrac,
                                           oilRelPerm_go,
-                                          dOilRelPerm_go_dOilVolFrac,
-                                          phaseRelPerm[ipOil],
-                                          dPhaseRelPerm_dPhaseVolFrac[ipOil] );
-//    relpermInterpolators::Stone2::compute(shiftedWaterVolFrac,
-//                                          phaseVolFraction[ipGas],
-//                                          m_phaseOrder,
-//                                          m_waterOilRelPermMaxValue[ipOil],
-//                                          oilRelPerm_wo,
-//                                          dOilRelPerm_wo_dOilVolFrac,
-//                                          oilRelPerm_go,
-//                                          dOilRelPerm_go_dOilVolFrac,
-//                                          phaseRelPerm[ipWater],
-//                                          dPhaseRelPerm_dPhaseVolFrac[ipWater][ipWater],
-//                                          phaseRelPerm[ipGas],
-//                                          dPhaseRelPerm_dPhaseVolFrac[ipGas][ipGas],
-//                                          phaseRelPerm[ipOil],
-//                                          dPhaseRelPerm_dPhaseVolFrac[ipOil] );
-//    INTERPOLATOR::compute(...);
-
+                                          phaseRelPerm[ipWater],
+                                          phaseRelPerm[ipGas],
+                                          phaseRelPerm[ipOil]);
   }
-
-  // update trapped phase volume fraction
-  if( ipWater >= 0 )
-  {
-    phaseTrappedVolFrac[ipWater] = LvArray::math::min( phaseVolFraction[ipWater], m_phaseMinVolumeFraction[ipWater] );
-  }
-  if( ipGas >= 0 )
-  {
-    phaseTrappedVolFrac[ipGas] = LvArray::math::min( phaseVolFraction[ipGas], m_phaseMinVolumeFraction[ipGas] );
-  }
-  if( ipOil >= 0 )
-  {
-    phaseTrappedVolFrac[ipOil] = LvArray::math::min( phaseVolFraction[ipOil], m_phaseMinVolumeFraction[ipOil] );
-  }
-
 }
 
-GEOS_HOST_DEVICE
-GEOS_FORCE_INLINE
+GEOSX_HOST_DEVICE
+GEOSX_FORCE_INLINE
 void
-BrooksCoreyBakerRelativePermeabilityUpdate::
+BrooksCoreyStone2RelativePermeabilityUpdate::
   evaluateBrooksCoreyFunction( real64 const & scaledVolFrac,
                                real64 const & dScaledVolFrac_dVolFrac,
                                real64 const & exponent,
@@ -337,6 +296,6 @@ BrooksCoreyBakerRelativePermeabilityUpdate::
 
 } // namespace constitutive
 
-} // namespace geos
+} // namespace geosx
 
-#endif //GEOS_CONSTITUTIVE_RELPERM_BROOKSCOREYBAKERRELATIVEPERMEABILITY_HPP
+#endif //GEOSX_CONSTITUTIVE_RELPERM_BROOKSCOREYBAKERRELATIVEPERMEABILITY_HPP

--- a/src/coreComponents/constitutive/relativePermeability/BrooksCoreyStone2RelativePermeability.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/BrooksCoreyStone2RelativePermeability.hpp
@@ -16,13 +16,13 @@
  * @file BrooksCoreyStone2RelativePermeability.hpp
  */
 
-#ifndef GEOSX_CONSTITUTIVE_RELPERM_BROOKSCOREYSTONE2RELATIVEPERMEABILITY_HPP
-#define GEOSX_CONSTITUTIVE_RELPERM_BROOKSCOREYSTONE2RELATIVEPERMEABILITY_HPP
+#ifndef GEOS_CONSTITUTIVE_RELPERM_BROOKSCOREYSTONE2RELATIVEPERMEABILITY_HPP
+#define GEOS_CONSTITUTIVE_RELPERM_BROOKSCOREYSTONE2RELATIVEPERMEABILITY_HPP
 
 #include "constitutive/relativePermeability/RelativePermeabilityBase.hpp"
 #include "constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp"
 
-namespace geosx
+namespace geos
 {
 namespace constitutive
 {
@@ -55,13 +55,13 @@ public:
     m_volFracScale( volFracScale )
   {}
 
-  GEOSX_HOST_DEVICE
+  GEOS_HOST_DEVICE
   void compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
                 arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseTrappedVolFrac,
                 arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseRelPerm,
                 arraySlice2d< real64, relperm::USD_RELPERM_DS - 2 > const & dPhaseRelPerm_dPhaseVolFrac ) const;
 
-  GEOSX_HOST_DEVICE
+  GEOS_HOST_DEVICE
   virtual void update( localIndex const k,
                        localIndex const q,
                        arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction ) const override
@@ -87,8 +87,8 @@ private:
    * This function evaluates the relperm function and its derivative at a given phase saturation
    * Reference: Eclipse technical description and Petrowiki
    */
-  GEOSX_HOST_DEVICE
-  GEOSX_FORCE_INLINE
+  GEOS_HOST_DEVICE
+  inline
   static void
   evaluateBrooksCoreyFunction( real64 const & scaledVolFrac,
                                real64 const & dScaledVolFrac_dVolFrac,
@@ -157,7 +157,7 @@ protected:
 };
 
 
-GEOSX_HOST_DEVICE
+GEOS_HOST_DEVICE
 inline void
 BrooksCoreyStone2RelativePermeabilityUpdate::
   compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
@@ -294,8 +294,8 @@ BrooksCoreyStone2RelativePermeabilityUpdate::
 
 }
 
-GEOSX_HOST_DEVICE
-GEOSX_FORCE_INLINE
+GEOS_HOST_DEVICE
+inline
 void
 BrooksCoreyStone2RelativePermeabilityUpdate::
   evaluateBrooksCoreyFunction( real64 const & scaledVolFrac,
@@ -324,6 +324,6 @@ BrooksCoreyStone2RelativePermeabilityUpdate::
 
 } // namespace constitutive
 
-} // namespace geosx
+} // namespace geos
 
-#endif //GEOSX_CONSTITUTIVE_RELPERM_BROOKSCOREYSTONE2RELATIVEPERMEABILITY_HPP
+#endif //GEOS_CONSTITUTIVE_RELPERM_BROOKSCOREYSTONE2RELATIVEPERMEABILITY_HPP

--- a/src/coreComponents/constitutive/relativePermeability/BrooksCoreyStone2RelativePermeability.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/BrooksCoreyStone2RelativePermeability.hpp
@@ -31,20 +31,22 @@ class BrooksCoreyStone2RelativePermeabilityUpdate final : public RelativePermeab
 {
 public:
 
-  BrooksCoreyStone2RelativePermeabilityUpdate( arrayView1d< real64 const > const & phaseMinVolumeFraction,
-                                              arrayView1d< real64 const > const & waterOilRelPermExponent,
-                                              arrayView1d< real64 const > const & waterOilRelPermMaxValue,
-                                              arrayView1d< real64 const > const & gasOilRelPermExponent,
-                                              arrayView1d< real64 const > const & gasOilRelPermMaxValue,
-                                              real64 const volFracScale,
-                                              arrayView1d< integer const > const & phaseTypes,
-                                              arrayView1d< integer const > const & phaseOrder,
-                                              arrayView3d< real64, relperm::USD_RELPERM > const & phaseRelPerm,
-                                              arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac )
+    BrooksCoreyStone2RelativePermeabilityUpdate( arrayView1d< real64 const > const & phaseMinVolumeFraction,
+                                                 arrayView1d< real64 const > const & waterOilRelPermExponent,
+                                                 arrayView1d< real64 const > const & waterOilRelPermMaxValue,
+                                                 arrayView1d< real64 const > const & gasOilRelPermExponent,
+                                                 arrayView1d< real64 const > const & gasOilRelPermMaxValue,
+                                                 real64 const volFracScale,
+                                                 arrayView1d< integer const > const & phaseTypes,
+                                                 arrayView1d< integer const > const & phaseOrder,
+                                                 arrayView3d< real64, relperm::USD_RELPERM > const & phaseRelPerm,
+                                                 arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac,
+                                                 arrayView3d< real64, relperm::USD_RELPERM > const & phaseTrappedVolFrac )
     : RelativePermeabilityBaseUpdate( phaseTypes,
-                                      phaseOrder,
-                                      phaseRelPerm,
-                                      dPhaseRelPerm_dPhaseVolFrac),
+            phaseOrder,
+            phaseRelPerm,
+            dPhaseRelPerm_dPhaseVolFrac,
+            phaseTrappedVolFrac ),
     m_phaseMinVolumeFraction( phaseMinVolumeFraction ),
     m_waterOilRelPermExponent( waterOilRelPermExponent ),
     m_waterOilRelPermMaxValue( waterOilRelPermMaxValue ),
@@ -55,6 +57,7 @@ public:
 
   GEOSX_HOST_DEVICE
   void compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
+                arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseTrappedVolFrac,
                 arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseRelPerm,
                 arraySlice2d< real64, relperm::USD_RELPERM_DS - 2 > const & dPhaseRelPerm_dPhaseVolFrac ) const;
 
@@ -64,6 +67,7 @@ public:
                        arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction ) const override
   {
     compute( phaseVolFraction,
+             m_phaseTrappedVolFrac[k][q],
              m_phaseRelPerm[k][q],
              m_dPhaseRelPerm_dPhaseVolFrac[k][q] );
   }
@@ -133,6 +137,8 @@ public:
     static constexpr char const * volFracScaleString() { return "volFracScale"; }
   };
 
+    arrayView1d< real64 const > getPhaseMinVolumeFraction() const override { return m_phaseMinVolumeFraction; };
+
 protected:
 
   virtual void postProcessInput() override;
@@ -155,6 +161,7 @@ GEOSX_HOST_DEVICE
 inline void
 BrooksCoreyStone2RelativePermeabilityUpdate::
   compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
+           arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseTrappedVolFrac,
            arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseRelPerm,
            arraySlice2d< real64, relperm::USD_RELPERM_DS - 2 > const & dPhaseRelPerm_dPhaseVolFrac ) const
 {
@@ -255,15 +262,36 @@ BrooksCoreyStone2RelativePermeabilityUpdate::
     real64 const shiftedWaterVolFrac = (phaseVolFraction[ipWater] - m_phaseMinVolumeFraction[ipWater]);
 
     // TODO: change name of the class and add template to choose interpolation
-    relpermInterpolators::Stone2::compute(shiftedWaterVolFrac,
-                                          phaseVolFraction[ipGas],
-                                          m_waterOilRelPermMaxValue[ipOil],
-                                          oilRelPerm_wo,
-                                          oilRelPerm_go,
-                                          phaseRelPerm[ipWater],
-                                          phaseRelPerm[ipGas],
-                                          phaseRelPerm[ipOil]);
+      relpermInterpolators::Stone2::compute(shiftedWaterVolFrac,
+                                            phaseVolFraction[ipGas],
+                                            m_phaseOrder,
+                                            m_waterOilRelPermMaxValue[ipOil],
+                                            oilRelPerm_wo,
+                                            dOilRelPerm_wo_dOilVolFrac,
+                                            oilRelPerm_go,
+                                            dOilRelPerm_go_dOilVolFrac,
+                                            phaseRelPerm[ipWater],
+                                            dPhaseRelPerm_dPhaseVolFrac[ipWater][ipWater],
+                                            phaseRelPerm[ipGas],
+                                            dPhaseRelPerm_dPhaseVolFrac[ipGas][ipGas],
+                                            phaseRelPerm[ipOil],
+                                            dPhaseRelPerm_dPhaseVolFrac[ipOil] );
   }
+
+    // update trapped phase volume fraction
+    if( ipWater >= 0 )
+    {
+        phaseTrappedVolFrac[ipWater] = LvArray::math::min( phaseVolFraction[ipWater], m_phaseMinVolumeFraction[ipWater] );
+    }
+    if( ipGas >= 0 )
+    {
+        phaseTrappedVolFrac[ipGas] = LvArray::math::min( phaseVolFraction[ipGas], m_phaseMinVolumeFraction[ipGas] );
+    }
+    if( ipOil >= 0 )
+    {
+        phaseTrappedVolFrac[ipOil] = LvArray::math::min( phaseVolFraction[ipOil], m_phaseMinVolumeFraction[ipOil] );
+    }
+
 }
 
 GEOSX_HOST_DEVICE
@@ -298,4 +326,4 @@ BrooksCoreyStone2RelativePermeabilityUpdate::
 
 } // namespace geosx
 
-#endif //GEOSX_CONSTITUTIVE_RELPERM_BROOKSCOREYBAKERRELATIVEPERMEABILITY_HPP
+#endif //GEOSX_CONSTITUTIVE_RELPERM_BROOKSCOREYSTONE2RELATIVEPERMEABILITY_HPP

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp
@@ -132,8 +132,8 @@ struct Stone2
      * The interpolation is based on the modified Stone 2 method
      * Reference: Eclipse technical description
      */
-  GEOSX_HOST_DEVICE
-  GEOSX_FORCE_INLINE
+  GEOS_HOST_DEVICE
+  GEOS_FORCE_INLINE
   static void compute( real64 const & shiftedWaterVolFrac,
                       real64 const & gasVolFrac,
                       arraySlice1d< integer const > const & phaseOrder,

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp
@@ -162,14 +162,20 @@ struct Stone2
           dThreePhaseRelPerm_dVolFrac[ipOil] = dGoRelPerm_dOilVolFrac;
       } else {
           threePhaseRelPerm = connatewoRelPerm * ((woRelPerm/connatewoRelPerm + wRelPerm)*(goRelPerm/connatewoRelPerm + gRelPerm) - (wRelPerm + gRelPerm));
-//          if (threePhaseRelPerm < 0)
-//              threePhaseRelPerm = 0;
           // derivative w.r.t. Sw
-          dThreePhaseRelPerm_dVolFrac[ipWater] = connatewoRelPerm * ((woRelPerm/connatewoRelPerm + dWRelPerm_dWaterVolFrac)*(goRelPerm/connatewoRelPerm + gRelPerm) - dWRelPerm_dWaterVolFrac);
+          dThreePhaseRelPerm_dVolFrac[ipWater] = dWRelPerm_dWaterVolFrac * (goRelPerm + gRelPerm*connatewoRelPerm - connatewoRelPerm);
           // derivative w.r.t. So
           dThreePhaseRelPerm_dVolFrac[ipOil]   = dWoRelPerm_dOilVolFrac/connatewoRelPerm*goRelPerm + woRelPerm*dGoRelPerm_dOilVolFrac/connatewoRelPerm + wRelPerm*dGoRelPerm_dOilVolFrac + gRelPerm*dWoRelPerm_dOilVolFrac;
           // derivative w.r.t. Sg
-          dThreePhaseRelPerm_dVolFrac[ipGas]   = connatewoRelPerm * ((woRelPerm/connatewoRelPerm + wRelPerm) * (goRelPerm/connatewoRelPerm + dGRelPerm_dGasVolFrac) - dGRelPerm_dGasVolFrac);
+          dThreePhaseRelPerm_dVolFrac[ipGas] = dGRelPerm_dGasVolFrac * (woRelPerm + wRelPerm*connatewoRelPerm - connatewoRelPerm);
+          if (threePhaseRelPerm < 0) {
+              threePhaseRelPerm = 0;
+              dThreePhaseRelPerm_dVolFrac[ipWater] = 0;
+              // derivative w.r.t. So
+              dThreePhaseRelPerm_dVolFrac[ipOil]   = 0;
+              // derivative w.r.t. Sg
+              dThreePhaseRelPerm_dVolFrac[ipGas] = 0;
+          }
       }
 
 

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp
@@ -110,6 +110,73 @@ struct Baker
 
 };
 
+struct Stone2
+{
+    /**
+     * @brief Interpolate the two-phase relperms to compute the three-phase relperm
+     * @param[in] shiftedWaterVolFrac
+     * @param[in] gasVolFrac
+     * @param[in] woRelPerm
+     * @param[in] dWoRelPerm_dOilVolFrac
+     * @param[in] connatewoRelPerm
+     * @param[in] goRelPerm
+     * @param[in] dGoRelPerm_dOilVolFrac
+     * @param[in] wRelPerm
+     * @param[in] dWRelPerm_dWaterVolFrac
+     * @param[in] gRelPerm
+     * @param[in] dGRelPerm_dGasVolFrac
+     * @param[out] threePhaseRelPerm
+     * @param[out] dThreePhaseRelPerm_dVolFrac
+     *
+     * This function interpolates the two-phase relperms to compute the three-phase relperm
+     * The interpolation is based on the modified Stone 2 method
+     * Reference: Eclipse technical description
+     */
+  GEOSX_HOST_DEVICE
+  GEOSX_FORCE_INLINE
+  static void compute( real64 const & shiftedWaterVolFrac,
+                      real64 const & gasVolFrac,
+                      arraySlice1d< integer const > const & phaseOrder,
+                      real64 const & connatewoRelPerm,
+                      real64 const & woRelPerm,
+                      real64 const & dWoRelPerm_dOilVolFrac,
+                      real64 const & goRelPerm,
+                      real64 const & dGoRelPerm_dOilVolFrac,
+                      real64 const & wRelPerm,
+                      real64 const & dWRelPerm_dWaterVolFrac,
+                      real64 const & gRelPerm,
+                      real64 const & dGRelPerm_dGasVolFrac,
+                      real64 & threePhaseRelPerm,
+                      arraySlice1d< real64, relperm::USD_RELPERM_DS - 3 > const & dThreePhaseRelPerm_dVolFrac ) {
+
+      using PT = RelativePermeabilityBase::PhaseType;
+      integer const ipWater = phaseOrder[PT::WATER];
+      integer const ipOil   = phaseOrder[PT::OIL];
+      integer const ipGas   = phaseOrder[PT::GAS];
+
+      if (gasVolFrac <= 0) {
+          threePhaseRelPerm = woRelPerm;
+          dThreePhaseRelPerm_dVolFrac[ipOil] = dWoRelPerm_dOilVolFrac;
+      } else if (shiftedWaterVolFrac <= 0) {
+          threePhaseRelPerm = goRelPerm;
+          dThreePhaseRelPerm_dVolFrac[ipOil] = dGoRelPerm_dOilVolFrac;
+      } else {
+          threePhaseRelPerm = connatewoRelPerm * ((woRelPerm/connatewoRelPerm + wRelPerm)*(goRelPerm/connatewoRelPerm + gRelPerm) - (wRelPerm + gRelPerm));
+          if (threePhaseRelPerm < 0)
+              threePhaseRelPerm = 0;
+          // derivative w.r.t. Sw
+          dThreePhaseRelPerm_dVolFrac[ipWater] = connatewoRelPerm * ((woRelPerm/connatewoRelPerm + dWRelPerm_dWaterVolFrac)*(goRelPerm/connatewoRelPerm + gRelPerm) - dWRelPerm_dWaterVolFrac);
+          // derivative w.r.t. So
+          dThreePhaseRelPerm_dVolFrac[ipOil]   = dWoRelPerm_dOilVolFrac/connatewoRelPerm*goRelPerm + woRelPerm*dGoRelPerm_dOilVolFrac/connatewoRelPerm + wRelPerm*dGoRelPerm_dOilVolFrac + gRelPerm*dWoRelPerm_dOilVolFrac;
+          // derivative w.r.t. Sg
+          dThreePhaseRelPerm_dVolFrac[ipGas]   = connatewoRelPerm * ((woRelPerm/connatewoRelPerm + wRelPerm) * (goRelPerm/connatewoRelPerm + dGRelPerm_dGasVolFrac) - dGRelPerm_dGasVolFrac);
+      }
+
+
+  }
+};
+
+
 } // namespace relpermInterpolators
 
 } // namespace constitutive

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp
@@ -162,8 +162,8 @@ struct Stone2
           dThreePhaseRelPerm_dVolFrac[ipOil] = dGoRelPerm_dOilVolFrac;
       } else {
           threePhaseRelPerm = connatewoRelPerm * ((woRelPerm/connatewoRelPerm + wRelPerm)*(goRelPerm/connatewoRelPerm + gRelPerm) - (wRelPerm + gRelPerm));
-          if (threePhaseRelPerm < 0)
-              threePhaseRelPerm = 0;
+//          if (threePhaseRelPerm < 0)
+//              threePhaseRelPerm = 0;
           // derivative w.r.t. Sw
           dThreePhaseRelPerm_dVolFrac[ipWater] = connatewoRelPerm * ((woRelPerm/connatewoRelPerm + dWRelPerm_dWaterVolFrac)*(goRelPerm/connatewoRelPerm + gRelPerm) - dWRelPerm_dWaterVolFrac);
           // derivative w.r.t. So

--- a/src/coreComponents/constitutive/relativePermeability/RelativePermeabilitySelector.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelativePermeabilitySelector.hpp
@@ -22,9 +22,11 @@
 #include "constitutive/ConstitutivePassThruHandler.hpp"
 #include "constitutive/relativePermeability/BrooksCoreyRelativePermeability.hpp"
 #include "constitutive/relativePermeability/BrooksCoreyBakerRelativePermeability.hpp"
+#include "constitutive/relativePermeability/BrooksCoreyStone2RelativePermeability.hpp"
 #include "constitutive/relativePermeability/TableRelativePermeability.hpp"
 #include "constitutive/relativePermeability/TableRelativePermeabilityHysteresis.hpp"
 #include "constitutive/relativePermeability/VanGenuchtenBakerRelativePermeability.hpp"
+#include "constitutive/relativePermeability/VanGenuchtenStone2RelativePermeability.hpp"
 
 namespace geos
 {
@@ -46,9 +48,11 @@ void constitutiveUpdatePassThru( RelativePermeabilityBase const & relPerm,
 {
   ConstitutivePassThruHandler< BrooksCoreyRelativePermeability,
                                BrooksCoreyBakerRelativePermeability,
+                               BrooksCoreyStone2RelativePermeability,
                                TableRelativePermeability,
                                TableRelativePermeabilityHysteresis,
-                               VanGenuchtenBakerRelativePermeability >::execute( relPerm, std::forward< LAMBDA >( lambda ) );
+                               VanGenuchtenBakerRelativePermeability,
+                               VanGenuchtenStone2RelativePermeability>::execute( relPerm, std::forward< LAMBDA >( lambda ) );
 }
 
 template< typename LAMBDA >
@@ -57,9 +61,11 @@ void constitutiveUpdatePassThru( RelativePermeabilityBase & relPerm,
 {
   ConstitutivePassThruHandler< BrooksCoreyRelativePermeability,
                                BrooksCoreyBakerRelativePermeability,
+                               BrooksCoreyStone2RelativePermeability,
                                TableRelativePermeability,
                                TableRelativePermeabilityHysteresis,
-                               VanGenuchtenBakerRelativePermeability >::execute( relPerm, std::forward< LAMBDA >( lambda ) );
+                               VanGenuchtenBakerRelativePermeability,
+                               VanGenuchtenStone2RelativePermeability>::execute( relPerm, std::forward< LAMBDA >( lambda ) );
 }
 
 #undef PASSTHROUGH_HANDLE_CASE

--- a/src/coreComponents/constitutive/relativePermeability/RelpermDriverBrooksCoreyStone2RunTest.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelpermDriverBrooksCoreyStone2RunTest.cpp
@@ -18,5 +18,5 @@
 
 namespace geos
 {
-    template void RelpermDriver::runTest< geosx::constitutive::BrooksCoreyStone2RelativePermeability >( geosx::constitutive::BrooksCoreyStone2RelativePermeability &, arrayView2d< real64 > const & );
+    template void RelpermDriver::runTest< geos::constitutive::BrooksCoreyStone2RelativePermeability >( geos::constitutive::BrooksCoreyStone2RelativePermeability &, arrayView2d< real64 > const & );
 }

--- a/src/coreComponents/constitutive/relativePermeability/RelpermDriverBrooksCoreyStone2RunTest.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelpermDriverBrooksCoreyStone2RunTest.cpp
@@ -1,0 +1,22 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+#include "RelpermDriverRunTest.hpp"
+#include "BrooksCoreyStone2RelativePermeability.hpp"
+
+
+namespace geos
+{
+    template void RelpermDriver::runTest< geosx::constitutive::BrooksCoreyStone2RelativePermeability >( geosx::constitutive::BrooksCoreyStone2RelativePermeability &, arrayView2d< real64 > const & );
+}

--- a/src/coreComponents/constitutive/relativePermeability/RelpermDriverVanGenuchtenStone2RunTest.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelpermDriverVanGenuchtenStone2RunTest.cpp
@@ -17,5 +17,5 @@
 
 namespace geos
 {
-    template void RelpermDriver::runTest< geosx::constitutive::VanGenuchtenStone2RelativePermeability >( geosx::constitutive::VanGenuchtenStone2RelativePermeability &, arrayView2d< real64 > const & );
+    template void RelpermDriver::runTest< geos::constitutive::VanGenuchtenStone2RelativePermeability >( geos::constitutive::VanGenuchtenStone2RelativePermeability &, arrayView2d< real64 > const & );
 }

--- a/src/coreComponents/constitutive/relativePermeability/RelpermDriverVanGenuchtenStone2RunTest.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/RelpermDriverVanGenuchtenStone2RunTest.cpp
@@ -1,0 +1,21 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+#include "RelpermDriverRunTest.hpp"
+#include "VanGenuchtenStone2RelativePermeability.hpp"
+
+
+namespace geos
+{
+    template void RelpermDriver::runTest< geosx::constitutive::VanGenuchtenStone2RelativePermeability >( geosx::constitutive::VanGenuchtenStone2RelativePermeability &, arrayView2d< real64 > const & );
+}

--- a/src/coreComponents/constitutive/relativePermeability/TableRelativePermeability.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/TableRelativePermeability.cpp
@@ -75,7 +75,8 @@ TableRelativePermeability::TableRelativePermeability( std::string const & name,
 
   registerWrapper( viewKeyStruct::flagInterpolatorString(), &m_flagInterpolator).
     setInputFlag( InputFlags::OPTIONAL).
-    setDefaultValue(0);
+    setDefaultValue(0).
+          setDescription("Flag wheter choose Baker(0) or StoneII (else) interpolation (temp).");
 }
 
 void TableRelativePermeability::postProcessInput()
@@ -136,7 +137,6 @@ void TableRelativePermeability::initializePreSubGroups()
 
   integer const numPhases = m_phaseNames.size();
   m_phaseMinVolumeFraction.resize( MAX_NUM_PHASES );
-  m_waterOilMaxRelPerm.resize(MAX_NUM_PHASES );
 
 
   string const fullName = getFullName();
@@ -166,13 +166,11 @@ void TableRelativePermeability::initializePreSubGroups()
       {
         integer const ipWetting = ( m_phaseOrder[PhaseType::WATER] >= 0 ) ? m_phaseOrder[PhaseType::WATER] : m_phaseOrder[PhaseType::OIL];
         m_phaseMinVolumeFraction[ipWetting] = phaseMinVolFrac;
-//          m_waterOilMaxRelPerm[m_phaseOrder[PhaseType::OIL]] = phaseRelPermEndPoint;//todo correct
       }
       else if( ip == 1 ) // non-wetting phase is either oil (for two-phase oil-water systems), or gas
       {
         integer const ipNonWetting = ( m_phaseOrder[PhaseType::GAS] >= 0 ) ? m_phaseOrder[PhaseType::GAS] : m_phaseOrder[PhaseType::OIL];
         m_phaseMinVolumeFraction[ipNonWetting] = phaseMinVolFrac;
-//        m_gasOilRelPermMaxValue[ip] = phaseRelPermEndPoint;//todo correct
       }
     }
   }
@@ -200,7 +198,7 @@ void TableRelativePermeability::initializePreSubGroups()
       else if( ip == 1 ) // intermediate phase is oil
       {
         m_phaseMinVolumeFraction[m_phaseOrder[PhaseType::OIL]] = phaseMinVolFrac;
-          m_waterOilMaxRelPerm[m_phaseOrder[PhaseType::OIL]] = phaseRelPermEndPoint;//todo correct
+          m_waterOilMaxRelPerm = phaseRelPermEndPoint;
       }
     }
     for( integer ip = 0; ip < m_nonWettingIntermediateRelPermTableNames.size(); ++ip )
@@ -225,7 +223,6 @@ void TableRelativePermeability::initializePreSubGroups()
       else if( ip == 1 ) // intermediate phase is oil
       {
         m_phaseMinVolumeFraction[m_phaseOrder[PhaseType::OIL]] = phaseMinVolFrac;
-//          m_waterOilRelPermMaxValue[m_phaseOrder[PhaseType::OIL]] = phaseRelPermEndPoint;//todo correct
       }
     }
   }
@@ -266,8 +263,10 @@ void TableRelativePermeability::createAllTableKernelWrappers()
 TableRelativePermeability::KernelWrapper::
   KernelWrapper( arrayView1d< TableFunction::KernelWrapper const > const & relPermKernelWrappers,
                  arrayView1d< real64 const > const & phaseMinVolumeFraction,
+                 real64 const & waterPhaseMaxVolumeFraction,
                  arrayView1d< integer const > const & phaseTypes,
                  arrayView1d< integer const > const & phaseOrder,
+                 integer const & flagInterpolator,
                  arrayView3d< real64, relperm::USD_RELPERM > const & phaseRelPerm,
                  arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac,
                  arrayView3d< real64, relperm::USD_RELPERM > const & phaseTrappedVolFrac )
@@ -275,10 +274,11 @@ TableRelativePermeability::KernelWrapper::
                                     phaseOrder,
                                     phaseRelPerm,
                                     dPhaseRelPerm_dPhaseVolFrac,
-                                    phaseTrappedVolFrac ),
-  m_phaseMinVolumeFraction( phaseMinVolumeFraction ),
-  m_relPermKernelWrappers( relPermKernelWrappers )
-{}
+                                    phaseTrappedVolFrac),
+    m_relPermKernelWrappers(relPermKernelWrappers),
+    m_phaseMinVolumeFraction(phaseMinVolumeFraction),
+    m_waterOilRelPermMaxValue(waterPhaseMaxVolumeFraction),
+    m_flagInterpolator(flagInterpolator) {}
 
 TableRelativePermeability::KernelWrapper
 TableRelativePermeability::createKernelWrapper()
@@ -290,9 +290,10 @@ TableRelativePermeability::createKernelWrapper()
   // then we create the actual TableRelativePermeability::KernelWrapper
   return KernelWrapper( m_relPermKernelWrappers,
                         m_phaseMinVolumeFraction,
-                        m_flagInterpolator,
+                        m_waterOilMaxRelPerm,
                         m_phaseTypes,
                         m_phaseOrder,
+                        m_flagInterpolator,
                         m_phaseRelPerm,
                         m_dPhaseRelPerm_dPhaseVolFrac,
                         m_phaseTrappedVolFrac );

--- a/src/coreComponents/constitutive/relativePermeability/TableRelativePermeability.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/TableRelativePermeability.hpp
@@ -60,6 +60,11 @@ public:
 
   virtual string getCatalogName() const override { return catalogName(); }
 
+  void setFlagToStoneII()
+  {
+      m_flagInterpolator = 1;
+  }
+
   /// Type of kernel wrapper for in-kernel update
   class KernelWrapper final : public RelativePermeabilityBaseUpdate
   {
@@ -67,6 +72,7 @@ public:
 
     KernelWrapper( arrayView1d< TableFunction::KernelWrapper const > const & relPermKernelWrappers,
                    arrayView1d< real64 const > const & phaseMinVolumeFraction,
+                   real64 const & waterOilPhaseMaxVolumeFraction,
                    arrayView1d< integer const > const & phaseTypes,
                    arrayView1d< integer const > const & phaseOrder,
                    integer const & flagInterpolator,
@@ -119,7 +125,7 @@ private:
     /// Minimum volume fraction for each phase (deduced from the table)
     arrayView1d< real64 const > m_phaseMinVolumeFraction;
 
-    array1d< real64 > m_waterOilRelPermMaxValue;
+    real64 const  m_waterOilRelPermMaxValue;
 
     integer const m_flagInterpolator;
   };
@@ -177,7 +183,7 @@ private:
   /// Min phase volume fractions (deduced from the tables). With Baker, only the water phase entry is used
   array1d< real64 > m_phaseMinVolumeFraction;
 
-  array1d< real64 > m_waterOilMaxRelPerm;
+  real64 m_waterOilMaxRelPerm;
 
   integer m_flagInterpolator;
 
@@ -270,7 +276,7 @@ TableRelativePermeability::KernelWrapper::
       relpermInterpolators::Stone2::compute(shiftedWettingVolFrac,
                                             phaseVolFraction[ipNonWetting],
                                             m_phaseOrder,
-                                            m_waterOilRelPermMaxValue[ipNonWetting],
+                                            m_waterOilRelPermMaxValue,
                                             interRelPerm_wi,
                                             dInterRelPerm_wi_dInterVolFrac,
                                             interRelPerm_nwi,

--- a/src/coreComponents/constitutive/relativePermeability/TableRelativePermeability.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/TableRelativePermeability.hpp
@@ -109,8 +109,6 @@ public:
 
 private:
 
-    arrayView1d< real64 const > m_phaseMinVolumeFraction;
-
     /// Kernel wrappers for relative permeabilities in the following order:
     /// Two-phase flow:
     ///  0- wetting-phase

--- a/src/coreComponents/constitutive/relativePermeability/TableRelativePermeabilityHysteresis.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/TableRelativePermeabilityHysteresis.cpp
@@ -650,6 +650,7 @@ TableRelativePermeabilityHysteresis::KernelWrapper::
                  integer const & flagInterpolator,
                  arrayView2d< real64 const, compflow::USD_PHASE > const & phaseMinHistoricalVolFraction,
                  arrayView2d< real64 const, compflow::USD_PHASE > const & phaseMaxHistoricalVolFraction,
+                 arrayView3d< real64, relperm::USD_RELPERM > const & phaseTrappedVolFrac,
                  arrayView3d< real64, relperm::USD_RELPERM > const & phaseRelPerm,
                  arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac )
   : RelativePermeabilityBaseUpdate( phaseTypes,

--- a/src/coreComponents/constitutive/relativePermeability/TableRelativePermeabilityHysteresis.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/TableRelativePermeabilityHysteresis.cpp
@@ -143,6 +143,10 @@ TableRelativePermeabilityHysteresis::TableRelativePermeabilityHysteresis( std::s
     setSizedFromParent( 0 ).
     setRestartFlags( RestartFlags::NO_WRITE );
 
+  registerWrapper( viewKeyStruct::waterOilMaxRelPermString(), &m_waterOilMaxRelPerm ).
+    setInputFlag( InputFlags::FALSE ). // will be deduced from tables
+    setSizedFromParent( 0 );
+
 }
 
 void TableRelativePermeabilityHysteresis::postProcessInput()
@@ -586,6 +590,7 @@ TableRelativePermeabilityHysteresis::createKernelWrapper()
                         m_imbibitionPhaseRelPermEndPoint,
                         m_phaseTypes,
                         m_phaseOrder,
+                        m_flagInterpolator,
                         m_phaseMinHistoricalVolFraction,
                         m_phaseMaxHistoricalVolFraction,
                         m_phaseTrappedVolFrac,
@@ -626,26 +631,27 @@ void TableRelativePermeabilityHysteresis::saveConvergedPhaseVolFractionState( ar
 
 }
 
-TableRelativePermeabilityHysteresis::KernelWrapper::KernelWrapper( arrayView1d< TableFunction::KernelWrapper const > const & drainageRelPermKernelWrappers,
-                                                                   arrayView1d< TableFunction::KernelWrapper const > const & imbibitionRelPermKernelWrappers,
-                                                                   real64 const & jerauldParam_a,
-                                                                   real64 const & jerauldParam_b,
-                                                                   real64 const & killoughCurvatureParam,
-                                                                   arrayView1d< integer const > const & phaseHasHysteresis,
-                                                                   arrayView1d< real64 const > const & landParam,
-                                                                   arrayView1d< real64 const > const & drainagePhaseMinVolFraction,
-                                                                   arrayView1d< real64 const > const & imbibitionPhaseMinVolFraction,
-                                                                   arrayView1d< real64 const > const & drainagePhaseMaxVolFraction,
-                                                                   arrayView1d< real64 const > const & imbibitionPhaseMaxVolFraction,
-                                                                   arrayView1d< real64 const > const & drainagePhaseRelPermEndPoint,
-                                                                   arrayView1d< real64 const > const & imbibitionPhaseRelPermEndPoint,
-                                                                   arrayView1d< integer const > const & phaseTypes,
-                                                                   arrayView1d< integer const > const & phaseOrder,
-                                                                   arrayView2d< real64 const, compflow::USD_PHASE > const & phaseMinHistoricalVolFraction,
-                                                                   arrayView2d< real64 const, compflow::USD_PHASE > const & phaseMaxHistoricalVolFraction,
-                                                                   arrayView3d< real64, relperm::USD_RELPERM > const & phaseTrappedVolFrac,
-                                                                   arrayView3d< real64, relperm::USD_RELPERM > const & phaseRelPerm,
-                                                                   arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac )
+TableRelativePermeabilityHysteresis::KernelWrapper::
+  KernelWrapper( arrayView1d< TableFunction::KernelWrapper const > const & drainageRelPermKernelWrappers,
+                 arrayView1d< TableFunction::KernelWrapper const > const & imbibitionRelPermKernelWrappers,
+                 real64 const & jerauldParam_a,
+                 real64 const & jerauldParam_b,
+                 real64 const & killoughCurvatureParam,
+                 arrayView1d< integer const > const & phaseHasHysteresis,
+                 arrayView1d< real64 const > const & landParam,
+                 arrayView1d< real64 const > const & drainagePhaseMinVolFraction,
+                 arrayView1d< real64 const > const & imbibitionPhaseMinVolFraction,
+                 arrayView1d< real64 const > const & drainagePhaseMaxVolFraction,
+                 arrayView1d< real64 const > const & imbibitionPhaseMaxVolFraction,
+                 arrayView1d< real64 const > const & drainagePhaseRelPermEndPoint,
+                 arrayView1d< real64 const > const & imbibitionPhaseRelPermEndPoint,
+                 arrayView1d< integer const > const & phaseTypes,
+                 arrayView1d< integer const > const & phaseOrder,
+                 integer const & flagInterpolator,
+                 arrayView2d< real64 const, compflow::USD_PHASE > const & phaseMinHistoricalVolFraction,
+                 arrayView2d< real64 const, compflow::USD_PHASE > const & phaseMaxHistoricalVolFraction,
+                 arrayView3d< real64, relperm::USD_RELPERM > const & phaseRelPerm,
+                 arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac )
   : RelativePermeabilityBaseUpdate( phaseTypes,
                                     phaseOrder,
                                     phaseRelPerm,
@@ -665,7 +671,8 @@ TableRelativePermeabilityHysteresis::KernelWrapper::KernelWrapper( arrayView1d< 
   m_drainagePhaseRelPermEndPoint( drainagePhaseRelPermEndPoint ),
   m_imbibitionPhaseRelPermEndPoint( imbibitionPhaseRelPermEndPoint ),
   m_phaseMinHistoricalVolFraction( phaseMinHistoricalVolFraction ),
-  m_phaseMaxHistoricalVolFraction( phaseMaxHistoricalVolFraction )
+  m_phaseMaxHistoricalVolFraction( phaseMaxHistoricalVolFraction ),
+  m_flagInterpolator( flagInterpolator )
 {}
 
 

--- a/src/coreComponents/constitutive/relativePermeability/VanGenuchtenStone2RelativePermeability.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/VanGenuchtenStone2RelativePermeability.cpp
@@ -1,0 +1,180 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file VanGenuchtenStone2RelativePermeability.cpp
+ */
+
+#include "VanGenuchtenStone2RelativePermeability.hpp"
+
+#include <cmath>
+
+namespace geos
+{
+
+    using namespace dataRepository;
+
+    namespace constitutive
+    {
+
+        VanGenuchtenStone2RelativePermeability::VanGenuchtenStone2RelativePermeability( string const & name,
+                                                                                      Group * const parent )
+                : RelativePermeabilityBase( name, parent )
+        {
+            registerWrapper( viewKeyStruct::phaseMinVolumeFractionString(), &m_phaseMinVolumeFraction ).
+                    setApplyDefaultValue( 0.0 ).
+                    setInputFlag( InputFlags::OPTIONAL ).
+                    setDescription( "Minimum volume fraction value for each phase" );
+
+            registerWrapper( viewKeyStruct::waterOilRelPermExponentInvString(), &m_waterOilRelPermExponentInv ).
+                    setApplyDefaultValue( 0.5 ).
+                    setInputFlag( InputFlags::OPTIONAL ).
+                    setDescription( "Rel perm power law exponent inverse for the pair (water phase, oil phase) at residual gas saturation\n"
+                                    "The expected format is \"{ waterExp, oilExp }\", in that order" );
+
+            registerWrapper( viewKeyStruct::waterOilRelPermMaxValueString(), &m_waterOilRelPermMaxValue ).
+                    setApplyDefaultValue( 0.0 ).
+                    setInputFlag( InputFlags::OPTIONAL ).
+                    setDescription( "Maximum rel perm value for the pair (water phase, oil phase) at residual gas saturation\n"
+                                    "The expected format is \"{ waterMax, oilMax }\", in that order" );
+
+            registerWrapper( viewKeyStruct::gasOilRelPermExponentInvString(), &m_gasOilRelPermExponentInv ).
+                    setApplyDefaultValue( 0.5 ).
+                    setInputFlag( InputFlags::OPTIONAL ).
+                    setDescription( "Rel perm power law exponent inverse for the pair (gas phase, oil phase) at residual water saturation\n"
+                                    "The expected format is \"{ gasExp, oilExp }\", in that order" );
+
+            registerWrapper( viewKeyStruct::gasOilRelPermMaxValueString(), &m_gasOilRelPermMaxValue ).
+                    setApplyDefaultValue( 0.0 ).
+                    setInputFlag( InputFlags::OPTIONAL ).
+                    setDescription( "Maximum rel perm value for the pair (gas phase, oil phase) at residual water saturation\n"
+                                    "The expected format is \"{ gasMax, oilMax }\", in that order" );
+
+            registerWrapper( viewKeyStruct::volFracScaleString(), &m_volFracScale ).
+                    setApplyDefaultValue( 1.0 ).
+                    setDescription( "Factor used to scale the phase capillary pressure, defined as: one minus the sum of the phase minimum volume fractions." );
+
+        }
+
+        void VanGenuchtenStone2RelativePermeability::postProcessInput()
+        {
+            RelativePermeabilityBase::postProcessInput();
+
+            GEOSX_THROW_IF( m_phaseOrder[PhaseType::OIL] < 0,
+                            GEOSX_FMT( "{}: reference oil phase has not been defined and must be included in model", getFullName() ),
+                            InputError );
+
+            auto const checkInputSize = [&]( auto const & array, localIndex const expected, auto const & attribute )
+            {
+                GEOSX_THROW_IF_NE_MSG( array.size(), expected,
+                                       GEOSX_FMT( "{}: invalid number of values in attribute '{}'", getFullName(), attribute ),
+                                       InputError );
+            };
+            checkInputSize( m_phaseMinVolumeFraction, numFluidPhases(), viewKeyStruct::phaseMinVolumeFractionString() );
+
+            if( m_phaseOrder[PhaseType::WATER] >= 0 )
+            {
+                checkInputSize( m_waterOilRelPermExponentInv, 2, viewKeyStruct::waterOilRelPermExponentInvString() );
+                checkInputSize( m_waterOilRelPermMaxValue, 2, viewKeyStruct::waterOilRelPermMaxValueString() );
+            }
+
+            if( m_phaseOrder[PhaseType::GAS] >= 0 )
+            {
+                checkInputSize( m_gasOilRelPermExponentInv, 2, viewKeyStruct::gasOilRelPermExponentInvString() );
+                checkInputSize( m_gasOilRelPermMaxValue, 2, viewKeyStruct::gasOilRelPermMaxValueString() );
+            }
+
+            m_volFracScale = 1.0;
+            for( integer ip = 0; ip < numFluidPhases(); ++ip )
+            {
+                auto const errorMsg = [&]( auto const & attribute )
+                {
+                    return GEOSX_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
+                };
+                GEOSX_THROW_IF_LT_MSG( m_phaseMinVolumeFraction[ip], 0.0,
+                                       errorMsg( viewKeyStruct::phaseMinVolumeFractionString() ),
+                                       InputError );
+                GEOSX_THROW_IF_GT_MSG( m_phaseMinVolumeFraction[ip], 1.0,
+                                       errorMsg( viewKeyStruct::phaseMinVolumeFractionString() ),
+                                       InputError );
+                m_volFracScale -= m_phaseMinVolumeFraction[ip];
+            }
+
+            GEOSX_THROW_IF_LT_MSG( m_volFracScale, 0.0,
+                                   GEOSX_FMT( "{}: sum of min volume fractions exceeds 1.0", getFullName() ),
+                                   InputError );
+
+            for( integer ip = 0; ip < 2; ++ip )
+            {
+                auto const errorMsg = [&]( auto const & attribute )
+                {
+                    return GEOSX_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
+                };
+                if( m_phaseOrder[PhaseType::WATER] >= 0 )
+                {
+                    GEOSX_THROW_IF_LT_MSG( m_waterOilRelPermExponentInv[ip], 0.0,
+                                           errorMsg( viewKeyStruct::waterOilRelPermExponentInvString() ),
+                                           InputError );
+                    GEOSX_THROW_IF_LT_MSG( m_waterOilRelPermMaxValue[ip], 0.0,
+                                           errorMsg( viewKeyStruct::waterOilRelPermMaxValueString() ),
+                                           InputError );
+                    GEOSX_THROW_IF_GT_MSG( m_waterOilRelPermMaxValue[ip], 1.0,
+                                           errorMsg( viewKeyStruct::waterOilRelPermMaxValueString() ),
+                                           InputError );
+                }
+
+                if( m_phaseOrder[PhaseType::GAS] >= 0 )
+                {
+                    GEOSX_THROW_IF_LT_MSG( m_gasOilRelPermExponentInv[ip], 0.0,
+                                           errorMsg( viewKeyStruct::gasOilRelPermExponentInvString() ),
+                                           InputError );
+                    GEOSX_THROW_IF_LT_MSG( m_gasOilRelPermMaxValue[ip], 0.0,
+                                           errorMsg( viewKeyStruct::gasOilRelPermMaxValueString() ),
+                                           InputError );
+                    GEOSX_THROW_IF_GT_MSG( m_gasOilRelPermMaxValue[ip], 1.0,
+                                           errorMsg( viewKeyStruct::gasOilRelPermMaxValueString() ),
+                                           InputError );
+                }
+            }
+
+            if( m_phaseOrder[PhaseType::WATER] >= 0 && m_phaseOrder[PhaseType::GAS] >= 0 )
+            {
+                real64 const mean = 0.5 * ( m_gasOilRelPermMaxValue[GasOilPairPhaseType::OIL]
+                                            + m_waterOilRelPermMaxValue[WaterOilPairPhaseType::OIL] );
+                m_gasOilRelPermMaxValue[GasOilPairPhaseType::OIL]     = mean;
+                m_waterOilRelPermMaxValue[WaterOilPairPhaseType::OIL] = mean;
+            }
+
+        }
+
+        VanGenuchtenStone2RelativePermeability::KernelWrapper
+        VanGenuchtenStone2RelativePermeability::createKernelWrapper()
+        {
+            return KernelWrapper( m_phaseMinVolumeFraction,
+                                  m_waterOilRelPermExponentInv,
+                                  m_waterOilRelPermMaxValue,
+                                  m_gasOilRelPermExponentInv,
+                                  m_gasOilRelPermMaxValue,
+                                  m_volFracScale,
+                                  m_phaseTypes,
+                                  m_phaseOrder,
+                                  m_phaseRelPerm,
+                                  m_dPhaseRelPerm_dPhaseVolFrac,
+                                  m_phaseTrappedVolFrac );
+        }
+
+        REGISTER_CATALOG_ENTRY( ConstitutiveBase, VanGenuchtenStone2RelativePermeability, string const &, Group * const )
+    } // namespace constitutive
+
+} // namespace geos

--- a/src/coreComponents/constitutive/relativePermeability/VanGenuchtenStone2RelativePermeability.cpp
+++ b/src/coreComponents/constitutive/relativePermeability/VanGenuchtenStone2RelativePermeability.cpp
@@ -71,14 +71,14 @@ namespace geos
         {
             RelativePermeabilityBase::postProcessInput();
 
-            GEOSX_THROW_IF( m_phaseOrder[PhaseType::OIL] < 0,
-                            GEOSX_FMT( "{}: reference oil phase has not been defined and must be included in model", getFullName() ),
+            GEOS_THROW_IF( m_phaseOrder[PhaseType::OIL] < 0,
+                            GEOS_FMT( "{}: reference oil phase has not been defined and must be included in model", getFullName() ),
                             InputError );
 
             auto const checkInputSize = [&]( auto const & array, localIndex const expected, auto const & attribute )
             {
-                GEOSX_THROW_IF_NE_MSG( array.size(), expected,
-                                       GEOSX_FMT( "{}: invalid number of values in attribute '{}'", getFullName(), attribute ),
+                GEOS_THROW_IF_NE_MSG( array.size(), expected,
+                                       GEOS_FMT( "{}: invalid number of values in attribute '{}'", getFullName(), attribute ),
                                        InputError );
             };
             checkInputSize( m_phaseMinVolumeFraction, numFluidPhases(), viewKeyStruct::phaseMinVolumeFractionString() );
@@ -100,49 +100,49 @@ namespace geos
             {
                 auto const errorMsg = [&]( auto const & attribute )
                 {
-                    return GEOSX_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
+                    return GEOS_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
                 };
-                GEOSX_THROW_IF_LT_MSG( m_phaseMinVolumeFraction[ip], 0.0,
+                GEOS_THROW_IF_LT_MSG( m_phaseMinVolumeFraction[ip], 0.0,
                                        errorMsg( viewKeyStruct::phaseMinVolumeFractionString() ),
                                        InputError );
-                GEOSX_THROW_IF_GT_MSG( m_phaseMinVolumeFraction[ip], 1.0,
+                GEOS_THROW_IF_GT_MSG( m_phaseMinVolumeFraction[ip], 1.0,
                                        errorMsg( viewKeyStruct::phaseMinVolumeFractionString() ),
                                        InputError );
                 m_volFracScale -= m_phaseMinVolumeFraction[ip];
             }
 
-            GEOSX_THROW_IF_LT_MSG( m_volFracScale, 0.0,
-                                   GEOSX_FMT( "{}: sum of min volume fractions exceeds 1.0", getFullName() ),
+            GEOS_THROW_IF_LT_MSG( m_volFracScale, 0.0,
+                                   GEOS_FMT( "{}: sum of min volume fractions exceeds 1.0", getFullName() ),
                                    InputError );
 
             for( integer ip = 0; ip < 2; ++ip )
             {
                 auto const errorMsg = [&]( auto const & attribute )
                 {
-                    return GEOSX_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
+                    return GEOS_FMT( "{}: invalid value at {}[{}]", getFullName(), attribute, ip );
                 };
                 if( m_phaseOrder[PhaseType::WATER] >= 0 )
                 {
-                    GEOSX_THROW_IF_LT_MSG( m_waterOilRelPermExponentInv[ip], 0.0,
+                    GEOS_THROW_IF_LT_MSG( m_waterOilRelPermExponentInv[ip], 0.0,
                                            errorMsg( viewKeyStruct::waterOilRelPermExponentInvString() ),
                                            InputError );
-                    GEOSX_THROW_IF_LT_MSG( m_waterOilRelPermMaxValue[ip], 0.0,
+                    GEOS_THROW_IF_LT_MSG( m_waterOilRelPermMaxValue[ip], 0.0,
                                            errorMsg( viewKeyStruct::waterOilRelPermMaxValueString() ),
                                            InputError );
-                    GEOSX_THROW_IF_GT_MSG( m_waterOilRelPermMaxValue[ip], 1.0,
+                    GEOS_THROW_IF_GT_MSG( m_waterOilRelPermMaxValue[ip], 1.0,
                                            errorMsg( viewKeyStruct::waterOilRelPermMaxValueString() ),
                                            InputError );
                 }
 
                 if( m_phaseOrder[PhaseType::GAS] >= 0 )
                 {
-                    GEOSX_THROW_IF_LT_MSG( m_gasOilRelPermExponentInv[ip], 0.0,
+                    GEOS_THROW_IF_LT_MSG( m_gasOilRelPermExponentInv[ip], 0.0,
                                            errorMsg( viewKeyStruct::gasOilRelPermExponentInvString() ),
                                            InputError );
-                    GEOSX_THROW_IF_LT_MSG( m_gasOilRelPermMaxValue[ip], 0.0,
+                    GEOS_THROW_IF_LT_MSG( m_gasOilRelPermMaxValue[ip], 0.0,
                                            errorMsg( viewKeyStruct::gasOilRelPermMaxValueString() ),
                                            InputError );
-                    GEOSX_THROW_IF_GT_MSG( m_gasOilRelPermMaxValue[ip], 1.0,
+                    GEOS_THROW_IF_GT_MSG( m_gasOilRelPermMaxValue[ip], 1.0,
                                            errorMsg( viewKeyStruct::gasOilRelPermMaxValueString() ),
                                            InputError );
                 }

--- a/src/coreComponents/constitutive/relativePermeability/VanGenuchtenStone2RelativePermeability.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/VanGenuchtenStone2RelativePermeability.hpp
@@ -16,13 +16,13 @@
  * @file VanGenuchtenStone2RelativePermeability.hpp
  */
 
-#ifndef GEOSX_CONSTITUTIVE_VANGENUCHTENSTONE2RELATIVEPERMEABILITY_HPP
-#define GEOSX_CONSTITUTIVE_VANGENUCHTENSTONE2RELATIVEPERMEABILITY_HPP
+#ifndef GEOS_CONSTITUTIVE_VANGENUCHTENSTONE2RELATIVEPERMEABILITY_HPP
+#define GEOS_CONSTITUTIVE_VANGENUCHTENSTONE2RELATIVEPERMEABILITY_HPP
 
 #include "constitutive/relativePermeability/RelativePermeabilityBase.hpp"
 #include "constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp"
 
-namespace geosx
+namespace geos
 {
 namespace constitutive
 {
@@ -55,13 +55,13 @@ public:
     m_volFracScale( volFracScale )
   {}
 
-  GEOSX_HOST_DEVICE
+  GEOS_HOST_DEVICE
   void compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
                 arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseTrappedVolFrac,
                 arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseRelPerm,
                 arraySlice2d< real64, relperm::USD_RELPERM_DS - 2 > const & dPhaseRelPerm_dPhaseVolFrac ) const;
 
-  GEOSX_HOST_DEVICE
+  GEOS_HOST_DEVICE
   virtual void update( localIndex const k,
                        localIndex const q,
                        arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction ) const override
@@ -88,8 +88,8 @@ private:
    * This function evaluates the relperm function and its derivative at a given phase saturation
    * Reference: Eclipse technical description and Petrowiki
    */
-  GEOSX_HOST_DEVICE
-  GEOSX_FORCE_INLINE
+  GEOS_HOST_DEVICE
+  inline
   static void evaluateVanGenuchtenFunction( real64 const & scaledVolFrac,
                                             real64 const & dScaledVolFrac_dVolFrac,
                                             real64 const & exponentInv,
@@ -158,7 +158,7 @@ protected:
 };
 
 
-GEOSX_HOST_DEVICE
+GEOS_HOST_DEVICE
 inline void
 VanGenuchtenStone2RelativePermeabilityUpdate::
   compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
@@ -305,8 +305,8 @@ VanGenuchtenStone2RelativePermeabilityUpdate::
     }
 }
 
-GEOSX_HOST_DEVICE
-GEOSX_FORCE_INLINE
+GEOS_HOST_DEVICE
+inline
 void
 VanGenuchtenStone2RelativePermeabilityUpdate::
   evaluateVanGenuchtenFunction( real64 const & scaledVolFrac,
@@ -342,6 +342,6 @@ VanGenuchtenStone2RelativePermeabilityUpdate::
 
 } // namespace constitutive
 
-} // namespace geosx
+} // namespace geos
 
-#endif //GEOSX_CONSTITUTIVE_VANGENUCHTENSTONE2RELATIVEPERMEABILITY_HPP
+#endif //GEOS_CONSTITUTIVE_VANGENUCHTENSTONE2RELATIVEPERMEABILITY_HPP

--- a/src/coreComponents/constitutive/relativePermeability/VanGenuchtenStone2RelativePermeability.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/VanGenuchtenStone2RelativePermeability.hpp
@@ -13,25 +13,25 @@
  */
 
 /**
- * @file VanGenuchtenBakerRelativePermeability.hpp
+ * @file VanGenuchtenStone2RelativePermeability.hpp
  */
 
-#ifndef GEOS_CONSTITUTIVE_VANGENUCHTENBAKERRELATIVEPERMEABILITY_HPP
-#define GEOS_CONSTITUTIVE_VANGENUCHTENBAKERRELATIVEPERMEABILITY_HPP
+#ifndef GEOSX_CONSTITUTIVE_VANGENUCHTENSTONE2RELATIVEPERMEABILITY_HPP
+#define GEOSX_CONSTITUTIVE_VANGENUCHTENSTONE2RELATIVEPERMEABILITY_HPP
 
 #include "constitutive/relativePermeability/RelativePermeabilityBase.hpp"
 #include "constitutive/relativePermeability/RelativePermeabilityInterpolators.hpp"
 
-namespace geos
+namespace geosx
 {
 namespace constitutive
 {
 
-class VanGenuchtenBakerRelativePermeabilityUpdate final : public RelativePermeabilityBaseUpdate
+class VanGenuchtenStone2RelativePermeabilityUpdate final : public RelativePermeabilityBaseUpdate
 {
 public:
 
-  VanGenuchtenBakerRelativePermeabilityUpdate( arrayView1d< real64 const > const & phaseMinVolumeFraction,
+  VanGenuchtenStone2RelativePermeabilityUpdate( arrayView1d< real64 const > const & phaseMinVolumeFraction,
                                                arrayView1d< real64 const > const & waterOilRelPermExponentInv,
                                                arrayView1d< real64 const > const & waterOilRelPermMaxValue,
                                                arrayView1d< real64 const > const & gasOilRelPermExponentInv,
@@ -40,13 +40,11 @@ public:
                                                arrayView1d< integer const > const & phaseTypes,
                                                arrayView1d< integer const > const & phaseOrder,
                                                arrayView3d< real64, relperm::USD_RELPERM > const & phaseRelPerm,
-                                               arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac,
-                                               arrayView3d< real64, relperm::USD_RELPERM > const & phaseTrappedVolFrac )
+                                               arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac )
     : RelativePermeabilityBaseUpdate( phaseTypes,
                                       phaseOrder,
                                       phaseRelPerm,
-                                      dPhaseRelPerm_dPhaseVolFrac,
-                                      phaseTrappedVolFrac ),
+                                      dPhaseRelPerm_dPhaseVolFrac ),
     m_phaseMinVolumeFraction( phaseMinVolumeFraction ),
     m_waterOilRelPermExponentInv( waterOilRelPermExponentInv ),
     m_waterOilRelPermMaxValue( waterOilRelPermMaxValue ),
@@ -55,19 +53,17 @@ public:
     m_volFracScale( volFracScale )
   {}
 
-  GEOS_HOST_DEVICE
+  GEOSX_HOST_DEVICE
   void compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
-                arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseTrappedVolFrac,
                 arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseRelPerm,
                 arraySlice2d< real64, relperm::USD_RELPERM_DS - 2 > const & dPhaseRelPerm_dPhaseVolFrac ) const;
 
-  GEOS_HOST_DEVICE
+  GEOSX_HOST_DEVICE
   virtual void update( localIndex const k,
                        localIndex const q,
                        arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction ) const override
   {
     compute( phaseVolFraction,
-             m_phaseTrappedVolFrac[k][q],
              m_phaseRelPerm[k][q],
              m_dPhaseRelPerm_dPhaseVolFrac[k][q] );
   }
@@ -88,8 +84,8 @@ private:
    * This function evaluates the relperm function and its derivative at a given phase saturation
    * Reference: Eclipse technical description and Petrowiki
    */
-  GEOS_HOST_DEVICE
-  GEOS_FORCE_INLINE
+  GEOSX_HOST_DEVICE
+  GEOSX_FORCE_INLINE
   static void evaluateVanGenuchtenFunction( real64 const & scaledVolFrac,
                                             real64 const & dScaledVolFrac_dVolFrac,
                                             real64 const & exponentInv,
@@ -109,18 +105,18 @@ private:
 
 };
 
-class VanGenuchtenBakerRelativePermeability : public RelativePermeabilityBase
+class VanGenuchtenStone2RelativePermeability : public RelativePermeabilityBase
 {
 public:
 
-  VanGenuchtenBakerRelativePermeability( string const & name, dataRepository::Group * const parent );
+  VanGenuchtenStone2RelativePermeability( string const & name, dataRepository::Group * const parent );
 
-  static string catalogName() { return "VanGenuchtenBakerRelativePermeability"; }
+  static string catalogName() { return "VanGenuchtenStone2RelativePermeability"; }
 
   virtual string getCatalogName() const override { return catalogName(); }
 
   /// Type of kernel wrapper for in-kernel update
-  using KernelWrapper = VanGenuchtenBakerRelativePermeabilityUpdate;
+  using KernelWrapper = VanGenuchtenStone2RelativePermeabilityUpdate;
 
   /**
    * @brief Create an update kernel wrapper.
@@ -138,7 +134,6 @@ public:
     static constexpr char const * volFracScaleString() { return "volFracScale"; }
   };
 
-  arrayView1d< real64 const > getPhaseMinVolumeFraction() const override { return m_phaseMinVolumeFraction; };
 protected:
 
   virtual void postProcessInput() override;
@@ -157,11 +152,10 @@ protected:
 };
 
 
-GEOS_HOST_DEVICE
+GEOSX_HOST_DEVICE
 inline void
-VanGenuchtenBakerRelativePermeabilityUpdate::
+VanGenuchtenStone2RelativePermeabilityUpdate::
   compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
-           arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseTrappedVolFrac,
            arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseRelPerm,
            arraySlice2d< real64, relperm::USD_RELPERM_DS - 2 > const & dPhaseRelPerm_dPhaseVolFrac ) const
 {
@@ -211,6 +205,7 @@ VanGenuchtenBakerRelativePermeabilityUpdate::
 
   }
 
+
   // 2) Gas and oil phase relative permeabilities using gas-oil data
   if( ipGas >= 0 )
   {
@@ -220,6 +215,7 @@ VanGenuchtenBakerRelativePermeabilityUpdate::
     using GOPT = RelativePermeabilityBase::GasOilPairPhaseType;
     real64 const gasExponentInv = m_gasOilRelPermExponentInv[GOPT::GAS];
     real64 const gasMaxValue = m_gasOilRelPermMaxValue[GOPT::GAS];
+
     // gas rel perm
     evaluateVanGenuchtenFunction( scaledGasVolFrac,
                                   volFracScaleInv,
@@ -238,7 +234,10 @@ VanGenuchtenBakerRelativePermeabilityUpdate::
                                   oilMaxValue_go,
                                   oilRelPerm_go,
                                   dOilRelPerm_go_dOilVolFrac );
+
+
   }
+
 
   // 3) Compute the "three-phase" oil relperm
 
@@ -260,51 +259,37 @@ VanGenuchtenBakerRelativePermeabilityUpdate::
     real64 const shiftedWaterVolFrac = (phaseVolFraction[ipWater] - m_phaseMinVolumeFraction[ipWater]);
 
     // TODO: change name of the class and add template to choose interpolation
-    relpermInterpolators::Baker::compute( shiftedWaterVolFrac,
-                                          phaseVolFraction[ipGas],
-                                          m_phaseOrder,
-                                          oilRelPerm_wo,
-                                          dOilRelPerm_wo_dOilVolFrac,
-                                          oilRelPerm_go,
-                                          dOilRelPerm_go_dOilVolFrac,
-                                          phaseRelPerm[ipOil],
-                                          dPhaseRelPerm_dPhaseVolFrac[ipOil] );
+//    relpermInterpolators::Stone2::compute( shiftedWaterVolFrac,
+//                                          phaseVolFraction[ipGas],
+//                                          m_phaseOrder,
+//                                          oilRelPerm_wo,
+//                                          dOilRelPerm_wo_dOilVolFrac,
+//                                          oilRelPerm_go,
+//                                          dOilRelPerm_go_dOilVolFrac,
+//                                          phaseRelPerm[ipOil],
+//                                          dPhaseRelPerm_dPhaseVolFrac[ipOil] );
 
-//      relpermInterpolators::Stone2::compute(shiftedWaterVolFrac,
-//                                            phaseVolFraction[ipGas],
-//                                            m_phaseOrder,
-//                                            m_waterOilRelPermMaxValue[ipOil],
-//                                            oilRelPerm_wo,
-//                                            dOilRelPerm_wo_dOilVolFrac,
-//                                            oilRelPerm_go,
-//                                            dOilRelPerm_go_dOilVolFrac,
-//                                            phaseRelPerm[ipWater],
-//                                            dPhaseRelPerm_dPhaseVolFrac[ipWater][ipWater],
-//                                            phaseRelPerm[ipGas],
-//                                            dPhaseRelPerm_dPhaseVolFrac[ipGas][ipGas],
-//                                            phaseRelPerm[ipOil],
-//                                            dPhaseRelPerm_dPhaseVolFrac[ipOil] );
-  }
-
-  // update trapped phase volume fraction
-  if( ipWater >= 0 )
-  {
-    phaseTrappedVolFrac[ipWater] = LvArray::math::min( phaseVolFraction[ipWater], m_phaseMinVolumeFraction[ipWater] );
-  }
-  if( ipGas >= 0 )
-  {
-    phaseTrappedVolFrac[ipGas] = LvArray::math::min( phaseVolFraction[ipGas], m_phaseMinVolumeFraction[ipGas] );
-  }
-  if( ipOil >= 0 )
-  {
-    phaseTrappedVolFrac[ipOil] = LvArray::math::min( phaseVolFraction[ipOil], m_phaseMinVolumeFraction[ipOil] );
+      relpermInterpolators::Stone2::compute(shiftedWaterVolFrac,
+                                            phaseVolFraction[ipGas],
+                                            m_phaseOrder,
+                                            m_waterOilRelPermMaxValue[ipOil],
+                                            oilRelPerm_wo,
+                                            dOilRelPerm_wo_dOilVolFrac,
+                                            oilRelPerm_go,
+                                            dOilRelPerm_go_dOilVolFrac,
+                                            phaseRelPerm[ipWater],
+                                            dPhaseRelPerm_dPhaseVolFrac[ipWater][ipWater],
+                                            phaseRelPerm[ipGas],
+                                            dPhaseRelPerm_dPhaseVolFrac[ipGas][ipGas],
+                                            phaseRelPerm[ipOil],
+                                            dPhaseRelPerm_dPhaseVolFrac[ipOil] );
   }
 }
 
-GEOS_HOST_DEVICE
-GEOS_FORCE_INLINE
+GEOSX_HOST_DEVICE
+GEOSX_FORCE_INLINE
 void
-VanGenuchtenBakerRelativePermeabilityUpdate::
+VanGenuchtenStone2RelativePermeabilityUpdate::
   evaluateVanGenuchtenFunction( real64 const & scaledVolFrac,
                                 real64 const & dScaledVolFrac_dVolFrac,
                                 real64 const & exponentInv,
@@ -338,6 +323,6 @@ VanGenuchtenBakerRelativePermeabilityUpdate::
 
 } // namespace constitutive
 
-} // namespace geos
+} // namespace geosx
 
-#endif //GEOS_CONSTITUTIVE_VANGENUCHTENBAKERRELATIVEPERMEABILITY_HPP
+#endif //GEOSX_CONSTITUTIVE_VANGENUCHTENSTONE2RELATIVEPERMEABILITY_HPP

--- a/src/coreComponents/constitutive/relativePermeability/VanGenuchtenStone2RelativePermeability.hpp
+++ b/src/coreComponents/constitutive/relativePermeability/VanGenuchtenStone2RelativePermeability.hpp
@@ -40,11 +40,13 @@ public:
                                                arrayView1d< integer const > const & phaseTypes,
                                                arrayView1d< integer const > const & phaseOrder,
                                                arrayView3d< real64, relperm::USD_RELPERM > const & phaseRelPerm,
-                                               arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac )
+                                               arrayView4d< real64, relperm::USD_RELPERM_DS > const & dPhaseRelPerm_dPhaseVolFrac,
+                                               arrayView3d< real64, relperm::USD_RELPERM > const & phaseTrappedVolFrac )
     : RelativePermeabilityBaseUpdate( phaseTypes,
                                       phaseOrder,
                                       phaseRelPerm,
-                                      dPhaseRelPerm_dPhaseVolFrac ),
+                                      dPhaseRelPerm_dPhaseVolFrac,
+                                      phaseTrappedVolFrac ),
     m_phaseMinVolumeFraction( phaseMinVolumeFraction ),
     m_waterOilRelPermExponentInv( waterOilRelPermExponentInv ),
     m_waterOilRelPermMaxValue( waterOilRelPermMaxValue ),
@@ -55,6 +57,7 @@ public:
 
   GEOSX_HOST_DEVICE
   void compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
+                arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseTrappedVolFrac,
                 arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseRelPerm,
                 arraySlice2d< real64, relperm::USD_RELPERM_DS - 2 > const & dPhaseRelPerm_dPhaseVolFrac ) const;
 
@@ -64,6 +67,7 @@ public:
                        arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction ) const override
   {
     compute( phaseVolFraction,
+             m_phaseTrappedVolFrac[k][q],
              m_phaseRelPerm[k][q],
              m_dPhaseRelPerm_dPhaseVolFrac[k][q] );
   }
@@ -134,6 +138,8 @@ public:
     static constexpr char const * volFracScaleString() { return "volFracScale"; }
   };
 
+  arrayView1d< real64 const > getPhaseMinVolumeFraction() const override { return m_phaseMinVolumeFraction; };
+
 protected:
 
   virtual void postProcessInput() override;
@@ -156,6 +162,7 @@ GEOSX_HOST_DEVICE
 inline void
 VanGenuchtenStone2RelativePermeabilityUpdate::
   compute( arraySlice1d< real64 const, compflow::USD_PHASE - 1 > const & phaseVolFraction,
+           arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseTrappedVolFrac,
            arraySlice1d< real64, relperm::USD_RELPERM - 2 > const & phaseRelPerm,
            arraySlice2d< real64, relperm::USD_RELPERM_DS - 2 > const & dPhaseRelPerm_dPhaseVolFrac ) const
 {
@@ -284,6 +291,18 @@ VanGenuchtenStone2RelativePermeabilityUpdate::
                                             phaseRelPerm[ipOil],
                                             dPhaseRelPerm_dPhaseVolFrac[ipOil] );
   }
+    if( ipWater >= 0 )
+    {
+        phaseTrappedVolFrac[ipWater] = LvArray::math::min( phaseVolFraction[ipWater], m_phaseMinVolumeFraction[ipWater] );
+    }
+    if( ipGas >= 0 )
+    {
+        phaseTrappedVolFrac[ipGas] = LvArray::math::min( phaseVolFraction[ipGas], m_phaseMinVolumeFraction[ipGas] );
+    }
+    if( ipOil >= 0 )
+    {
+        phaseTrappedVolFrac[ipOil] = LvArray::math::min( phaseVolFraction[ipOil], m_phaseMinVolumeFraction[ipOil] );
+    }
 }
 
 GEOSX_HOST_DEVICE

--- a/src/coreComponents/unitTests/constitutiveTests/testRelPerm.cpp
+++ b/src/coreComponents/unitTests/constitutiveTests/testRelPerm.cpp
@@ -748,6 +748,8 @@ RelativePermeabilityBase & makeTableRelPermThreePhase( string const & name, Grou
 
   auto & relPerm = parent.registerGroup< TableRelativePermeability >( name );
 
+  relPerm.setFlagToStoneII();
+
   auto & phaseNames = relPerm.getReference< string_array >( RelativePermeabilityBase::viewKeyStruct::phaseNamesString() );
   phaseNames.resize( 3 );
   phaseNames[0] = "oil"; phaseNames[1] = "water"; phaseNames[2] = "gas";

--- a/src/coreComponents/unitTests/constitutiveTests/testRelPerm.cpp
+++ b/src/coreComponents/unitTests/constitutiveTests/testRelPerm.cpp
@@ -107,6 +107,39 @@ RelativePermeabilityBase & makeBrooksCoreyBakerRelPermThreePhase( string const &
   return relPerm;
 }
 
+RelativePermeabilityBase & makeBrooksCoreyStone2RelPermThreePhase( string const & name, Group & parent )
+{
+    BrooksCoreyStone2RelativePermeability & relPerm = parent.registerGroup< BrooksCoreyStone2RelativePermeability >( name );
+
+    string_array & phaseNames = relPerm.getReference< string_array >( RelativePermeabilityBase::viewKeyStruct::phaseNamesString() );
+    phaseNames.resize( 3 );
+    phaseNames[0] = "oil"; phaseNames[1] = "gas"; phaseNames[2] = "water";
+
+    array1d< real64 > & phaseMinSat = relPerm.getReference< array1d< real64 > >( BrooksCoreyStone2RelativePermeability::viewKeyStruct::phaseMinVolumeFractionString() );
+    phaseMinSat.resize( 3 );
+    phaseMinSat[0] = 0.03; phaseMinSat[1] = 0.01; phaseMinSat[2] = 0.025;
+
+    array1d< real64 > & waterOilRelPermExp = relPerm.getReference< array1d< real64 > >( BrooksCoreyStone2RelativePermeability::viewKeyStruct::waterOilRelPermExponentString() );
+    waterOilRelPermExp.resize( 2 );
+    waterOilRelPermExp[0] = 2.4; waterOilRelPermExp[1] = 1.5;
+
+    array1d< real64 > & waterOilRelPermMaxVal =
+            relPerm.getReference< array1d< real64 > >( BrooksCoreyStone2RelativePermeability::viewKeyStruct::waterOilRelPermMaxValueString() );
+    waterOilRelPermMaxVal.resize( 2 );
+    waterOilRelPermMaxVal[0] = 0.9; waterOilRelPermMaxVal[1] = 0.65;
+
+    array1d< real64 > & gasOilRelPermExp = relPerm.getReference< array1d< real64 > >( BrooksCoreyStone2RelativePermeability::viewKeyStruct::gasOilRelPermExponentString() );
+    gasOilRelPermExp.resize( 2 );
+    gasOilRelPermExp[0] = 1.9; gasOilRelPermExp[1] = 3.95;
+
+    array1d< real64 > & gasOilRelPermMaxVal = relPerm.getReference< array1d< real64 > >( BrooksCoreyStone2RelativePermeability::viewKeyStruct::gasOilRelPermMaxValueString() );
+    gasOilRelPermMaxVal.resize( 2 );
+    gasOilRelPermMaxVal[0] = 0.8; gasOilRelPermMaxVal[1] = 0.95;
+
+    relPerm.postProcessInputRecursive();
+    return relPerm;
+}
+
 RelativePermeabilityBase & makeVanGenuchtenBakerRelPermTwoPhase( string const & name, Group & parent )
 {
   VanGenuchtenBakerRelativePermeability & relPerm = parent.registerGroup< VanGenuchtenBakerRelativePermeability >( name );
@@ -165,6 +198,41 @@ RelativePermeabilityBase & makeVanGenuchtenBakerRelPermThreePhase( string const 
 
   relPerm.postProcessInputRecursive();
   return relPerm;
+}
+
+RelativePermeabilityBase & makeVanGenuchtenStone2RelPermThreePhase( string const & name, Group & parent )
+{
+    VanGenuchtenStone2RelativePermeability & relPerm = parent.registerGroup< VanGenuchtenStone2RelativePermeability >( name );
+
+    string_array & phaseNames = relPerm.getReference< string_array >( RelativePermeabilityBase::viewKeyStruct::phaseNamesString() );
+    phaseNames.resize( 3 );
+    phaseNames[0] = "oil"; phaseNames[1] = "gas"; phaseNames[2] = "water";
+
+    array1d< real64 > & phaseMinSat = relPerm.getReference< array1d< real64 > >( VanGenuchtenStone2RelativePermeability::viewKeyStruct::phaseMinVolumeFractionString() );
+    phaseMinSat.resize( 3 );
+    phaseMinSat[0] = 0.03; phaseMinSat[1] = 0.01; phaseMinSat[2] = 0.025;
+
+    array1d< real64 > & waterOilRelPermExpInv = relPerm.getReference< array1d< real64 > >(
+            VanGenuchtenStone2RelativePermeability::viewKeyStruct::waterOilRelPermExponentInvString() );
+    waterOilRelPermExpInv.resize( 2 );
+    waterOilRelPermExpInv[0] = 2.4; waterOilRelPermExpInv[1] = 2.5;
+
+    array1d< real64 > & waterOilRelPermMaxVal =
+            relPerm.getReference< array1d< real64 > >( VanGenuchtenStone2RelativePermeability::viewKeyStruct::waterOilRelPermMaxValueString() );
+    waterOilRelPermMaxVal.resize( 2 );
+    waterOilRelPermMaxVal[0] = 0.9; waterOilRelPermMaxVal[1] = 0.75;
+
+    array1d< real64 > & gasOilRelPermExpInv =
+            relPerm.getReference< array1d< real64 > >( VanGenuchtenStone2RelativePermeability::viewKeyStruct::gasOilRelPermExponentInvString() );
+    gasOilRelPermExpInv.resize( 2 );
+    gasOilRelPermExpInv[0] = 1.9; gasOilRelPermExpInv[1] = 3.95;
+
+    array1d< real64 > & gasOilRelPermMaxVal = relPerm.getReference< array1d< real64 > >( BrooksCoreyStone2RelativePermeability::viewKeyStruct::gasOilRelPermMaxValueString() );
+    gasOilRelPermMaxVal.resize( 2 );
+    gasOilRelPermMaxVal[0] = 0.8; gasOilRelPermMaxVal[1] = 0.75;
+
+    relPerm.postProcessInputRecursive();
+    return relPerm;
 }
 
 RelativePermeabilityBase & makeTableRelPermTwoPhase( string const & name, Group & parent )
@@ -796,20 +864,99 @@ public:
   }
 };
 
-TEST_F( RelPermTest, numericalDerivatives_brooksCoreyRelPerm )
+//TEST_F( RelPermTest, numericalDerivatives_brooksCoreyRelPerm )
+//{
+//  initialize( makeBrooksCoreyRelPerm( "relPerm", m_parent ) );
+//
+//  array1d< real64 > sat( 2 );
+//  sat[0] = 0.7;
+//  sat[1] = 0.3;
+//
+//  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+//  real64 const tol = 1e-4;
+//
+//  test( sat, eps, tol );
+//}
+//
+//TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyBakerRelPermTwoPhase )
+//{
+//  initialize( makeBrooksCoreyBakerRelPermTwoPhase( "relPerm", m_parent ) );
+//
+//  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+//  real64 const tol = 1e-4;
+//
+//  real64 const startSat = 0.3;
+//  real64 const endSat   = 0.7;
+//  real64 const dS = 1e-1;
+//
+//  array1d< real64 > sat( 2 );
+//
+//  sat[0] = startSat;
+//  sat[1] = 1.0-sat[0];
+//
+//  while( sat[0] <= endSat )
+//  {
+//    test( sat, eps, tol );
+//    sat[0] += dS;
+//    sat[1] = 1-sat[0];
+//  }
+//}
+//
+//TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyBakerRelPermThreePhase )
+//{
+//  initialize( makeBrooksCoreyBakerRelPermThreePhase( "relPerm", m_parent ) );
+//
+//  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+//  real64 const tol = 1e-4;
+//
+//  real64 const startSat = 0.3;
+//  real64 const endSat   = 0.7;
+//  real64 const dS = 1e-1;
+//  real64 const alpha = 0.4;
+//
+//  array1d< real64 > sat( 3 );
+//
+//  sat[0] = startSat;
+//  sat[1] = alpha*(1.0-sat[0]);
+//  sat[2] = (1-alpha)*(1.0-sat[0]);
+//
+//  while( sat[0] <= endSat )
+//  {
+//    test( sat, eps, tol );
+//    sat[0] += dS;
+//    sat[1] = alpha *(1-sat[0]);
+//    sat[2] = (1-alpha) *(1-sat[0]);
+//  }
+//}
+
+TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyStone2RelPermThreePhase )
 {
-  initialize( makeBrooksCoreyRelPerm( "relPerm", m_parent ) );
+    initialize( makeBrooksCoreyStone2RelPermThreePhase( "relPerm", m_parent ) );
 
-  array1d< real64 > sat( 2 );
-  sat[0] = 0.7;
-  sat[1] = 0.3;
+    real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+    real64 const tol = 1e-4;
 
-  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
-  real64 const tol = 1e-4;
+    real64 const startSat = 0.3;
+    real64 const endSat   = 0.7;
+    real64 const dS = 1e-1;
+    real64 const alpha = 0.4;
 
-  test( sat, eps, tol );
+    array1d< real64 > sat( 3 );
+
+    sat[0] = startSat;
+    sat[1] = alpha*(1.0-sat[0]);
+    sat[2] = (1-alpha)*(1.0-sat[0]);
+
+    while( sat[0] <= endSat )
+    {
+        test( sat, eps, tol );
+        sat[0] += dS;
+        sat[1] = alpha *(1-sat[0]);
+        sat[2] = (1-alpha) *(1-sat[0]);
+    }
 }
 
+<<<<<<< HEAD
 TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyBakerRelPermTwoPhase )
 {
   initialize( makeBrooksCoreyBakerRelPermTwoPhase( "relPerm", m_parent ) );
@@ -999,6 +1146,145 @@ TEST_F( RelPermTest, numericalDerivatives_TableRelPermHysteresisTwoPhase )
     sat[1] = 1-sat[0];
   }
 }
+=======
+//
+//TEST_F( RelPermTest, numericalDerivatives_VanGenuchtenBakerRelPermTwoPhase )
+//{
+//  initialize( makeVanGenuchtenBakerRelPermTwoPhase( "relPerm", m_parent ) );
+//
+//  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+//  real64 const tol = 1e-4;
+//
+//  real64 const startSat = 0.3;
+//  real64 const endSat   = 0.7;
+//  real64 const dS = 1e-1;
+//
+//  array1d< real64 > sat( 2 );
+//
+//  sat[0] = startSat;
+//  sat[1] = 1.0-sat[0];
+//
+//  while( sat[0] <= endSat )
+//  {
+//    test( sat, eps, tol );
+//    sat[0] += dS;
+//    sat[1] = 1-sat[0];
+//  }
+//}
+//
+//TEST_F( RelPermTest, numericalDerivatives_VanGenuchtenBakerRelPermThreePhase )
+//{
+//  initialize( makeVanGenuchtenBakerRelPermThreePhase( "relPerm", m_parent ) );
+//
+//  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+//  real64 const tol = 1e-4;
+//
+//  real64 const startSat = 0.3;
+//  real64 const endSat   = 0.7;
+//  real64 const dS = 1e-1;
+//  real64 const alpha = 0.4;
+//
+//  array1d< real64 > sat( 3 );
+//
+//  sat[0] = startSat;
+//  sat[1] = alpha*(1.0-sat[0]);
+//  sat[2] = (1-alpha)*(1.0-sat[0]);
+//
+//  while( sat[0] <= endSat )
+//  {
+//    test( sat, eps, tol );
+//    sat[0] += dS;
+//    sat[1] = alpha *(1-sat[0]);
+//    sat[2] = (1-alpha) *(1-sat[0]);
+//  }
+//}
+//
+//TEST_F( RelPermTest, numericalDerivatives_TableRelPermTwoPhase )
+//{
+//  initialize( makeTableRelPermTwoPhase( "relPerm", m_parent ) );
+//
+//  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+//  real64 const tol = 1e-4;
+//
+//  real64 const startSat = 0.2;
+//  real64 const endSat = 0.6;
+//  real64 const dS = 1e-1;
+//
+//  array1d< real64 > sat( 2 );
+//
+//  sat[0] = startSat;
+//  sat[1] = 1.0-sat[0];
+//  while( sat[0] <= endSat )
+//  {
+//    test( sat, eps, tol );
+//    sat[0] += dS;
+//    sat[1] = 1-sat[0];
+//  }
+//}
+//
+//TEST_F( RelPermTest, numericalDerivatives_TableRelPermThreePhase )
+//{
+//  initialize( makeTableRelPermThreePhase( "relPerm", m_parent ) );
+//
+//  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+//  real64 const tol = 1e-4;
+//
+//  real64 const startSat = 0.3;
+//  real64 const endSat   = 0.7;
+//  real64 const dS = 1e-1;
+//  real64 const alpha = 0.4;
+//
+//  array1d< real64 > sat( 3 );
+//
+//  sat[0] = startSat;
+//  sat[1] = alpha*(1.0-sat[0]);
+//  sat[2] = (1-alpha)*(1.0-sat[0]);
+//
+//  while( sat[0] <= endSat )
+//  {
+//    test( sat, eps, tol );
+//    sat[0] += dS;
+//    sat[1] = alpha *(1-sat[0]);
+//    sat[2] = (1-alpha) *(1-sat[0]);
+//  }
+//}
+//
+//TEST_F( RelPermTest, numericalDerivatives_TableRelPermHysteresisTwoPhase )
+//{
+//  initialize( makeTableRelPermHysteresisTwoPhase( "relPerm", m_parent ) );
+//  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+//  real64 const tol = 1e-4;
+//
+//  real64 const startSat = 0.352;
+//  real64 const endSat = 0.952;
+//  real64 const dS = 2e-2;
+//
+//  array1d< real64 > sat( 2 );
+//  array2d< real64, compflow::LAYOUT_PHASE > initSat( 1, 2 );
+//
+//  sat[0] = startSat;
+//  sat[1] = 1.0-sat[0];
+//  initSat[0][0] = 0.6;
+//  initSat[0][1] = 0.4;
+//
+//  m_model->allocateConstitutiveData( m_parent, 1 );
+//  m_model->saveConvergedPhaseVolFractionState( initSat.toViewConst() );
+//
+//  // move the historical phase vol fraction back to the CPU since the test is performed on the CPU
+//  auto & phaseMinHistoricalVolFraction =
+//    m_model->getReference< array2d< real64, compflow::LAYOUT_PHASE > >( fields::relperm::phaseMinHistoricalVolFraction::key() );
+//  phaseMinHistoricalVolFraction.move( LvArray::MemorySpace::host, false );
+//  auto & phaseMaxHistoricalVolFraction =
+//    m_model->getReference< array2d< real64, compflow::LAYOUT_PHASE > >( fields::relperm::phaseMaxHistoricalVolFraction::key() );
+//  phaseMaxHistoricalVolFraction.move( LvArray::MemorySpace::host, false );
+//
+//  while( sat[0] <= endSat )
+//  {
+//    test( sat, eps, tol );
+//    sat[0] += dS;
+//    sat[1] = 1-sat[0];
+//  }
+//}
 
 
 int main( int argc, char * * argv )

--- a/src/coreComponents/unitTests/constitutiveTests/testRelPerm.cpp
+++ b/src/coreComponents/unitTests/constitutiveTests/testRelPerm.cpp
@@ -864,70 +864,70 @@ public:
   }
 };
 
-//TEST_F( RelPermTest, numericalDerivatives_brooksCoreyRelPerm )
-//{
-//  initialize( makeBrooksCoreyRelPerm( "relPerm", m_parent ) );
-//
-//  array1d< real64 > sat( 2 );
-//  sat[0] = 0.7;
-//  sat[1] = 0.3;
-//
-//  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
-//  real64 const tol = 1e-4;
-//
-//  test( sat, eps, tol );
-//}
-//
-//TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyBakerRelPermTwoPhase )
-//{
-//  initialize( makeBrooksCoreyBakerRelPermTwoPhase( "relPerm", m_parent ) );
-//
-//  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
-//  real64 const tol = 1e-4;
-//
-//  real64 const startSat = 0.3;
-//  real64 const endSat   = 0.7;
-//  real64 const dS = 1e-1;
-//
-//  array1d< real64 > sat( 2 );
-//
-//  sat[0] = startSat;
-//  sat[1] = 1.0-sat[0];
-//
-//  while( sat[0] <= endSat )
-//  {
-//    test( sat, eps, tol );
-//    sat[0] += dS;
-//    sat[1] = 1-sat[0];
-//  }
-//}
-//
-//TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyBakerRelPermThreePhase )
-//{
-//  initialize( makeBrooksCoreyBakerRelPermThreePhase( "relPerm", m_parent ) );
-//
-//  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
-//  real64 const tol = 1e-4;
-//
-//  real64 const startSat = 0.3;
-//  real64 const endSat   = 0.7;
-//  real64 const dS = 1e-1;
-//  real64 const alpha = 0.4;
-//
-//  array1d< real64 > sat( 3 );
-//
-//  sat[0] = startSat;
-//  sat[1] = alpha*(1.0-sat[0]);
-//  sat[2] = (1-alpha)*(1.0-sat[0]);
-//
-//  while( sat[0] <= endSat )
-//  {
-//    test( sat, eps, tol );
-//    sat[0] += dS;
-//    sat[1] = alpha *(1-sat[0]);
-//    sat[2] = (1-alpha) *(1-sat[0]);
-//  }
-//}
+TEST_F( RelPermTest, numericalDerivatives_brooksCoreyRelPerm )
+{
+  initialize( makeBrooksCoreyRelPerm( "relPerm", m_parent ) );
+
+  array1d< real64 > sat( 2 );
+  sat[0] = 0.7;
+  sat[1] = 0.3;
+
+  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+  real64 const tol = 1e-4;
+
+  test( sat, eps, tol );
+}
+
+TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyBakerRelPermTwoPhase )
+{
+  initialize( makeBrooksCoreyBakerRelPermTwoPhase( "relPerm", m_parent ) );
+
+  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+  real64 const tol = 1e-4;
+
+  real64 const startSat = 0.3;
+  real64 const endSat   = 0.7;
+  real64 const dS = 1e-1;
+
+  array1d< real64 > sat( 2 );
+
+  sat[0] = startSat;
+  sat[1] = 1.0-sat[0];
+
+  while( sat[0] <= endSat )
+  {
+    test( sat, eps, tol );
+    sat[0] += dS;
+    sat[1] = 1-sat[0];
+  }
+}
+
+TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyBakerRelPermThreePhase )
+{
+  initialize( makeBrooksCoreyBakerRelPermThreePhase( "relPerm", m_parent ) );
+
+  real64 const eps = std::sqrt( std::numeric_limits< real64 >::epsilon() );
+  real64 const tol = 1e-4;
+
+  real64 const startSat = 0.3;
+  real64 const endSat   = 0.7;
+  real64 const dS = 1e-1;
+  real64 const alpha = 0.4;
+
+  array1d< real64 > sat( 3 );
+
+  sat[0] = startSat;
+  sat[1] = alpha*(1.0-sat[0]);
+  sat[2] = (1-alpha)*(1.0-sat[0]);
+
+  while( sat[0] <= endSat )
+  {
+    test( sat, eps, tol );
+    sat[0] += dS;
+    sat[1] = alpha *(1-sat[0]);
+    sat[2] = (1-alpha) *(1-sat[0]);
+  }
+}
 
 TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyStone2RelPermThreePhase )
 {
@@ -956,6 +956,7 @@ TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyStone2RelPermThreePhase )
     }
 }
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyBakerRelPermTwoPhase )
 {
@@ -1008,6 +1009,8 @@ TEST_F( RelPermTest, numericalDerivatives_BrooksCoreyBakerRelPermThreePhase )
   }
 }
 
+=======
+>>>>>>> 04ee082fc (Uncomment tests in testRelPerm.cpp)
 
 TEST_F( RelPermTest, numericalDerivatives_VanGenuchtenBakerRelPermTwoPhase )
 {
@@ -1134,10 +1137,17 @@ TEST_F( RelPermTest, numericalDerivatives_TableRelPermHysteresisTwoPhase )
   // move the historical phase vol fraction back to the CPU since the test is performed on the CPU
   auto & phaseMinHistoricalVolFraction =
     m_model->getReference< array2d< real64, compflow::LAYOUT_PHASE > >( fields::relperm::phaseMinHistoricalVolFraction::key() );
+<<<<<<< HEAD
   phaseMinHistoricalVolFraction.move( hostMemorySpace, false );
   auto & phaseMaxHistoricalVolFraction =
     m_model->getReference< array2d< real64, compflow::LAYOUT_PHASE > >( fields::relperm::phaseMaxHistoricalVolFraction::key() );
   phaseMaxHistoricalVolFraction.move( hostMemorySpace, false );
+=======
+  phaseMinHistoricalVolFraction.move( LvArray::MemorySpace::host, false );
+  auto & phaseMaxHistoricalVolFraction =
+    m_model->getReference< array2d< real64, compflow::LAYOUT_PHASE > >( fields::relperm::phaseMaxHistoricalVolFraction::key() );
+  phaseMaxHistoricalVolFraction.move( LvArray::MemorySpace::host, false );
+>>>>>>> 04ee082fc (Uncomment tests in testRelPerm.cpp)
 
   while( sat[0] <= endSat )
   {
@@ -1146,6 +1156,7 @@ TEST_F( RelPermTest, numericalDerivatives_TableRelPermHysteresisTwoPhase )
     sat[1] = 1-sat[0];
   }
 }
+<<<<<<< HEAD
 =======
 //
 //TEST_F( RelPermTest, numericalDerivatives_VanGenuchtenBakerRelPermTwoPhase )


### PR DESCRIPTION
(reedition of #2301)

Adding the Stone II interpolation for three phases relperm as an other option (Baker is default).
To do that I added :
- `BrooksCoreyStone2` , `VanGenuchtenStone2` classes to handle cases in which the relperm are obtained through resp. Brooks and Corey and Van Genuchten models
- `flagInterpolate` boolean flag in `TableRelativePermeability` to switch between the two possible interpolation.
- `makeBrooksCoreyStone2RelPermThreePhase` and `makeVanGenuchtenStone2RelPermThreePhase` to the `testRelPerm.cpp` 
Once the code was added, I added new integrated tests: `black_oil_wells_saturated_3d_stone2.xml` and `black_oil_wells_unsaturated_3d_stone2.xml`