### PR TITLE
Allow negative pressure by default (revert change from #2762)

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
@@ -66,7 +66,7 @@ SinglePhaseBase::SinglePhaseBase( const string & name,
     setDescription( "Maximum (absolute) pressure change in a Newton iteration" );
 
   this->registerWrapper( viewKeyStruct::allowNegativePressureString(), &m_allowNegativePressure ).
-    setApplyDefaultValue( 0 ). // by default not allowed, except fot HydrofractureSolver
+    setApplyDefaultValue( 1 ). // negative pressure is allowed by default
     setInputFlag( InputFlags::OPTIONAL ).
     setDescription( "Flag indicating if negative pressure is allowed" );
 }

--- a/src/docs/doxygen/GeosxConfig.hpp
+++ b/src/docs/doxygen/GeosxConfig.hpp
@@ -30,7 +30,7 @@
 #define GEOSX_USE_MPI
 
 /// Enables use of OpenMP (CMake option ENABLE_OPENMP)
-/* #undef GEOSX_USE_OPENMP */
+#define GEOSX_USE_OPENMP
 
 /// Enables use of CUDA (CMake option ENABLE_CUDA)
 /* #undef GEOS_USE_CUDA */
@@ -171,7 +171,7 @@
 #define fmt_VERSION 10.0.0
 
 /// Version information for python
-#define Python3_VERSION 3.9.13
+#define Python3_VERSION 3.10.8
 
 /// Version information for CUDAToolkit
 /* #undef CUDAToolkit_VERSION */


### PR DESCRIPTION
First step to fix the test cases: revert negative pressure check enabled by default in https://github.com/GEOS-DEV/GEOS/pull/2762


https://github.com/GEOS-DEV/integratedTests/pull/55