### PR TITLE
Make `Particle` methods optional

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,7 @@ add_subdirectory( thirdparty )
 # Add components
 ################################
 unset( externalComponentsLinkList )
+option( ENABLE_PARTICLE_METHOD "Build GEOS with particle method support" ON )
 add_subdirectory( coreComponents )
 add_subdirectory( externalComponents )
 add_subdirectory( main )

--- a/src/cmake/GeosxConfig.cmake
+++ b/src/cmake/GeosxConfig.cmake
@@ -4,7 +4,7 @@ set( PREPROCESSOR_DEFINES ARRAY_BOUNDS_CHECK
                           CUDA
                           CUDA_NVTOOLSEXT
                           HIP
-			  FMT_CONST_FORMATTER_WORKAROUND
+                          FMT_CONST_FORMATTER_WORKAROUND
                           FORTRAN_MANGLE_NO_UNDERSCORE
                           FPE
                           HYPRE
@@ -13,6 +13,7 @@ set( PREPROCESSOR_DEFINES ARRAY_BOUNDS_CHECK
                           MKL
                           MPI
                           PARMETIS
+                          PARTICLE_METHOD
                           PETSC
                           PVTPackage
                           PYGEOSX
@@ -32,7 +33,7 @@ foreach( DEP in ${PREPROCESSOR_DEFINES} )
         set( USE_${DEP} TRUE )
         set( GEOSX_USE_${DEP} TRUE )
         set( GEOS_USE_${DEP} TRUE )
-	message(STATUS "GEOSX_USE_${DEP} = ${GEOSX_USE_${DEP}}")
+        message( STATUS "GEOSX_USE_${DEP} = ${GEOSX_USE_${DEP}}" )
     endif()
 endforeach()
 
@@ -44,7 +45,7 @@ foreach( DEP in ${STRICT_PPD} )
         set( USE_${DEP} TRUE )
         set( GEOSX_USE_${DEP} TRUE )
         set( GEOS_USE_${DEP} TRUE )
-	message(STATUS "GEOSX_USE_${DEP} = ${GEOSX_USE_${DEP}}")
+        message( STATUS "GEOSX_USE_${DEP} = ${GEOSX_USE_${DEP}}" )
     endif()
 endforeach( )
 

--- a/src/coreComponents/common/GeosxConfig.hpp.in
+++ b/src/coreComponents/common/GeosxConfig.hpp.in
@@ -44,6 +44,9 @@
 /// Workaround for FMT compilation issue on some NVCC/PowerPC machines (CMake option ENABLE_FMT_CONST_FORMATTER_WORKAROUND)
 #cmakedefine GEOS_USE_FMT_CONST_FORMATTER_WORKAROUND
 
+/// Enables use of particle methods
+#cmakedefine GEOS_USE_PARTICLE_METHOD
+
 /// Enables use of PVTPackage (CMake option ENABLE_PVTPackage)
 #cmakedefine GEOSX_USE_PVTPackage
 

--- a/src/coreComponents/dataRepository/KeyNames.hpp
+++ b/src/coreComponents/dataRepository/KeyNames.hpp
@@ -32,8 +32,9 @@ namespace keys
 
 static constexpr auto ProblemManager = "Problem";
 static constexpr auto cellManager = "cellManager";
+#if defined(GEOS_USE_PARTICLE_METHOD)
 static constexpr auto particleManager = "particleManager";
-
+#endif
 /// @endcond
 
 }

--- a/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
+++ b/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.cpp
@@ -92,6 +92,7 @@ toVTKCellType( ElementType const elementType, localIndex const numNodes )
   return VTK_EMPTY_CELL;
 }
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
 static int
 toVTKCellType( ParticleType const particleType )
 {
@@ -117,6 +118,7 @@ getVtkToGeosxNodeOrdering( ParticleType const particleType )
   }
   return {};
 }
