### PR TITLE
Fixed issue #2853

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.cpp
@@ -736,7 +736,7 @@ void FlowSolverBase::prepareStencilWeights( DomainPartition & domain ) const
     FiniteVolumeManager const & fvManager = numericalMethodManager.getFiniteVolumeManager();
     FluxApproximationBase const & fluxApprox = fvManager.getFluxApproximation( getDiscretizationName() );
     ElementRegionManager::ElementViewAccessor< arrayView1d< real64 const > > hydraulicAperture =
-      mesh.getElemManager().constructViewAccessor< array1d< real64 >, arrayView1d< real64 const > >( fields::flow::hydraulicAperture::key() );
+      mesh.getElemManager().constructViewAccessor< array1d< real64 >, arrayView1d< real64 const > >( fields::flow::aperture0::key() );
 
     fluxApprox.forStencils< SurfaceElementStencil, FaceElementToCellStencil, EmbeddedSurfaceToCellStencil >( mesh, [&]( auto & stencil )
     {

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
@@ -856,13 +856,7 @@ void HydrofractureSolver< POROMECHANICS_SOLVER >::updateState( DomainPartition &
 
   Base::updateState( domain );
 
-  // remove the contribution of the hydraulic aperture from the stencil weights
-  flowSolver()->prepareStencilWeights( domain );
-
   updateHydraulicApertureAndFracturePermeability( domain );
-
-  // update the stencil weights using the updated hydraulic aperture
-  flowSolver()->updateStencilWeights( domain );
 
   forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                 MeshLevel & mesh,
@@ -878,6 +872,20 @@ void HydrofractureSolver< POROMECHANICS_SOLVER >::updateState( DomainPartition &
       flowSolver()->updateFluidState( subRegion );
     } );
   } );
+}
+
+template< typename POROMECHANICS_SOLVER >
+void HydrofractureSolver< POROMECHANICS_SOLVER >::implicitStepComplete( real64 const & time_n,
+                                                                        real64 const & dt,
+                                                                        DomainPartition & domain )
+{
+  Base::implicitStepComplete( time_n, dt, domain );
+
+  // remove the contribution of the hydraulic aperture from the stencil weights
+  flowSolver()->prepareStencilWeights( domain );
+
+  // update the stencil weights using the updated hydraulic aperture
+  flowSolver()->updateStencilWeights( domain );
 }
 
 template< typename POROMECHANICS_SOLVER >

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.hpp
@@ -112,6 +112,11 @@ public:
 
   virtual void updateState( DomainPartition & domain ) override final;
 
+  virtual void implicitStepComplete( real64 const & time_n,
+                                     real64 const & dt,
+                                     DomainPartition & domain ) override final;
+
+
   /**@}*/
 
   void updateHydraulicApertureAndFracturePermeability( DomainPartition & domain );

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsConformingFractures.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsConformingFractures.cpp
@@ -736,13 +736,7 @@ void SinglePhasePoromechanicsConformingFractures::updateState( DomainPartition &
 
   Base::updateState( domain );
 
-  // remove the contribution of the hydraulic aperture from the stencil weights
-  poromechanicsSolver()->flowSolver()->prepareStencilWeights( domain );
-
   updateHydraulicApertureAndFracturePermeability( domain );
-
-  // update the stencil weights using the updated hydraulic aperture
-  poromechanicsSolver()->flowSolver()->updateStencilWeights( domain );
 
   forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                 MeshLevel & mesh,
@@ -763,6 +757,20 @@ void SinglePhasePoromechanicsConformingFractures::updateState( DomainPartition &
       }
     } );
   } );
+}
+
+void SinglePhasePoromechanicsConformingFractures::implicitStepComplete( real64 const & time_n,
+                                                                        real64 const & dt,
+                                                                        DomainPartition & domain )
+{
+  Base::implicitStepComplete( time_n, dt, domain );
+
+  // remove the contribution of the hydraulic aperture from the stencil weights
+  poromechanicsSolver()->flowSolver()->prepareStencilWeights( domain );
+
+  // update the stencil weights using the updated hydraulic aperture
+  poromechanicsSolver()->flowSolver()->updateStencilWeights( domain );
+
 }
 
 void SinglePhasePoromechanicsConformingFractures::updateHydraulicApertureAndFracturePermeability( DomainPartition & domain )

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsConformingFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsConformingFractures.hpp
@@ -114,9 +114,9 @@ public:
   virtual void updateState( DomainPartition & domain ) override final;
 
 
-  // virtual void implicitStepComplete( real64 const & time_n,
-  //                                    real64 const & dt,
-  //                                    DomainPartition & domain ) override;
+  virtual void implicitStepComplete( real64 const & time_n,
+                                     real64 const & dt,
+                                     DomainPartition & domain ) override final;
 
   bool resetConfigurationToDefault( DomainPartition & domain ) const override final;
 

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsEmbeddedFractures.cpp
@@ -489,6 +489,12 @@ void SinglePhasePoromechanicsEmbeddedFractures::implicitStepComplete( real64 con
 {
   m_fracturesSolver->implicitStepComplete( time_n, dt, domain );
   flowSolver()->implicitStepComplete( time_n, dt, domain );
+
+  // remove the contribution of the hydraulic aperture from the stencil weights
+  flowSolver()->prepareStencilWeights( domain );
+
+  // update the stencil weights using the updated hydraulic aperture
+  flowSolver()->updateStencilWeights( domain );
 }
 
 void SinglePhasePoromechanicsEmbeddedFractures::resetStateToBeginningOfStep( DomainPartition & domain )
@@ -531,9 +537,6 @@ void SinglePhasePoromechanicsEmbeddedFractures::updateState( DomainPartition & d
 {
   /// 1. update the reservoir
   SinglePhasePoromechanics::updateState( domain );
-
-  // remove the contribution of the hydraulic aperture from the stencil weights
-  flowSolver()->prepareStencilWeights( domain );
 
   /// 2. update the fractures
   m_fracturesSolver->updateState( domain );
@@ -600,8 +603,6 @@ void SinglePhasePoromechanicsEmbeddedFractures::updateState( DomainPartition & d
 
       } );
 
-      // update the stencil weights using the updated hydraulic aperture
-      flowSolver()->updateStencilWeights( domain );
       // update fracture's porosity from pressure and temperature
       flowSolver()->updatePorosityAndPermeability( subRegion );
       // update fluid model


### PR DESCRIPTION
This PR fixed issue #2853 . 

The nonlinear system solver (`solveNonlinearSystem`) may invoke the `updateState` function, which can modify the stencil weights at each newton iteration. In this PR, the stencil weights are updated only once in `implicitStepComplete` function at the end of each solver step.