### PR TITLE
DRAFT: CSV TimeHistory output

### DIFF
--- a/src/coreComponents/fileIO/CMakeLists.txt
+++ b/src/coreComponents/fileIO/CMakeLists.txt
@@ -9,10 +9,12 @@ set( fileIO_headers
      Outputs/PythonOutput.hpp
      Outputs/RestartOutput.hpp
      Outputs/TimeHistoryOutput.hpp
+     timeHistory/ASCIIFile.hpp
      timeHistory/HDFFile.hpp
      timeHistory/HistoryCollectionBase.hpp
      timeHistory/BufferedHistoryIO.hpp
      timeHistory/PackCollection.hpp
+     timeHistory/CSVHistoryIO.hpp
      timeHistory/HDFHistoryIO.hpp
      timeHistory/HistoryCollection.hpp
    )
@@ -30,7 +32,9 @@ set( fileIO_sources
      Outputs/TimeHistoryOutput.cpp
      timeHistory/HDFFile.cpp
      timeHistory/HistoryCollectionBase.cpp
+     timeHistory/BufferedHistoryIO.cpp
      timeHistory/PackCollection.cpp
+     timeHistory/CSVHistoryIO.cpp
      timeHistory/HDFHistoryIO.cpp
    )
 
@@ -59,10 +63,10 @@ endif()
 
 if( ENABLE_SILO )
   set( dependencyList ${dependencyList} silo )
