### PR TITLE
Specifying npm/mermaid versions

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,8 +13,8 @@ build:
     python: "3.7"
   jobs:
     post_install:
-    - npm install -g npm
-    - npm install -g @mermaid-js/mermaid-cli
+    - npm install -g npm@9.8.1
+    - npm install -g @mermaid-js/mermaid-cli@10.3.1
 
 # Set requirements to build the docs
 python:


### PR DESCRIPTION
The versions of `npm` and `mermaid` were not fixed: latest versions were used.
A recent upgrade lead us into an incompatible combination of dependencies.
I've fixed to yesterday's version.