### PR TITLE
Fix "status 137" error on streak

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -201,6 +201,7 @@ jobs:
       ENABLE_TRILINOS: OFF
       GCP_BUCKET: geosx/integratedTests
       RUNS_ON: self-hosted
+      DOCKER_RUN_ARGS: "--cpus=8 --memory=128g"
 
   code_coverage:
     needs:
@@ -247,7 +248,7 @@ jobs:
             ENABLE_HYPRE: ON
             ENABLE_TRILINOS: OFF
             RUNS_ON: self-hosted
-            DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia --gpus all"
+            DOCKER_RUN_ARGS: "--cpus=8 --memory=256g --runtime=nvidia --gpus all"
 
 
           - name: Centos (7.7, gcc 8.3.1, open-mpi 1.10.7, cuda 11.8.89)


### PR DESCRIPTION
The following error indicates out of memory on streak. Trying to add more memory to the docker run args.

Received exit status 137 from the build process.
Error: Process completed with exit code 137.