### PR TITLE
PoC / Paraview integration for ``mesh_doctor``

### DIFF
--- a/src/coreComponents/python/modules/geosx_mesh_doctor/mesh_doctor-pvplugin.py
+++ b/src/coreComponents/python/modules/geosx_mesh_doctor/mesh_doctor-pvplugin.py
@@ -1,0 +1,62 @@
+from paraview.util.vtkAlgorithm import *
+from paraview.selection import *
+
+
+@smproxy.filter(name="Mesh Doctor(GEOS)")
+@smproperty.input(name="Input")
+@smdomain.datatype(dataTypes=["vtkUnstructuredGrid"], composite_data_supported=False)
+class ElementVolumesFilter(VTKPythonAlgorithmBase):
+    """
+        Example portage meshDoctor in PV Python plugins
+    """
+    def __init__(self):
+        super().__init__(outputType='vtkUnstructuredGrid')
+        from checks import element_volumes
+        self.opt = element_volumes.Options(0)
+
+    def RequestData(self, request, inInfo, outInfo):
+        inData = self.GetInputData(inInfo, 0, 0)
+        outData = self.GetOutputData(outInfo, 0)
+        assert inData is not None
+        if outData is None or (not outData.IsA(inData.GetClassName())):
+            outData = inData.NewInstance()
+        extracted = self._Process(inData)
+        outData.DeepCopy( extracted.GetOutput() )
+        outInfo.GetInformationObject(0).Set(outData.DATA_OBJECT(), extracted.GetOutput())
+
+        print("1> There are {} cells under {} m3 vol".format(outData.GetNumberOfCells(), self.opt))
+        return 1
+
+    def _Process(self,mesh):
+        from checks import element_volumes
+        from paraview.vtk import vtkIdTypeArray, vtkSelectionNode, vtkSelection, vtkCollection
+        from vtk import vtkExtractSelection
+        res = element_volumes.check(mesh, self.opt)
+        ids = vtkIdTypeArray()
+        ids.SetNumberOfComponents(1)
+        for val in res.element_volumes:
+            ids.InsertNextValue(val[0])
+
+
+        selectionNode = vtkSelectionNode()
+        selectionNode.SetFieldType(vtkSelectionNode.CELL)
+        selectionNode.SetContentType(vtkSelectionNode.INDICES)
+        selectionNode.SetSelectionList(ids)
+        selection = vtkSelection()
+        selection.AddNode(selectionNode)
+
+        extracted = vtkExtractSelection()
+        extracted.SetInputDataObject(0, mesh)
+        extracted.SetInputData(1, selection)
+        extracted.Update()
+        print("There are {} cells under {} m3 vol".format(extracted.GetOutput().GetNumberOfCells(), self.opt))
+        print("There are {} arrays of cell data".format(extracted.GetOutput().GetCellData().GetNumberOfArrays(), self.opt))
+
+        return extracted
+
+    @smproperty.doublevector(name="Vol Threshold", default_values=["0.0"])
+    def SetValue(self, val):
+        from checks import element_volumes
+        self.opt = element_volumes.Options(val)
+        # print("settings value:", self.opt)
+        self.Modified()

