### PR TITLE
Replace result_of of invoke_result to fix macOS compilation.

### DIFF
--- a/src/coreComponents/codingUtilities/Utilities.hpp
+++ b/src/coreComponents/codingUtilities/Utilities.hpp
@@ -225,7 +225,7 @@ template< template< typename ... > class C, typename MAP, typename TRANSFORMER >
 auto mapTransformer( MAP const & map,
                      TRANSFORMER const & transformer )
 {
-  using v = typename std::invoke_result<TRANSFORMER, typename MAP::value_type>::type;
+  using v = typename std::invoke_result< TRANSFORMER, typename MAP::value_type >::type;
   C< v > result;
   auto inserter = std::inserter( result, result.end() );
   std::transform( map.begin(), map.end(), inserter, transformer );

--- a/src/coreComponents/codingUtilities/Utilities.hpp
+++ b/src/coreComponents/codingUtilities/Utilities.hpp
@@ -225,7 +225,7 @@ template< template< typename ... > class C, typename MAP, typename TRANSFORMER >
 auto mapTransformer( MAP const & map,
                      TRANSFORMER const & transformer )
 {
-  using v = typename std::invoke_result< TRANSFORMER, typename MAP::value_type >::type;
+  using v = std::invoke_result_t< TRANSFORMER, typename MAP::const_reference >;
   C< v > result;
   auto inserter = std::inserter( result, result.end() );
   std::transform( map.begin(), map.end(), inserter, transformer );

--- a/src/coreComponents/codingUtilities/Utilities.hpp
+++ b/src/coreComponents/codingUtilities/Utilities.hpp
@@ -225,7 +225,7 @@ template< template< typename ... > class C, typename MAP, typename TRANSFORMER >
 auto mapTransformer( MAP const & map,
                      TRANSFORMER const & transformer )
 {
-  using v = typename std::result_of< TRANSFORMER( typename MAP::const_reference ) >::type;
+  using v = typename std::invoke_result<TRANSFORMER, typename MAP::value_type>::type;
   C< v > result;
   auto inserter = std::inserter( result, result.end() );
   std::transform( map.begin(), map.end(), inserter, transformer );


### PR DESCRIPTION
This PR fixes a compilation error on MacOS with clang15:

````
error: 'result_of<(lambda at /Users/cusini1/geosx/GEOSX/src/coreComponents/codingUtilities/Utilities.hpp:247:22) (const std::pair<std::string, geos::dataRepository::WrapperBase *> &)>' is deprecated [-Werror,-Wdeprecated-declarations]
  using v = typename std::result_of< TRANSFORMER( typename MAP::const_reference ) >::type;
                          ^
/Users/cusini1/geosx/GEOSX/src/coreComponents/codingUtilities/Utilities.hpp:249:10: note: in instantiation of function template specialization 'geos::(anonymous namespace)::mapTransformer<std::vector, geos::MappedVector<geos::dataRepository::WrapperBase>, (lambda at /Users/cusini1/geosx/GEOSX/src/coreComponents/codingUtilities/Utilities.hpp:247:22)>' requested here
  return mapTransformer< C >( map, transformer );
 ```` 

I have no idea why no other compiler (including clang15 on the CI) picks this up. 