-  list( APPEND fileIO_headers 
-               silo/SiloFile.hpp 
+  list( APPEND fileIO_headers
+               silo/SiloFile.hpp
                Outputs/SiloOutput.hpp )
-  list( APPEND fileIO_sources 
+  list( APPEND fileIO_sources
                silo/SiloFile.cpp
                Outputs/SiloOutput.cpp )
 endif( )

--- a/src/coreComponents/fileIO/Outputs/TimeHistoryOutput.hpp
+++ b/src/coreComponents/fileIO/Outputs/TimeHistoryOutput.hpp
@@ -23,6 +23,7 @@
 #include "fileIO/timeHistory/HistoryCollection.hpp"
 #include "fileIO/timeHistory/BufferedHistoryIO.hpp"
 #include "fileIO/timeHistory/HDFHistoryIO.hpp"
+#include "fileIO/timeHistory/CSVHistoryIO.hpp"
 
 #include "LvArray/src/Array.hpp" // just for collector
 

--- a/src/coreComponents/fileIO/timeHistory/ASCIIFile.hpp
+++ b/src/coreComponents/fileIO/timeHistory/ASCIIFile.hpp
@@ -1,0 +1,110 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2019 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2019 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2019 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All right reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef GEOS_FILEIO_TIMEHISTORY_ASCIIFILE_HPP_
+#define GEOS_FILEIO_TIMEHISTORY_ASCIIFILE_HPP_
+
+#include <fstream>
+#include <string>
+#include <filesystem>
+#include <algorithm>
+#include <iterator>
+
+namespace geos
+{
+
+class ASCIIFile
+{
+public:
+  // Constructor: Opens the ASCII file. If the file already exists and `existsOkay` is false, throws an error.
+  ASCIIFile( const std::string & filename,
+             bool deleteExisting,
+             bool existsOkay) :
+    m_filename(filename),
+    m_filestream()
+  {
+    bool exists = std::filesystem::exists(m_filename);
+    if ( exists )
+    {
+      if ( !existsOkay )
+      {
+        GEOS_ERROR("File already exists: " + m_filename);
+      }
+      else if ( deleteExisting )
+      {
+        m_filestream.open(m_filename,std::ios::trunc);
+      }
+    }
+    else
+    {
+      m_filestream.open(m_filename,std::ios::app);
+      if (!m_filestream)
+      {
+        GEOS_ERROR("Failed to create file: " + m_filename);
+      }
+      m_filestream.close();
+    }
+  }
+
+  // Destructor: Closes the file
+  ~ASCIIFile()
+  {
+    if (m_filestream.is_open())
+    {
+      m_filestream.close();
+    }
+  }
+
+  // Append data to the ASCII file
+  void append( const std::string &data )
+  {
+    ensureOpenForAppend();
+    m_filestream << data;
+  }
+
+  // Counts the number of lines in the file
+  int countLinesInFile()
+  {
+    std::ifstream inFile(m_filename);
+    if (!inFile)
+    {
+      GEOS_ERROR( "Error: Cannot open the file " + m_filename );
+    }
+
+    return std::count(std::istreambuf_iterator<char>(inFile),
+                      std::istreambuf_iterator<char>(), '\n');
+  }
+
+private:
+  // Ensures the file stream is open for appending data
+  void ensureOpenForAppend()
+  {
+    if (!m_filestream.is_open())
+    {
+      m_filestream.open(m_filename, std::ios::app);
+      if (!m_filestream)
+      {
+        GEOS_ERROR("Failed to open file for appending: " + m_filename);
+      }
+    }
+  }
+
+  std::string m_filename;
+  std::ofstream m_filestream;
+};
+
+
+}
+
+#endif

--- a/src/coreComponents/fileIO/timeHistory/BufferedHistoryIO.cpp
+++ b/src/coreComponents/fileIO/timeHistory/BufferedHistoryIO.cpp
@@ -1,0 +1,122 @@
+#include "BufferedHistoryIO.hpp"
+
+namespace geos
+{
+
+namespace detail
+{
+  inline size_t getTypeSize( std::type_index const & type )
+  {
+    if( type == std::type_index( typeid(char)) )
+    {
+      return sizeof( char );
+    }
+    else if( type == std::type_index( typeid(signed char)) )
+    {
+      return sizeof( signed char );
+    }
+    else if( type == std::type_index( typeid(real32)) )
+    {
+      return sizeof( real32 );
+    }
+    else if( type == std::type_index( typeid(real64)) )
+    {
+      return sizeof( real64 );
+    }
+    else if( type == std::type_index( typeid(integer)) )
+    {
+      return sizeof( integer );
+    }
+    else if( type == std::type_index( typeid(localIndex)) )
+    {
+      return sizeof( localIndex );
+    }
+    else if( type == std::type_index( typeid(globalIndex)) )
+    {
+      return sizeof( globalIndex );
+    }
+    else
+    {
+      return sizeof( char );
+    }
+  }
+}
+
+BufferedHistoryIO::BufferedHistoryIO( std::type_index typeIdx,
+                                      localIndex rank,
+                                      std::vector< localIndex > const & dims ) :
+  m_bufferedCount( 0 ),
+  m_bufferHead( nullptr ),
+  m_dataBuffer( 0 ),
+  m_bufferedLocalIdxCounts( ),
+  m_typeIdx( typeIdx ),
+  m_typeSize( detail::getTypeSize( typeIdx ) ),
+  m_typeCount( 1 ),
+  m_rank( rank ),
+  m_dims( rank )
+{
+  for( size_t dd = 0; dd < m_rank; ++dd )
+  {
+    m_dims[dd] = LvArray::integerConversion< size_t >( dims[dd] );
+    m_typeCount *= m_dims[dd];
+  }
+  m_dataBuffer.resize( m_typeSize * m_typeCount );
+  m_bufferHead = &m_dataBuffer[0];
+}
+
+buffer_unit_type * BufferedHistoryIO::getBufferHead()
+{
+  resizeBuffer();
+  m_bufferedCount++;
+  buffer_unit_type * const currentBufferHead = m_bufferHead;
+  m_bufferHead += getRowBytes();
+  return currentBufferHead;
+}
+
+size_t BufferedHistoryIO::getRowBytes()
+{
+  return m_typeCount * m_typeSize;
+}
+
+void BufferedHistoryIO::emptyBuffer()
+{
+  m_sizeChanged = false;
+  m_bufferedCount = 0;
+  m_bufferHead = &m_dataBuffer[0];
+  m_bufferedLocalIdxCounts.clear();
+}
+
+void BufferedHistoryIO::resizeBuffer()
+{
+  // need to store the count every time we collect (which calls this)
+  //  regardless of whether the size changes
+  m_bufferedLocalIdxCounts.emplace_back( m_dims[0] );
+
+  size_t const capacity = m_dataBuffer.size();
+  size_t const inUse = m_bufferHead - &m_dataBuffer[0];
+  size_t const nextRow = getRowBytes( );
+  // if needed, resize the buffer
+  if( inUse + nextRow > capacity )
+  {
+    // resize based on the ammount currently in use rather than on the capacity ( less aggressive w/ changing sizes )
+    m_dataBuffer.resize( inUse + ( nextRow * m_overallocMultiple ) );
+  }
+  // reset the buffer head and advance based on count in case the underlying data buffer moves during a resize
+  m_bufferHead = &m_dataBuffer[0] + inUse;
+}
+
+void BufferedHistoryIO::updateCollectingCount( localIndex count )
+{
+  if( LvArray::integerConversion< size_t >( count ) != m_dims[0] )
+  {
+    m_sizeChanged = true;
+    m_dims[0] = count;
+    m_typeCount = count;
+    for( size_t dd = 1; dd < m_rank; ++dd )
+    {
+      m_typeCount *= m_dims[dd];
+    }
+  }
+}
+
+}

--- a/src/coreComponents/fileIO/timeHistory/CSVHistoryIO.cpp
+++ b/src/coreComponents/fileIO/timeHistory/CSVHistoryIO.cpp
@@ -1,0 +1,145 @@
+#include <sstream>
+
+#include "CSVHistoryIO.hpp"
+#include "ASCIIFile.hpp"
+#include "common/MpiWrapper.hpp"
+
+namespace geos
+{
+
+namespace detail
+{
+
+template <typename T>
+void inline printAdvance(std::ostream & os, buffer_unit_type * & data)
+{
+  os << *reinterpret_cast<T*>(data);
+  data += sizeof(T);
+}
+
+void inline printAndAdvance(std::ostream & os, std::type_index const & type, buffer_unit_type * & data)
+{
+  static const std::unordered_map<std::type_index, std::function<void(std::ostream&, buffer_unit_type*&)>> actions =
+  {
+    { std::type_index(typeid(char)), &printAdvance<char> },
+    { std::type_index(typeid(signed char)), &printAdvance<signed char> },
+    { std::type_index(typeid(real32)), &printAdvance<real32> },
+    { std::type_index(typeid(real64)), &printAdvance<real64> },
+    { std::type_index(typeid(integer)), &printAdvance<integer> },
+    { std::type_index(typeid(localIndex)), &printAdvance<localIndex> },
+    { std::type_index(typeid(globalIndex)), &printAdvance<globalIndex> }
+  };
+
+  auto it = actions.find(type);
+  if(it != actions.end())
+  {
+    it->second(os, data);
+  }
+  else
+  {
+    GEOS_ERROR( "Error: unsupported type for CSV Time History output!" );
+  }
+}
+
+void inline printRankedData( std::ostream & outFile,
+                              buffer_unit_type *& dataBuffer,
+                              size_t currentDim,
+                              size_t dataRank,
+                              const std::vector< size_t > & dataDims,
+                              std::type_index atomDatatype )
+{
+  if ( currentDim < dataRank - 1 )
+  {
+    for ( size_t ii = 0; ii < dataDims[currentDim]; ++ii )
+    {
+      printRankedData(outFile, dataBuffer, currentDim + 1, dataRank, dataDims, atomDatatype);
+      if (currentDim == dataRank - 2)
+      {
+        outFile << " ";
+      }
+    }
+  }
+  else
+  {
+    printAndAdvance( outFile, atomDatatype, dataBuffer );
+  }
+}
+
+void inline printBufferedDataRows( std::ostream & outFile,
+                                   buffer_unit_type * & dataBuffer,
+                                   size_t rowCount,
+                                   const std::vector< size_t > & colCounts,
+                                   size_t dataRank,
+                                   const std::vector< size_t > & dataDims,
+                                   std::type_index atomDatatype )
+{
+  for ( size_t row = 0; row < rowCount; ++row )
+  {
+    for( size_t col = 0; col < colCounts[row]; ++col )
+    {
+      printRankedData( outFile, dataBuffer, 0, dataRank, dataDims, atomDatatype);
+      outFile << ", ";
+    }
+    outFile << "\n";
+  }
+}
+
+}
+
+CSVHistoryIO::CSVHistoryIO( string const & filename,
+                            localIndex dataRank,
+                            std::vector< localIndex > const & dims,
+                            std::type_index typeIdx,
+                            localIndex writeHead,
+                            MPI_Comm comm ):
+  BufferedHistoryIO( typeIdx, dataRank, dims ),
+  m_filename( filename ),
+  m_writeHead( writeHead ),
+  m_comm( comm )
+{
+  int rank = MpiWrapper::commRank( m_comm );
+  if (m_filename.substr(m_filename.size() - 4) == ".csv")
+  {
+      m_filename = m_filename.substr(0, m_filename.size() - 4)
+                + "." + std::to_string(rank) + ".csv";
+  }
+  else
+  {
+      m_filename += "." + std::to_string(rank) + ".csv";
+  }
+}
+
+void CSVHistoryIO::init( bool existsOkay )
+{
+  ASCIIFile outfile( m_filename, false, existsOkay );
+  GEOS_ERROR_IF( outfile.countLinesInFile( ) != m_writeHead,
+                 "Error: Unexpected number of lines in existing CSV time history output!" );
+}
+
+void CSVHistoryIO::write()
+{
+  if(m_bufferedCount > 0)
+  {
+    buffer_unit_type * dataBuffer = nullptr;
+    if(m_dataBuffer.size() > 0)
+    {
+      dataBuffer = &m_dataBuffer[0];
+    }
+    else
+    {
+      GEOS_ERROR("Error: Attempting to write buffered TimeHistory data but no data is buffered." );
+    }
+
+    // Use a stringstream to buffer the output
+    std::stringstream bufferStream;
+
+    detail::printBufferedDataRows(bufferStream, dataBuffer, m_bufferedCount, m_bufferedLocalIdxCounts, m_rank, m_dims, m_typeIdx);
+
+    ASCIIFile asciiFile(m_filename, false, true);
+    // Append the buffered data to the ASCII file
+    asciiFile.append(bufferStream.str());
+  }
+  emptyBuffer();
+}
+
+}

--- a/src/coreComponents/fileIO/timeHistory/CSVHistoryIO.hpp
+++ b/src/coreComponents/fileIO/timeHistory/CSVHistoryIO.hpp
@@ -1,0 +1,98 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2019 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2019 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2019 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All right reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef GEOS_FILEIO_TIMEHISTORY_CSVHISTORYIO_HPP_
+#define GEOS_FILEIO_TIMEHISTORY_CSVHISTORYIO_HPP_
+
+
+#include "dataRepository/HistoryDataSpec.hpp"
+#include "BufferedHistoryIO.hpp"
+#include "common/DataTypes.hpp"
+
+namespace geos
+{
+
+/**
+ * @class CSVHistoryIO
+ * @brief Perform buffered history I/O for a single type(really just output) to CSV files.
+ */
+class CSVHistoryIO : public BufferedHistoryIO
+{
+public:
+  /**
+   * @brief Constructor
+   * @param[in] filename The filename to perform history output to.
+   * @param[in] rank The rank of the history data being collected.
+   * @param[in] dims The dimensional extent for each dimension of the history data being collected.
+   * @param[in] typeId The std::type_index(typeid(T)) of the underlying data type.
+   * @param[in] writeHead How many time history states have been written to the file (used on restart and to compress data on exit).
+   * @param[in] initAlloc How many states to preallocate the internal buffer to hold.
+   * @param[in] overallocMultiple Integer to scale the internal buffer when we fill the existing space.
+   * @param[in] comm A communicator where every rank will participate in writting to the output file.
+   */
+  CSVHistoryIO( string const & filename,
+                localIndex rank,
+                std::vector< localIndex > const & dims,
+                std::type_index typeId,
+                localIndex writeHead = 0,
+                MPI_Comm comm = MPI_COMM_GEOSX );
+
+  /**
+   * @brief Constructor
+   * @param[in] filename The filename to perform history output to.
+   * @param[in] spec HistoryMetadata to use to call the other constructor.
+   * @param[in] writeHead How many time states have been written to the file (used on restart and to compress data on exit).
+   * @param[in] comm A communicator where every rank will participate in writing to the output file.
+   */
+  CSVHistoryIO( string const & filename,
+                const HistoryMetadata & spec,
+                localIndex writeHead = 0,
+                MPI_Comm comm = MPI_COMM_GEOSX ):
+    CSVHistoryIO( filename,
+                  spec.getRank(),
+                  spec.getDims(),
+                  spec.getType(),
+                  writeHead,
+                  comm )
+  { }
+
+  /// Destructor
+  virtual ~CSVHistoryIO() { }
+
+  /// @copydoc geos::BufferedHistoryIO::init
+  virtual void init( bool existsOkay ) override;
+
+  /// @copydoc geos::BufferedHistoryIO::write
+  virtual void write( ) override;
+
+  /// @copydoc geos::BufferedHistoryIO::finalize
+  virtual void finalize( ) override {};
+
+  /// @copydoc geos::BufferedHistoryIO::shareable
+  virtual bool shareable( ) const override { return false; }
+
+private:
+  // file io params
+  /// The filename to write to
+  string m_filename;
+  /// The current history count for this data set in the output file
+  localIndex m_writeHead;
+
+  /// The communicator across which the data set is distributed
+  MPI_Comm m_comm;
+};
+
+}
+
+#endif

--- a/src/docs/doxygen/GeosxConfig.hpp
+++ b/src/docs/doxygen/GeosxConfig.hpp
@@ -41,6 +41,9 @@
 /// Enables use of HIP (CMake option ENABLE_HIP)
 /* #undef GEOS_USE_HIP */
 
+/// Workaround for FMT compilation issue on some NVCC/PowerPC machines (CMake option ENABLE_FMT_CONST_FORMATTER_WORKAROUND)
+/* #undef GEOS_USE_FMT_CONST_FORMATTER_WORKAROUND */
+
 /// Enables use of PVTPackage (CMake option ENABLE_PVTPackage)
 #define GEOSX_USE_PVTPackage
 


### PR DESCRIPTION
Adding a basic ASCII CSV file output format for TimeHistory.

Each rank which actually collects data will write it's own file: `<filename>.<mpi_rank>.csv`

And each piece of data collected will have an individual file as well, to avoid having to totally rewrite the file at any point.

Very much WIP, needs tests/testing etc.