### PR TITLE
Gitlab CI - cleanup untracked files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,6 +21,10 @@ stages:
     - git submodule set-url integratedTests git@github.com:GEOS-DEV/integratedTests.git
     - git submodule set-url src/coreComponents/fileIO/coupling/hdf5_interface https://github.com/GEOS-DEV/hdf5_interface.git
 
+    # Clean up directory and submodules when pre-initialized from previous CI run
+    - git clean -x -f -d
+    - git submodule foreach --recursive git clean -x -f -d
+
     # Update submodules
     - git submodule update --init --recursive src/cmake/blt
     - git submodule update --init --recursive src/coreComponents/LvArray


### PR DESCRIPTION
This PR cleans up untracked files in Gitlab CI for cloned GEOS repo and submodules.

When Gitlab CI [reuses a repo clone](https://docs.gitlab.com/ee/user/project/repository/monorepos/#git-strategy) for testing, untracked files can cause errors with git, preventing updates to newer commits (nightlyTests run that errored out due to untracked files in integratedTests submodule: https://lc.llnl.gov/gitlab/settgast/GEOSX/-/pipelines/359642).