+#endif
 
 /**
  * @brief Provide the local list of nodes or face streams for the corresponding VTK element
@@ -251,6 +253,7 @@ getVtkPoints( NodeManager const & nodeManager,
   return points;
 }
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
 /**
  * @brief Gets the vertex coordinates as a VTK Object for @p particleManager
  * @param[in] particleManager the ParticleManager associated with the domain being written
@@ -274,6 +277,7 @@ getVtkPoints( ParticleRegion const & particleRegion ) // TODO: Loop over the sub
   } );
   return points;
 }
+#endif
 
 struct ElementData
 {
@@ -571,6 +575,7 @@ getVtkCells( CellElementRegion const & region,
   return { std::move( cellTypes ), cellsArray, std::move( relevantNodes ) };
 }
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
 using ParticleData = std::pair< std::vector< int >, vtkSmartPointer< vtkCellArray > >;
 /**
  * @brief Gets the cell connectivities as a VTK object for the ParticleRegion @p region
@@ -608,6 +613,7 @@ getVtkCells( ParticleRegion const & region )
   } );
   return std::make_pair( cellType, cellsArray );
 }
+#endif
 
 /**
  * @brief Writes timestamp information required by VisIt
@@ -889,6 +895,7 @@ writeElementField( Group const & subRegions,
   cellData->AddArray( data );
 }
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
 void VTKPolyDataWriterInterface::writeParticleFields( ParticleRegionBase const & region,
                                                       vtkCellData * cellData ) const
 {
@@ -942,6 +949,7 @@ void VTKPolyDataWriterInterface::writeParticleFields( ParticleRegionBase const &
     writeElementField( region.getGroup( ParticleRegionBase::viewKeyStruct::particleSubRegions() ), field, cellData );
   }
 }
+#endif
 
 void VTKPolyDataWriterInterface::writeNodeFields( NodeManager const & nodeManager,
                                                   arrayView1d< localIndex const > const & nodeIndices,
@@ -1048,6 +1056,7 @@ void VTKPolyDataWriterInterface::writeCellElementRegions( real64 const time,
   } );
 }
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
 void VTKPolyDataWriterInterface::writeParticleRegions( real64 const time,
                                                        ParticleManager const & particleManager,
                                                        string const & path ) const
@@ -1068,6 +1077,7 @@ void VTKPolyDataWriterInterface::writeParticleRegions( real64 const time,
     writeUnstructuredGrid( regionDir, ug.GetPointer() );
   } );
 }
+#endif
 
 void VTKPolyDataWriterInterface::writeWellElementRegions( real64 const time,
                                                           ElementRegionManager const & elemManager,
@@ -1170,8 +1180,9 @@ void VTKPolyDataWriterInterface::writeVtmFile( integer const cycle,
 
       ElementRegionManager const & elemManager = meshLevel.getElemManager();
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
       ParticleManager const & particleManager = meshLevel.getParticleManager();
-
+#endif
       string const meshPath = joinPath( getCycleSubFolder( cycle ), meshBodyName, meshLevelName );
 
       int const mpiSize = MpiWrapper::commSize();
@@ -1188,6 +1199,7 @@ void VTKPolyDataWriterInterface::writeVtmFile( integer const cycle,
         }
       };
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
       auto addParticleRegion = [&]( ParticleRegionBase const & region )
       {
         string const & regionName = region.getName();
@@ -1200,6 +1212,7 @@ void VTKPolyDataWriterInterface::writeVtmFile( integer const cycle,
           vtmWriter.addDataSet( blockPath, dataSetName, dataSetFile );
         }
       };
+#endif
 
       // Output each of the region types
       if( m_outputRegionType == VTKRegionTypes::CELL || m_outputRegionType == VTKRegionTypes::ALL )
@@ -1216,11 +1229,12 @@ void VTKPolyDataWriterInterface::writeVtmFile( integer const cycle,
       {
         elemManager.forElementRegions< SurfaceElementRegion >( addElementRegion );
       }
-
+#if defined(GEOS_USE_PARTICLE_METHOD)
       if( m_outputRegionType == VTKRegionTypes::PARTICLE || m_outputRegionType == VTKRegionTypes::ALL )
       {
         particleManager.forParticleRegions< ParticleRegion >( addParticleRegion );
       }
+#endif
     } );
   } );
 
@@ -1312,7 +1326,9 @@ void VTKPolyDataWriterInterface::write( real64 const time,
       }
 
       ElementRegionManager const & elemManager = meshLevel.getElemManager();
+#if defined(GEOS_USE_PARTICLE_METHOD)
       ParticleManager const & particleManager = meshLevel.getParticleManager();
+#endif
       NodeManager const & nodeManager = meshLevel.getNodeManager();
       EmbeddedSurfaceNodeManager const & embSurfNodeManager = meshLevel.getEmbSurfNodeManager();
       string const & meshBodyName = meshBody.getName();
@@ -1341,10 +1357,12 @@ void VTKPolyDataWriterInterface::write( real64 const time,
       {
         writeSurfaceElementRegions( time, elemManager, nodeManager, embSurfNodeManager, meshDir );
       }
+#if defined(GEOS_USE_PARTICLE_METHOD)
       if( m_outputRegionType == VTKRegionTypes::PARTICLE || m_outputRegionType == VTKRegionTypes::ALL )
       {
         writeParticleRegions( time, particleManager, meshDir );
       }
+#endif
     } );
   } );
 

--- a/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.hpp
+++ b/src/coreComponents/fileIO/vtk/VTKPolyDataWriterInterface.hpp
@@ -31,11 +31,13 @@ namespace geos
 
 class DomainPartition;
 class ElementRegionBase;
-class ParticleRegionBase;
 class EmbeddedSurfaceNodeManager;
 class ElementRegionManager;
 class NodeManager;
+#if defined(GEOS_USE_PARTICLE_METHOD)
+class ParticleRegionBase;
 class ParticleManager;
+#endif
 
 namespace vtk
 {
@@ -51,7 +53,9 @@ enum struct VTKRegionTypes
   CELL,
   WELL,
   SURFACE,
+#if defined(GEOS_USE_PARTICLE_METHOD)
   PARTICLE,
+#endif
   ALL
 };
 
@@ -61,13 +65,20 @@ ENUM_STRINGS( VTKOutputMode,
               "ascii" );
 
 /// Declare strings associated with region type enumeration values.
+#if defined(GEOS_USE_PARTICLE_METHOD)
 ENUM_STRINGS( VTKRegionTypes,
               "cell",
               "well",
               "surface",
               "particle",
               "all" );
-
+#else
+ENUM_STRINGS( VTKRegionTypes,
+              "cell",
+              "well",
+              "surface",
+              "all" );
+#endif
 /**
  * @brief Encapsulate output methods for vtk
  */
