### PR TITLE
Remove an erroneous assertion  (#2631)

### DIFF
--- a/src/coreComponents/mesh/generators/CellBlockManager.cpp
+++ b/src/coreComponents/mesh/generators/CellBlockManager.cpp
@@ -292,8 +292,7 @@ void populateFaceMaps( Group const & cellBlocks,
   GEOS_ERROR_IF_NE( faceToBlocks.size( 1 ), 2 );
 
   // loop over all the nodes.
-  forAll< parallelHostPolicy >( numNodes, [ numNodes,
-                                            uniqueFaceOffsets,
+  forAll< parallelHostPolicy >( numNodes, [ uniqueFaceOffsets,
                                             lowestNodeToFaces,
                                             faceToNodes,
                                             faceToCells,
@@ -309,8 +308,6 @@ void populateFaceMaps( Group const & cellBlocks,
       NodesAndElementOfFace const & f0 = *first;
       CellBlock const & cb = cellBlocks.getGroup< CellBlock >( f0.blockIndex );
       localIndex const numNodesInFace = cb.getFaceNodes( f0.cellIndex, f0.faceNumber, nodesInFace );
-      GEOS_ASSERT_EQ( numNodesInFace, numNodes );
-      GEOS_UNUSED_VAR( numNodes );
 
       for( localIndex i = 0; i < numNodesInFace; ++i )
       {

--- a/src/coreComponents/mesh/generators/CellBlockManager.cpp
+++ b/src/coreComponents/mesh/generators/CellBlockManager.cpp
@@ -267,7 +267,7 @@ struct FaceBuilder
 
 /**
  * @brief Fills the face to nodes map and face to element maps
- * @param [in] lowestNodeToFaces and array of size numNodes of arrays of NodesAndElementOfFace associated with each node.
+ * @param [in] lowestNodeToFaces an array of size numNodes of arrays of NodesAndElementOfFace associated with each node.
  * @param [in] uniqueFaceOffsets an array containing the unique ID of the first face associated with each node.
  * @param [inout] faceToCells the face to element map.
  * @param [inout] faceToNodes the face to node map.
@@ -338,7 +338,7 @@ void populateFaceMaps( Group const & cellBlocks,
 
 /**
  * @brief Resize the face maps
- * @param [in] lowestNodeToFaces and array of size numNodes of arrays of NodesAndElementOfFace associated with each node.
+ * @param [in] lowestNodeToFaces an array of size numNodes of arrays of NodesAndElementOfFace associated with each node.
  * @param [in] uniqueFaceOffsets an containing the unique face IDs for each node in lowestNodeToFaces.
  * @param [out] faceToNodeMap the map from faces to nodes. This function resizes the array appropriately.
  * @param [out] faceToCellMap the map from faces to elements. This function resizes the array appropriately.

--- a/src/coreComponents/mesh/generators/CellBlockManager.hpp
+++ b/src/coreComponents/mesh/generators/CellBlockManager.hpp
@@ -104,11 +104,12 @@ public:
 
   /**
    * @brief Defines the number of nodes and resizes some underlying arrays appropriately.
-   * @param[in] numNodes The number of nodes.
+   * @param[in] numNodes The number of nodes on the MPI rank (that is per domain).
+   * Nodes are not duplicated along subregion interfaces.
    *
    * The nodes coordinates and nodes local to global mappings get resized to @p numNodes.
    */
-  void setNumNodes( localIndex numNodes ); // TODO Improve doc. Is it per domain, are there duplicated nodes because of subregions?
+  void setNumNodes( localIndex numNodes );
 
   void generateHighOrderMaps( localIndex const order,
                               globalIndex const maxVertexGlobalID,


### PR DESCRIPTION
This PR:
  - removes an assertion who makes geos crash when it is built in Debug mode (see issue #2631).
   According to geos code and doc:
    - `numNodesInFace` is the number of nodes along the face of an element ([`getFaceNodes` method](https://github.com/GEOS-DEV/GEOS/blob/52354b4874c44d1132717a49732f2d9888d5241b/src/coreComponents/mesh/generators/CellBlock.hpp#L95-L100)),
    - `numNodes = lowestNodeToFaces.size();  (see [numNodes setting](https://github.com/GEOS-DEV/GEOS/blob/52354b4874c44d1132717a49732f2d9888d5241b/src/coreComponents/mesh/generators/CellBlockManager.cpp#L285))
    - `lowestNodeToFaces` is of size `m_numNodes` (that is the number of nodes on the partition) (see [lowestNodeToFaces allocation](https://github.com/GEOS-DEV/GEOS/blob/52354b4874c44d1132717a49732f2d9888d5241b/src/coreComponents/mesh/generators/CellBlockManager.cpp#L428C1-L428C1))
  - develops a little the associated code documentation.

Note that this erroneous assertion is not detected by the ci due to the transfer of the `NDEBUG` flag of the hdf5 build toward the geos compilation flags through Conduit (see TPL PR [#243](https://github.com/GEOS-DEV/thirdPartyLibs/pull/243) )

Closes issue #2631