### PR TITLE
Update .gitlab-ci.yml host-config paths, CMake version to 3.23.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ stages:
     - module load python/2
 
     # GEOS requires CMake >=3.23
-    - module load cmake/3.23
+    - module load cmake/3.23.1
 
     # CONFIGURE
     - echo "~~~~~~~~~~ START - configure ~~~~~~~~~~~"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,9 @@ stages:
     # geosxats needs python2 to run
     - module load python/2
 
+    # GEOS requires CMake >=3.23
+    - module load cmake/3.23
+
     # CONFIGURE
     - echo "~~~~~~~~~~ START - configure ~~~~~~~~~~~"
     - config_code=0

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -141,21 +141,21 @@ stages:
 # quartz job
 quartz_clang_14_build:
   variables:
-    HOST_CONFIG: "quartz-clang@14.cmake"
+    HOST_CONFIG: "quartz-clang-14.cmake"
   extends: [.build_on_quartz]
 
 ####
 # tioga job
-tioga_clang_14_build:
+tioga_cce_15_build:
   variables:
-    HOST_CONFIG: "tioga-cce@15.0.0.cmake"
+    HOST_CONFIG: "tioga-cce-15.cmake"
   extends: [.build_on_tioga]
 
 ####
 # lassen job
-lassen_clang_upstream_build:
+lassen_clang_10_cuda_11_build:
   variables:
-    HOST_CONFIG: "lassen-clang@upstream.cmake"
+    HOST_CONFIG: "lassen-clang-10-cuda-11.cmake"
   extends: [.build_on_lassen]
 
 ####


### PR DESCRIPTION
This PR updates gitlab CI host-config path names, and loads CMake 3.23 prior to building GEOS.

CI pipeline run of this branch here:
https://lc.llnl.gov/gitlab/settgast/GEOSX/-/pipelines/305958