@@ -223,9 +234,11 @@ private:
                                 NodeManager const & nodeManager,
                                 string const & path ) const;
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
   void writeParticleRegions( real64 const time,
                              ParticleManager const & particleManager,
                              string const & path ) const;
+#endif
 
   /**
    * @brief Writes the files containing the well representation
@@ -284,10 +297,10 @@ private:
    */
   void writeElementFields( ElementRegionBase const & subRegion,
                            vtkCellData * cellData ) const;
-
+#if defined(GEOS_USE_PARTICLE_METHOD)
   void writeParticleFields( ParticleRegionBase const & region,
                             vtkCellData * cellData ) const;
-
+#endif
   /**
    * @brief Writes an unstructured grid
    * @details The unstructured grid is the last element in the hierarchy of the output,

--- a/src/coreComponents/mainInterface/ProblemManager.hpp
+++ b/src/coreComponents/mainInterface/ProblemManager.hpp
@@ -38,8 +38,9 @@ class FunctionManager;
 class FieldSpecificationManager;
 struct CommandLineOptions;
 class CellBlockManagerABC;
+#if defined(GEOS_USE_PARTICLE_METHOD)
 class ParticleBlockManagerABC;
-
+#endif
 /**
  * @class ProblemManager
  * @brief This is the class handling the operation flow of the problem being ran in GEOS
@@ -345,9 +346,11 @@ private:
                           Group const * const discretization,
                           arrayView1d< string const > const & targetRegions );
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
   void generateMeshLevel( MeshLevel & meshLevel,
                           ParticleBlockManagerABC & particleBlockManager,
                           arrayView1d< string const > const & );
+#endif
 
   /**
    * @brief Allocate constitutive relations on each subregion with appropriate

--- a/src/coreComponents/mesh/CMakeLists.txt
+++ b/src/coreComponents/mesh/CMakeLists.txt
@@ -23,22 +23,12 @@ set( mesh_headers
      MeshObjectPath.hpp
      NodeManager.hpp
      ObjectManagerBase.hpp
-     generators/ParticleBlock.hpp
-     generators/ParticleBlockManager.hpp
-     ParticleManager.hpp
-     ParticleRegion.hpp
-     ParticleRegionBase.hpp
-     ParticleSubRegion.hpp
-     ParticleSubRegionBase.hpp
-     generators/ParticleBlockABC.hpp
-     ParticleType.hpp
      Perforation.hpp
      PerforationData.hpp
      PerforationFields.hpp
      SurfaceElementRegion.hpp
      SurfaceElementSubRegion.hpp
      ToElementRelation.hpp
-     ToParticleRelation.hpp
      WellElementRegion.hpp
      WellElementSubRegion.hpp
      generators/CellBlock.hpp
@@ -56,7 +46,6 @@ set( mesh_headers
      generators/InternalWellboreGenerator.hpp
      generators/MeshGeneratorBase.hpp
      generators/ParMETISInterface.hpp
-     generators/ParticleMeshGenerator.hpp
      generators/PartitionDescriptor.hpp
      generators/PrismUtilities.hpp
      generators/WellGeneratorABC.hpp
@@ -103,19 +92,11 @@ set( mesh_sources
      MeshObjectPath.cpp
      NodeManager.cpp
      ObjectManagerBase.cpp
-     generators/ParticleBlock.cpp
-     generators/ParticleBlockManager.cpp
-     ParticleManager.cpp
-     ParticleRegion.cpp
-     ParticleRegionBase.cpp
-     ParticleSubRegion.cpp
-     ParticleSubRegionBase.cpp
      Perforation.cpp
      PerforationData.cpp
      SurfaceElementRegion.cpp
      SurfaceElementSubRegion.cpp
      ToElementRelation.cpp
-     ToParticleRelation.cpp
      WellElementRegion.cpp
      WellElementSubRegion.cpp
      generators/CellBlock.cpp
@@ -129,7 +110,6 @@ set( mesh_sources
      generators/InternalWellboreGenerator.cpp
      generators/MeshGeneratorBase.cpp
      generators/ParMETISInterface.cpp
-     generators/ParticleMeshGenerator.cpp
      generators/WellGeneratorBase.cpp
      mpiCommunications/CommID.cpp
      mpiCommunications/CommunicationTools.cpp
@@ -149,6 +129,34 @@ set( mesh_sources
      utilities/ComputationalGeometry.cpp )
 
 set( dependencyList ${parallelDeps} schema dataRepository constitutive finiteElement parmetis metis )
+
+if( ENABLE_PARTICLE_METHOD )
+  message( STATUS "Adding particle method" )
+  set( mesh_headers ${mesh_headers}
+       generators/ParticleBlock.hpp
+       generators/ParticleBlockManager.hpp
+       ParticleManager.hpp
+       ParticleRegion.hpp
+       ParticleRegionBase.hpp
+       ParticleSubRegion.hpp
+       ParticleSubRegionBase.hpp
+       generators/ParticleBlockABC.hpp
+       ParticleType.hpp
+       ToParticleRelation.hpp
+       generators/ParticleMeshGenerator.hpp )
+
+  # Specify all sources
+  set( mesh_sources ${mesh_sources}
+       generators/ParticleBlock.cpp
+       generators/ParticleBlockManager.cpp
+       ParticleManager.cpp
+       ParticleRegion.cpp
+       ParticleRegionBase.cpp
+       ParticleSubRegion.cpp
+       ParticleSubRegionBase.cpp
+       ToParticleRelation.cpp
+       generators/ParticleMeshGenerator.cpp )
+endif()
 
 if( ENABLE_VTK )
     message(STATUS "Adding VTK readers")

--- a/src/coreComponents/mesh/MeshLevel.cpp
+++ b/src/coreComponents/mesh/MeshLevel.cpp
@@ -32,7 +32,9 @@ MeshLevel::MeshLevel( string const & name,
                       Group * const parent ):
   Group( name, parent ),
   m_nodeManager( new NodeManager( groupStructKeys::nodeManagerString(), this ) ),
+#if defined(GEOS_USE_PARTICLE_METHOD)
   m_particleManager( new ParticleManager( groupStructKeys::particleManagerString(), this ) ),
+#endif
   m_edgeManager( new EdgeManager( groupStructKeys::edgeManagerString(), this ) ),
   m_faceManager( new FaceManager( groupStructKeys::faceManagerString(), this ) ),
   m_elementManager( new ElementRegionManager( groupStructKeys::elemManagerString(), this ) ),
@@ -45,8 +47,9 @@ MeshLevel::MeshLevel( string const & name,
 
   registerGroup( groupStructKeys::nodeManagerString(), m_nodeManager );
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
   registerGroup( groupStructKeys::particleManagerString(), m_particleManager );
-
+#endif
   registerGroup( groupStructKeys::edgeManagerString(), m_edgeManager );
 
 
@@ -74,7 +77,9 @@ MeshLevel::MeshLevel( string const & name,
                       MeshLevel & source ):
   Group( name, parent ),
   m_nodeManager( source.m_nodeManager ),
+#if defined(GEOS_USE_PARTICLE_METHOD)
   m_particleManager( source.m_particleManager ),
+#endif
   m_edgeManager( source.m_edgeManager ),
   m_faceManager( source.m_faceManager ),
   m_elementManager( source.m_elementManager ),

--- a/src/coreComponents/mesh/MeshLevel.hpp
+++ b/src/coreComponents/mesh/MeshLevel.hpp
@@ -20,7 +20,9 @@
 #define GEOS_MESH_MESHLEVEL_HPP_
 
 #include "NodeManager.hpp"
+#if defined(GEOS_USE_PARTICLE_METHOD)
 #include "ParticleManager.hpp"
+#endif
 #include "EmbeddedSurfaceNodeManager.hpp"
 #include "EdgeManager.hpp"
 #include "ElementRegionManager.hpp"
@@ -126,13 +128,16 @@ public:
 
     // This key is defined in problem manager:
     static constexpr char const * elemManagerString() { return "ElementRegions"; }
+#if defined(GEOS_USE_PARTICLE_METHOD)
     static constexpr char const * particleManagerString() { return "ParticleRegions"; }
-
+#endif
     static constexpr auto embSurfNodeManagerString = "embeddedSurfacesNodeManager";
     static constexpr auto embSurfEdgeManagerString = "embeddedSurfacesEdgeManager";
 
     dataRepository::GroupKey nodeManager = {nodeManagerString()};
+#if defined(GEOS_USE_PARTICLE_METHOD)
     dataRepository::GroupKey particleManager = {particleManagerString()};
+#endif
     dataRepository::GroupKey edgeManager = {edgeManagerString()};
     dataRepository::GroupKey faceManager = {faceManagerString()};
     dataRepository::GroupKey elemManager = {elemManagerString()};
@@ -160,6 +165,7 @@ public:
   NodeManager & getNodeManager()
   { return *m_nodeManager; }
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
   /**
    * @brief Get the particle manager.
    * @return a reference to the particleManager object
@@ -172,6 +178,7 @@ public:
    */
   ParticleManager & getParticleManager()
   { return *m_particleManager; }
