### PR TITLE
Fix integratedTests fails.

### DIFF
--- a/src/coreComponents/fileIO/Outputs/BlueprintOutput.cpp
+++ b/src/coreComponents/fileIO/Outputs/BlueprintOutput.cpp
@@ -118,6 +118,7 @@ BlueprintOutput::BlueprintOutput( string const & name,
   registerWrapper( "plotLevel", &m_plotLevel ).
     setApplyDefaultValue( dataRepository::PlotLevel::LEVEL_1 ).
     setInputFlag( dataRepository::InputFlags::OPTIONAL ).
+    setRTTypeName( rtTypes::CustomTypes::plotLevel ).
     setDescription( "Determines which fields to write." );
 
   registerWrapper( "outputFullQuadratureData", &m_outputFullQuadratureData ).


### PR DESCRIPTION
integratedTests PR: https://github.com/GEOS-DEV/integratedTests/pull/63


@MelReyCG, @klevzoff are we sure that we do not want to accept `"x"` where x is an integer as a valid format for a string? The error I was getting for the plot level seems to suggest that that's not a valid string. 