### PR TITLE
Update tutorial example for CO2 injection

### DIFF
--- a/inputFiles/compositionalMultiphaseWell/simpleCo2InjTutorial_smoke.xml
+++ b/inputFiles/compositionalMultiphaseWell/simpleCo2InjTutorial_smoke.xml
@@ -22,8 +22,8 @@
         name="wellInjector1"
         wellRegionName="wellRegion"
         wellControlsName="wellControls"
-        polylineNodeCoords="{ { 500.0, 500.0, 6650.00 },
-                              { 500.0, 500.0, 6600.00 } }"
+        polylineNodeCoords="{ { 525.0, 525.0, 6650.00 },
+                              { 525.0, 525.0, 6600.00 } }"
         polylineSegmentConn="{ { 0, 1 } }"
         radius="0.1"
         numElementsPerSegment="2">


### PR DESCRIPTION
This small PR fixes the [reported issue ](https://github.com/GEOS-DEV/GEOS/issues/2595).

Somehow, the smoke test for this tutorial example is not included in the integratedTests and hence this unexpected issue. 