+#endif
 
   /**
    * @brief Get the edge manager.
@@ -285,8 +292,10 @@ private:
 
   /// Manager for node data
   NodeManager * const m_nodeManager;
+#if defined(GEOS_USE_PARTICLE_METHOD)
   /// Manager for particle data
   ParticleManager * const m_particleManager;
+#endif
   /// Manager for edge data
   EdgeManager * const m_edgeManager;
   /// Manager for face data

--- a/src/coreComponents/mesh/generators/MeshGeneratorBase.cpp
+++ b/src/coreComponents/mesh/generators/MeshGeneratorBase.cpp
@@ -50,6 +50,7 @@ MeshGeneratorBase::CatalogInterface::CatalogType & MeshGeneratorBase::getCatalog
 
 void MeshGeneratorBase::generateMesh( Group & parent, SpatialPartition & partition )
 {
+#if defined(GEOS_USE_PARTICLE_METHOD)
   MeshBody & meshBody = dynamic_cast< MeshBody & >( parent );
   if( meshBody.hasParticles() )
   {
@@ -61,6 +62,7 @@ void MeshGeneratorBase::generateMesh( Group & parent, SpatialPartition & partiti
     fillParticleBlockManager( particleBlockManager, particleManager, partition );
   }
   else
+#endif
   {
     CellBlockManager & cellBlockManager = parent.registerGroup< CellBlockManager >( keys::cellManager );
 

--- a/src/coreComponents/mesh/generators/MeshGeneratorBase.hpp
+++ b/src/coreComponents/mesh/generators/MeshGeneratorBase.hpp
@@ -152,6 +152,7 @@ private:
 
   void attachWellInfo( CellBlockManager & cellBlockManager );
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
   /**
    * @brief Fill the particleBlockManager object .
    * @param[inout] particleBlockManager the particleBlockManager that will receive the meshing information
@@ -165,7 +166,7 @@ private:
     GEOS_UNUSED_VAR( partition );
     GEOS_ERROR( "Particle mesh generation not implemented for generator of this type" );
   }
-
+#endif
 };
 }
 

--- a/src/coreComponents/mesh/generators/ParticleMeshGenerator.hpp
+++ b/src/coreComponents/mesh/generators/ParticleMeshGenerator.hpp
@@ -19,6 +19,7 @@
 #ifndef GEOSX_MESH_GENERATORS_PARTICLEMESHGENERATOR_HPP
 #define GEOSX_MESH_GENERATORS_PARTICLEMESHGENERATOR_HPP
 
+
 #include "mesh/generators/MeshGeneratorBase.hpp"
 
 #include "codingUtilities/EnumStrings.hpp"
@@ -27,6 +28,7 @@ namespace geos
 {
 
 class ParticleManager;
+class ParticleBlockManager;
 class SpatialPartition;
 
 /**
@@ -60,6 +62,12 @@ public:
    */
   virtual Group * createChild( string const & childKey, string const & childName ) override;
 
