### PR TITLE
fix two tutorial examples

### DIFF
--- a/src/docs/sphinx/advancedExamples/validationStudies/faultMechanics/mandel/mandelFigure.py
+++ b/src/docs/sphinx/advancedExamples/validationStudies/faultMechanics/mandel/mandelFigure.py
@@ -144,7 +144,7 @@ def main():
     hdf5File1Path = "pressure_history.hdf5"
     hdf5File2Path = "displacement_history.hdf5"
     xmlFile1Path = "../../../../../../../inputFiles/poromechanics/PoroElastic_Mandel_base.xml"
-    xmlFile2Path = "../../../../../../../inputFiles/poromechanics/PoroElastic_Mandel_benchmark.xml"
+    xmlFile2Path = "../../../../../../../inputFiles/poromechanics/PoroElastic_Mandel_benchmark_fim.xml"
 
     # Read HDF5
     # Global Coordinate of Element Center

--- a/src/docs/sphinx/advancedExamples/validationStudies/faultMechanics/sneddon/Example.rst
+++ b/src/docs/sphinx/advancedExamples/validationStudies/faultMechanics/sneddon/Example.rst
@@ -269,11 +269,11 @@ Running GEOS
 
 To run these three cases, use the following commands:
 
-``path/to/geosx -i inputFiles/efemFractureMechanics/Sneddon_embeddedFrac_benchmark.xml``
+``path/to/geos -i inputFiles/efemFractureMechanics/Sneddon_embeddedFrac_benchmark.xml``
 
-``path/to/geosx -i inputFiles/lagrangianContactMechanics/Sneddon_contactMechanics_benchmark.xml``
+``path/to/geos -i inputFiles/lagrangianContactMechanics/Sneddon_contactMechanics_benchmark.xml``
 
-``path/to/geosx -i inputFiles/hydraulicFracturing/Sneddon_hydroFrac_benchmark.xml``
+``path/to/geos -i inputFiles/hydraulicFracturing/Sneddon_hydroFrac_benchmark.xml``
 
 ---------------------------------
 Inspecting results

--- a/src/docs/sphinx/advancedExamples/validationStudies/faultMechanics/sneddon/sneddonFigure.py
+++ b/src/docs/sphinx/advancedExamples/validationStudies/faultMechanics/sneddon/sneddonFigure.py
@@ -55,7 +55,7 @@ def getFractureLengthFromXML(xmlFilePath):
     dimensions = rectangle.get("dimensions")
     dimensions = [float(i) for i in dimensions[1:-1].split(",")]
     length = dimensions[0] / 2
-    origin = boundedPlane.get("origin")
+    origin = rectangle.get("origin")
     origin = [float(i) for i in origin[1:-1].split(",")]
 
     return length, origin[0]


### PR DESCRIPTION
This small PR fixes broken links in

- [x]  [Sneddon example](https://geosx-geosx.readthedocs-hosted.com/en/latest/docs/sphinx/advancedExamples/validationStudies/faultMechanics/sneddon/Example.html), which is caused by [recent update](https://github.com/GEOS-DEV/GEOS/pull/2479).
- [x]  [Mandal example](https://geosx-geosx.readthedocs-hosted.com/en/latest/docs/sphinx/advancedExamples/validationStudies/faultMechanics/mandel/Example.html) which is caused by [this update](https://github.com/GEOS-DEV/GEOS/pull/2554).

No rebaseline is required.