### PR TITLE
Worked on a minimal reproducer.

### DIFF
--- a/src/coreComponents/CMakeLists.txt
+++ b/src/coreComponents/CMakeLists.txt
@@ -1,5 +1,5 @@
 set( subdirs
-     math
+    #  math
      common
      codingUtilities
      dataRepository
@@ -7,17 +7,17 @@ set( subdirs
      functions
      constitutive
      mesh
-     denseLinearAlgebra
-     linearAlgebra
-     fieldSpecification
-     finiteElement
-     finiteVolume
-     discretizationMethods
-     fileIO
-     physicsSolvers
+     denseLinearAlgebra # Commenting out denseLinearAlgebra will cause this to work
+    #  linearAlgebra
+    #  fieldSpecification
+    #  finiteElement
+    #  finiteVolume
+    #  discretizationMethods
+    #  fileIO
+    #  physicsSolvers
      events
      mainInterface
-     python
+    #  python
    )
 
 set( parallelDeps "" )

--- a/src/coreComponents/constitutive/CMakeLists.txt
+++ b/src/coreComponents/constitutive/CMakeLists.txt
@@ -247,7 +247,7 @@ set( constitutive_sources
      thermalConductivity/SinglePhaseThermalConductivityBase.cpp
    )
 
-set( dependencyList ${parallelDeps} events dataRepository functions denseLinearAlgebra )
+set( dependencyList ${parallelDeps} events dataRepository functions )
 
 if( ENABLE_PVTPackage )
     set( constitutive_headers

--- a/src/coreComponents/constitutive/fluid/multifluid/reactive/chemicalReactions/EquilibriumReactions.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/reactive/chemicalReactions/EquilibriumReactions.cpp
@@ -189,7 +189,8 @@ void EquilibriumReactions::KernelWrapper::updateConcentrations( real64 const tem
                                        matrix,
                                        rhs );
 
-    real64 const residualNorm = BlasLapackLA::vectorNorm2( rhs.toSliceConst() );
+    // real64 const residualNorm = BlasLapackLA::vectorNorm2( rhs.toSliceConst() );
+    real64 const residualNorm = 0;
 
     if( residualNorm < m_newtonTol && iteration >= 1 )
     {
@@ -197,7 +198,7 @@ void EquilibriumReactions::KernelWrapper::updateConcentrations( real64 const tem
       break;
     }
 
-    BlasLapackLA::solveLinearSystem( matrix, rhs, solution );
+    // BlasLapackLA::solveLinearSystem( matrix, rhs, solution );
 
     updatePrimarySpeciesConcentrations( solution, primarySpeciesConcentration );
   }

--- a/src/coreComponents/events/CMakeLists.txt
+++ b/src/coreComponents/events/CMakeLists.txt
@@ -24,7 +24,7 @@ set( events_sources
      tasks/TasksManager.cpp
    )
 
-set( dependencyList ${parallelDeps} common fileIO dataRepository )
+set( dependencyList ${parallelDeps} common dataRepository )
 
 blt_add_library( NAME       events
                  SOURCES    ${events_sources}

--- a/src/coreComponents/mainInterface/CMakeLists.txt
+++ b/src/coreComponents/mainInterface/CMakeLists.txt
@@ -6,19 +6,21 @@ set( mainInterface_headers
      ProblemManager.hpp
      initialization.hpp
      version.hpp
+     reproducer.hpp
    )
 
 #
 # Specify all sources
 #
 set( mainInterface_sources
-     GeosxState.cpp
-     ProblemManager.cpp
-     initialization.cpp
-     version.cpp
+    #  GeosxState.cpp
+    #  ProblemManager.cpp
+    #  initialization.cpp
+    #  version.cpp
+     reproducer.cpp
    )
 
-set( dependencyList ${parallelDeps} physicsSolvers discretizationMethods fieldSpecification linearAlgebra dataRepository events fileIO optionparser )
+set( dependencyList ${parallelDeps} dataRepository optionparser )
 
 blt_add_library( NAME       mainInterface
                  SOURCES    ${mainInterface_sources}

--- a/src/coreComponents/mainInterface/reproducer.cpp
+++ b/src/coreComponents/mainInterface/reproducer.cpp
@@ -1,0 +1,23 @@
+#include "reproducer.hpp"
+
+#include "RAJA/RAJA.hpp"
+
+#include <vector>
+#include <iostream>
+
+void test()
+{
+  std::vector< int > data { 0, 3, 1, 1, 0, 1, 0, 0, 0 };
+
+  // Perform an inplace prefix-sum to get the unique edge offset.
+  RAJA::inclusive_scan_inplace< RAJA::omp_parallel_for_exec >( RAJA::make_span( data.data(), data.size() ) );
+
+  std::cout << " after scan = ";
+
+  for( auto const & value : data )
+  {
+    std::cout << value << ", ";
+  }
+
+  std::cout << std::endl;
+}

--- a/src/coreComponents/mainInterface/reproducer.hpp
+++ b/src/coreComponents/mainInterface/reproducer.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "RAJA/RAJA.hpp"
+
+#include <vector>
+#include <iostream>
+
+inline void testInline()
+{
+  std::vector< int > data { 0, 3, 1, 1, 0, 1, 0, 0, 0 };
+
+  // Perform an inplace prefix-sum to get the unique edge offset.
+  RAJA::inclusive_scan_inplace< RAJA::omp_parallel_for_exec >( RAJA::make_span( data.data(), data.size() ) );
+
+  std::cout << " after scan = ";
+
+  for( auto const & value : data )
+  {
+    std::cout << value << ", ";
+  }
+
+  std::cout << std::endl;
+}
+
+void test();

--- a/src/coreComponents/mesh/CMakeLists.txt
+++ b/src/coreComponents/mesh/CMakeLists.txt
@@ -128,7 +128,7 @@ set( mesh_sources
      utilities/ComputationalGeometry.cpp
      )
 
-set( dependencyList ${parallelDeps} schema dataRepository constitutive finiteElement parmetis metis )
+set( dependencyList ${parallelDeps} schema dataRepository constitutive parmetis metis )
 
 if( ENABLE_VTK )
     message(STATUS "Adding VTKMeshGenerator sources and headers")

--- a/src/docs/doxygen/GeosxConfig.hpp
+++ b/src/docs/doxygen/GeosxConfig.hpp
@@ -33,7 +33,7 @@
 #define GEOSX_USE_OPENMP
 
 /// Enables use of CUDA (CMake option ENABLE_CUDA)
-/* #undef GEOS_USE_CUDA */
+#define GEOS_USE_CUDA
 
 /// Enables use of CUDA NVToolsExt (CMake option ENABLE_CUDA_NVTOOLSEXT)
 /* #undef GEOS_USE_CUDA_NVTOOLSEXT */
@@ -81,7 +81,7 @@
 /// Denotes HYPRE using HIP
 #define GEOS_USE_HYPRE_HIP 2
 /// Macro determining what parellel interface hypre is using
-#define GEOS_USE_HYPRE_DEVICE GEOS_USE_HYPRE_CPU
+#define GEOS_USE_HYPRE_DEVICE GEOS_USE_HYPRE_CUDA
 
 /// Enables use of SuperLU_dist library through HYPRE (CMake option ENABLE_SUPERLU_DIST)
 #define GEOSX_USE_SUPERLU_DIST

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -1,78 +1,12 @@
-/*
- * ------------------------------------------------------------------------------------------------------------
- * SPDX-License-Identifier: LGPL-2.1-only
- *
- * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
- * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
- * Copyright (c) 2018-2020 TotalEnergies
- * Copyright (c) 2019-     GEOSX Contributors
- * All rights reserved
- *
- * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
- * ------------------------------------------------------------------------------------------------------------
- */
-
-// Source includes
-#include "common/DataTypes.hpp"
-#include "common/Format.hpp"
-#include "common/TimingMacros.hpp"
-#include "mainInterface/initialization.hpp"
-#include "mainInterface/ProblemManager.hpp"
-#include "mainInterface/GeosxState.hpp"
-
-
-using namespace geos;
-
+#include "mainInterface/reproducer.hpp"
 
 int main( int argc, char *argv[] )
 {
-  try
-  {
-    std::chrono::system_clock::time_point startTime = std::chrono::system_clock::now();
+  testInline();
 
-    std::unique_ptr< CommandLineOptions > commandLineOptions = basicSetup( argc, argv, true );
+  test();
 
-    GEOS_LOG_RANK_0( GEOS_FMT( "Started at {:%Y-%m-%d %H:%M:%S}", startTime ) );
+  testInline();
 
-    std::chrono::system_clock::duration initTime;
-    std::chrono::system_clock::duration runTime;
-    {
-      GeosxState state( std::move( commandLineOptions ) );
-
-      bool const problemToRun = state.initializeDataRepository();
-      if( problemToRun )
-      {
-        state.applyInitialConditions();
-        state.run();
-        LVARRAY_WARNING_IF( state.getState() != State::COMPLETED, "Simulation exited early." );
-      }
-
-      initTime = state.getInitTime();
-      runTime = state.getRunTime();
-    }
-
-    basicCleanup();
-
-    std::chrono::system_clock::time_point endTime = std::chrono::system_clock::now();
-    std::chrono::system_clock::duration totalTime = endTime - startTime;
-
-    GEOS_LOG_RANK_0( GEOS_FMT( "Finished at {:%Y-%m-%d %H:%M:%S}", endTime ) );
-    GEOS_LOG_RANK_0( GEOS_FMT( "total time            {:%H:%M:%S}", totalTime ) );
-    GEOS_LOG_RANK_0( GEOS_FMT( "initialization time   {:%H:%M:%S}", initTime ) );
-    GEOS_LOG_RANK_0( GEOS_FMT( "run time              {:%H:%M:%S}", runTime ) );
-
-    return 0;
-  }
-  // A NotAnError is thrown if "-h" or "--help" option is used.
-  catch( NotAnError const & )
-  {
-    return 0;
-  }
-  catch( std::exception const & e )
-  {
-    GEOS_LOG( e.what() );
-    LvArray::system::callErrorHandler();
-    std::abort();
-  }
   return 0;
 }


### PR DESCRIPTION
Most of these changes are unnecessary and just reduce the dependencies.

The correct output from running `./bin/geosx` should be

```
 after scan = 0, 3, 4, 5, 5, 6, 6, 6, 6, 
 after scan = 0, 3, 4, 5, 5, 6, 6, 6, 6,
 after scan = 0, 3, 4, 5, 5, 6, 6, 6, 6,
```
this can be achieved by commenting out the `denseLinearAlgebra` component for whatever reason. Otherwise as is the output is

```
 after scan = 0, 3, 4, 5, 5, 6, 6, 6, 6, 
 after scan = 0, 3, 28, 145, 549, 1696, 4530, 10836, 23760, 
 after scan = 0, 3, 4, 5, 5, 6, 6, 6, 6, 
```

This is from `lassen-clang-10-cuda-11-relwithdebinfo` and my modules are

```
Currently Loaded Modules:
  1) xl/2022.08.19   2) spectrum-mpi/rolling-release   3) StdEnv (S)   4) git/2.20.0   5) git-lfs/2.5.2   6) cuda/11.8.0   7) cmake/3.23.1
```