+  /**
+   * @brief Fill the particleBlockManager object .
+   * @param[inout] particleBlockManager the particleBlockManager that will receive the meshing information
+   * @param[in] particleManager The reference to the particle manager
+   * @param[in] partition The reference to spatial partition
+   */
   virtual void fillParticleBlockManager( ParticleBlockManager & particleBlockManager, ParticleManager & particleManager, SpatialPartition const & partition ) override;
 
   void importFieldOnArray( Block block,

--- a/src/coreComponents/mesh/mpiCommunications/SpatialPartition.cpp
+++ b/src/coreComponents/mesh/mpiCommunications/SpatialPartition.cpp
@@ -327,6 +327,7 @@ void SpatialPartition::setContactGhostRange( const real64 bufferSize )
   LvArray::tensorOps::addScalar< 3 >( m_contactGhostMax, bufferSize );
 }
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
 void SpatialPartition::repartitionMasterParticles( ParticleSubRegion & subRegion,
                                                    MPI_iCommData & commData )
 {
@@ -1023,7 +1024,7 @@ void SpatialPartition::sendParticlesToNeighbor( ParticleSubRegionBase & subRegio
     // Unpack the buffer to an array of coordinates.
     subRegion.particleUnpack( receiveBuffer[n], newParticleStartingIndices[n], numberOfIncomingParticles[n] );
   }
-
 }
