### PR TITLE
add workflow_dispatch option to actions

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -5,6 +5,7 @@ on:
     branches: 
       - develop
   pull_request:
+  workflow_dispatch:
 
 # Cancels in-progress workflows for a PR when updated
 concurrency:


### PR DESCRIPTION
This PR enables launching our CI actions manually without a PR. So we can test the non-PR CI builds without having to merge into develop.