### PR TITLE
Fix python globbing to fix erroneous *py files

### DIFF
--- a/src/coreComponents/python/CMakeLists.txt
+++ b/src/coreComponents/python/CMakeLists.txt
@@ -30,20 +30,20 @@ if ( Python3_EXECUTABLE )
                          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
                        )
 
-     add_custom_target( geosx_python_tools 
+     add_custom_target( geosx_python_tools
                         DEPENDS ${GEOSX_PYTHON_TOOLS_BINS} )
 
      add_custom_target( geosx_python_tools_test
                         COMMAND ${CMAKE_BINARY_DIR}/python/geosx/bin/test_geosx_xml_tools
                         COMMAND rm -r ${CMAKE_BINARY_DIR}/python/geosx_xml_tools_tests*
                         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/python
-                        DEPENDS geosx_python_tools 
+                        DEPENDS geosx_python_tools
                       )
 
      add_custom_target( geosx_format_all_xml_files
                         COMMAND bash ${CMAKE_SOURCE_DIR}/../scripts/formatXMLFiles.bash -g ${CMAKE_BINARY_DIR}/bin/format_xml ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/../examples
                         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-                        DEPENDS geosx_xml_tools 
+                        DEPENDS geosx_xml_tools
                       )
 
 else()
@@ -55,7 +55,7 @@ endif()
 # Python formatting
 if ( ENABLE_YAPF )
      set( python_module_sources )
-     file( GLOB_RECURSE python_module_sources "*py" )
+     file( GLOB_RECURSE python_module_sources "*.py" )
 
      # Note: blt throws an error if sources doesn't include a c-file, so include dummy.cpp
      blt_add_code_checks( PREFIX  python_modules_yapf_style
@@ -63,7 +63,7 @@ if ( ENABLE_YAPF )
                           YAPF_CFG_FILE ${PROJECT_SOURCE_DIR}/yapf.cfg )
 
      set( python_script_sources )
-     file( GLOB_RECURSE python_script_sources "${CMAKE_SOURCE_DIR}/../scripts/*py" )
+     file( GLOB_RECURSE python_script_sources "${CMAKE_SOURCE_DIR}/../scripts/*.py" )
 
      blt_add_code_checks( PREFIX  python_scripts_yapf_style
                           SOURCES ${python_script_sources} ${CMAKE_SOURCE_DIR}/coreComponents/dummy.cpp


### PR DESCRIPTION
E.g. on lassen the config is failing due to capturing `h5copy` in the python source globbing.