+#endif
 
 }

--- a/src/coreComponents/mesh/mpiCommunications/SpatialPartition.hpp
+++ b/src/coreComponents/mesh/mpiCommunications/SpatialPartition.hpp
@@ -73,6 +73,7 @@ public:
 
   int getColor() override;
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
   void repartitionMasterParticles( ParticleSubRegion & subRegion,
                                    MPI_iCommData & commData );
 
@@ -101,6 +102,7 @@ public:
                                 std::vector< int > const & numberOfIncomingParticles,
                                 MPI_iCommData & commData,
                                 std::vector< array1d< localIndex > > const & particleLocalIndicesToSendToEachNeighbor );
+#endif
 
   /**
    * @brief Get the metis neighbors indices, const version. @see DomainPartition#m_metisNeighborList

--- a/src/coreComponents/physicsSolvers/CMakeLists.txt
+++ b/src/coreComponents/physicsSolvers/CMakeLists.txt
@@ -106,11 +106,8 @@ set( physicsSolvers_headers
      solidMechanics/SolidMechanicsLagrangianFEM.hpp
      solidMechanics/SolidMechanicsLagrangianSSLE.hpp
      solidMechanics/kernels/SolidMechanicsLagrangianFEMKernels.hpp
-     solidMechanics/SolidMechanicsMPM.hpp
-     solidMechanics/MPMSolverFields.hpp
      solidMechanics/kernels/ExplicitFiniteStrain.hpp
      solidMechanics/kernels/ExplicitFiniteStrain_impl.hpp
-     solidMechanics/kernels/ExplicitMPM.hpp
      solidMechanics/kernels/ExplicitSmallStrain.hpp
      solidMechanics/kernels/ExplicitSmallStrain_impl.hpp
      solidMechanics/kernels/FixedStressThermoPoromechanics.hpp
@@ -195,7 +192,6 @@ set( physicsSolvers_sources
      simplePDE/PhaseFieldDamageFEM.cpp
      solidMechanics/SolidMechanicsLagrangianFEM.cpp
      solidMechanics/SolidMechanicsLagrangianSSLE.cpp
-     solidMechanics/SolidMechanicsMPM.cpp
      solidMechanics/SolidMechanicsStateReset.cpp
      solidMechanics/SolidMechanicsStatistics.cpp
      surfaceGeneration/EmbeddedSurfaceGenerator.cpp
@@ -210,8 +206,17 @@ set( physicsSolvers_sources
      wavePropagation/AcousticVTIWaveEquationSEM.cpp
      wavePropagation/AcousticElasticWaveEquationSEM.cpp )
 
-  include( solidMechanics/kernels/SolidMechanicsKernels.cmake)
-  include( multiphysics/poromechanicsKernels/PoromechanicsKernels.cmake)
+include( solidMechanics/kernels/SolidMechanicsKernels.cmake)
+include( multiphysics/poromechanicsKernels/PoromechanicsKernels.cmake )
+
+if( ENABLE_PARTICLE_METHOD )
+  set( physicsSolvers_headers ${physicsSolvers_headers}
+       solidMechanics/SolidMechanicsMPM.hpp
+       solidMechanics/MPMSolverFields.hpp
+       solidMechanics/kernels/ExplicitMPM.hpp )
+  set( physicsSolvers_sources ${physicsSolvers_sources}
+       solidMechanics/SolidMechanicsMPM.cpp )
+endif()
 
 set( dependencyList ${parallelDeps} constitutive mesh linearAlgebra discretizationMethods events )
 if( ENABLE_PYGEOSX )

--- a/src/coreComponents/physicsSolvers/FieldStatisticsBase.hpp
+++ b/src/coreComponents/physicsSolvers/FieldStatisticsBase.hpp
@@ -24,6 +24,7 @@
 #include "mainInterface/ProblemManager.hpp"
 #include "mesh/MeshLevel.hpp"
 #include "fileIO/Outputs/OutputBase.hpp"
+#include "common/MpiWrapper.hpp"
 
 namespace geos
 {

--- a/src/coreComponents/physicsSolvers/SolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.hpp
@@ -763,8 +763,10 @@ protected:
   template< typename CONSTITUTIVE_BASE_TYPE >
   static string getConstitutiveName( ElementSubRegionBase const & subRegion );
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
   template< typename CONSTITUTIVE_BASE_TYPE >
   static string getConstitutiveName( ParticleSubRegionBase const & subRegion ); // particle overload
+#endif
 
   /**
    * @brief This function sets constitutive name fields on an
@@ -773,8 +775,10 @@ protected:
    *  names set.
    */
   virtual void setConstitutiveNamesCallSuper( ElementSubRegionBase & subRegion ) const { GEOS_UNUSED_VAR( subRegion ); }
