### PR TITLE
ReadTheDocs equations

### DIFF
--- a/src/docs/sphinx/requirements.txt
+++ b/src/docs/sphinx/requirements.txt
@@ -8,4 +8,3 @@ pandas
 # using plantuml for diagrams
 sphinxcontrib-plantuml
 sphinx-argparse
-pydata-sphinx-theme


### PR DESCRIPTION
This PR:
- Attempts to fix readthedocs sphinx equations
  -  Looks to be somewhat related to installing pydata-sphinx-theme, when readthedocs theme is already present/targeted for use?

ReadTheDocs link to this PR: https://geosx-geosx--2727.com.readthedocs.build/en/2727/
Related to #2633 