### PR TITLE
Update TPL tag to point back to the HEAD of the repo

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GEOSX_TPL_TAG: 228-73
+  GEOSX_TPL_TAG: 247-84
 
 jobs:
 


### PR DESCRIPTION
Make the `geos` repository point to the HEAD of the `thirdPartyLibs` repository again.
Relates to https://github.com/GEOS-DEV/thirdPartyLibs/pull/247