--- a/src/docs/sphinx/pythonTools/mesh_doctor.rst
+++ b/src/docs/sphinx/pythonTools/mesh_doctor.rst
@@ -125,6 +125,10 @@ It will also verify that the ``VTK_POLYHEDRON`` cells can effectively get conver
 
 ``Using mesh_doctor in paraview``
 """"""""""""""""""""""""""""""""""
+
+Using mesh_doctor as a programmable filter
+____________________________________________
+
 To use ``mesh_doctor`` in Paraview as a python programmable filter, a python package install is required first in Paraview python resolved
 path. Paraview is storing its python ressources under its *lib/pythonX.X* depending on the paraview version, *e.g* Paraview 5.11 is working
 with python 3.9. As a results the following command will install ``mesh_doctor`` package into Paraview resolved path.
@@ -179,3 +183,14 @@ the copy of the inital VTKObject `inputs[0].VTKObject` to ensure consistency wit
 What follows is ``pyvtk`` steps in oder to convert into input struct and extract from the original mesh this list of cells.
 Eventually, the `extracted` selection is shallow-copied to the output and then accessible in ``Paraview``. An helper print
 is left and should be reported in *Output Message* of ``Paraview`` (and in launching terminal if exist).
+
+Using mesh_doctor as a paraview plugins
+____________________________________________
+
+Another way of leveraging ``mesh_doctor`` in ``Paraview`` is to wrap it in a python plugin that would be loadable through the
+``Paraview`` interface under **Tools | Manage Plugins/Extensions** and **Load New** looking for ``mesh_doctor-pvplugin.py``.
+(see `Paraview How To <https://www.paraview.org/Wiki/ParaView/Plugin_HowTo#Using_Plugins>`_  for more details).
+
+The file ``mesh_doctor-pvplugin.py`` is located under the ``geosx_mesh_doctor`` module in GEOS. Once the plugin loaded and a mesh opened,
+it should appear in filter list as *Mesh Doctor(GEOS)*. It displays a parameter value box allowing the user to enter the volume he wants as
+threshold to select cells based on ``element_volumes`` capability. Once applied, it extracts selected set of cells as a new unstructured grid.

--- a/src/docs/sphinx/pythonTools/mesh_doctor.rst
+++ b/src/docs/sphinx/pythonTools/mesh_doctor.rst
@@ -142,19 +142,19 @@ Then launching ``Paraview`` and loading our *mesh.vtu*, as an example, we will d
 .. code-block:: python
     :linenos:
 
-    input0 = inputs[0]
+    mesh = inputs[0].VTKObject
     tol = 1.2e-6
 
     from checks import element_volumes
     import vtk
-    #
-    res = element_volumes.__check(inputs[0].VTKObject, element_volumes.Options(tol))
+
+    res = element_volumes.__check(mesh, element_volumes.Options(tol))
     #print(res)
     ids = vtk.vtkIdTypeArray()
     ids.SetNumberOfComponents(1)
-    for val in res.element_volumes:
-     ids.InsertNextValue(val[0])
-    #
+    for cell_index, volume in res.element_volumes:
+        ids.InsertNextValue(cell_index)
+
     selectionNode = vtk.vtkSelectionNode()
     selectionNode.SetFieldType(vtk.vtkSelectionNode.CELL)
     selectionNode.SetContentType(vtk.vtkSelectionNode.INDICES)
@@ -162,7 +162,7 @@ Then launching ``Paraview`` and loading our *mesh.vtu*, as an example, we will d
     selection = vtk.vtkSelection()
     selection.AddNode(selectionNode)
     extracted = vtk.vtkExtractSelection()
-    extracted.SetInputDataObject(0, inputs[0].VTKObject)
+    extracted.SetInputDataObject(0, mesh)
     extracted.SetInputData(1, selection)
     extracted.Update()
     print("There are {} cells under {} m3 vol".format(extracted.GetOutput().GetNumberOfCells(), tol))


### PR DESCRIPTION
This is a test to leverage `mesh_doctor` in `Paraview` either as a Python Programmable Filter or a python plugin
A example is given for `element_volumes` check. 
It is run over the unstructured version of _spe11a_ join here.

![screenshot-PVMeshDoctor](https://github.com/GEOS-DEV/GEOS/assets/49998870/f4fab30b-4fa3-4883-8799-7475f7ac5dbe)

[spe11a_mesh.zip](https://github.com/GEOS-DEV/GEOS/files/13226509/spe11a_mesh.zip)

As a programmable filter
-----------------------------------
``mesh_doctor`` has to be deploy in the Paraview python hierarchy so it is able to get the import path

As a python plugin
---------------------------
As examplified [here](), going through the loading procedure allow load and access to *Mesh Doctor(GEOS)* as a new filter (for now only volume check is available).