+#if defined(GEOS_USE_PARTICLE_METHOD)
   virtual void setConstitutiveNamesCallSuper( ParticleSubRegionBase & subRegion ) const { GEOS_UNUSED_VAR( subRegion ); } // particle
                                                                                                                           // overload
+#endif
 
   template< typename BASETYPE = constitutive::ConstitutiveBase, typename LOOKUP_TYPE >
   static BASETYPE const & getConstitutiveModel( dataRepository::Group const & dataGroup, LOOKUP_TYPE const & key );
@@ -836,7 +840,9 @@ private:
    *  names set.
    */
   virtual void setConstitutiveNames( ElementSubRegionBase & subRegion ) const { GEOS_UNUSED_VAR( subRegion ); }
+#if defined(GEOS_USE_PARTICLE_METHOD)
   virtual void setConstitutiveNames( ParticleSubRegionBase & subRegion ) const { GEOS_UNUSED_VAR( subRegion ); } // particle overload
+#endif
 
   bool solveNonlinearSystem( real64 const & time_n,
                              real64 const & dt,
@@ -859,6 +865,7 @@ string SolverBase::getConstitutiveName( ElementSubRegionBase const & subRegion )
   return validName;
 }
 
+#if defined(GEOS_USE_PARTICLE_METHOD)
 template< typename CONSTITUTIVE_BASE_TYPE >
 string SolverBase::getConstitutiveName( ParticleSubRegionBase const & subRegion ) // particle overload
 {
@@ -872,6 +879,7 @@ string SolverBase::getConstitutiveName( ParticleSubRegionBase const & subRegion 
   } );
   return validName;
 }
+#endif
 
 template< typename BASETYPE, typename LOOKUP_TYPE >
 BASETYPE const & SolverBase::getConstitutiveModel( dataRepository::Group const & dataGroup, LOOKUP_TYPE const & key )


### PR DESCRIPTION
Add the (intentionally non-documented) keyword `ENABLE_PARTICLE_METHOD` to trigger the support of the particle method in `geos`.
The support is `on` by default.