### PR TITLE
Upgrade version of `sccache` for GPU builds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "GEOS_TPL_TAG": "245-86"
+            "GEOS_TPL_TAG": "250-91"
         }
     },
     "runArgs": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "GEOS_TPL_TAG": "250-91"
+            "GEOS_TPL_TAG": "250-92"
         }
     },
     "runArgs": [

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -230,7 +230,7 @@ fi
 
 if [[ ! -z "${SCCACHE_CREDS}" ]]; then
   echo "sccache final state"
-  or_die ${SCCACHE} --show-stats
+  or_die ${SCCACHE} --show-adv-stats
 fi
 
 # If we're here, either everything went OK or we have to deal with the integrated tests manually.

--- a/src/coreComponents/constitutive/fluid/multifluid/CO2Brine/PVTDriverRunTestCO2BrineEzrokhiThermalFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/CO2Brine/PVTDriverRunTestCO2BrineEzrokhiThermalFluid.cpp
@@ -17,5 +17,5 @@
 
 namespace geos
 {
-template void PVTDriver::runTest< constitutive::CO2BrineEzrokhiFluid >( constitutive::CO2BrineEzrokhiFluid &, arrayView2d< real64 > const & );
+template void PVTDriver::runTest< constitutive::CO2BrineEzrokhiThermalFluid >( constitutive::CO2BrineEzrokhiThermalFluid &, arrayView2d< real64 > const & );
 }


### PR DESCRIPTION
Testing a new version of `sccache` to see if it better manages `nvcc` (there are patches in the Changelog 🤞).
So the flag `ci: ready to be merged` can be added when I ask for a build, but don't get fooled, it's just to run the `cuda` builds!

TPL PR: https://github.com/GEOS-DEV/thirdPartyLibs/pull/250