### PR TITLE
Fix broken compilation on Pangea3

### DIFF
--- a/src/coreComponents/physicsSolvers/SolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.hpp
@@ -21,6 +21,7 @@
 #include "linearAlgebra/interfaces/InterfaceTypes.hpp"
 #include "linearAlgebra/utilities/LinearSolverResult.hpp"
 #include "linearAlgebra/DofManager.hpp"
+#include "mesh/DomainPartition.hpp"
 #include "mesh/MeshBody.hpp"
 #include "physicsSolvers/NonlinearSolverParameters.hpp"
 #include "physicsSolvers/LinearSolverParameters.hpp"

--- a/src/coreComponents/physicsSolvers/SolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/SolverBase.hpp
@@ -21,7 +21,6 @@
 #include "linearAlgebra/interfaces/InterfaceTypes.hpp"
 #include "linearAlgebra/utilities/LinearSolverResult.hpp"
 #include "linearAlgebra/DofManager.hpp"
-#include "mesh/DomainPartition.hpp"
 #include "mesh/MeshBody.hpp"
 #include "physicsSolvers/NonlinearSolverParameters.hpp"
 #include "physicsSolvers/LinearSolverParameters.hpp"

--- a/src/coreComponents/physicsSolvers/python/PySolver.cpp
+++ b/src/coreComponents/physicsSolvers/python/PySolver.cpp
@@ -5,6 +5,7 @@
 #include "PySolver.hpp"
 #include "dataRepository/python/PyGroupType.hpp"
 #include "PySolverType.hpp"
+#include "mesh/DomainPartition.hpp"
 
 #define VERIFY_NON_NULL_SELF( self ) \
   PYTHON_ERROR_IF( self == nullptr, PyExc_RuntimeError, "Passed a nullptr as self.", nullptr )


### PR DESCRIPTION
Compilation is broken on Pangea 3 (where python component compilation is enabled), due to the following error:
```
src/coreComponents/common/DataTypes.hpp(83): error: the type in a dynamic_cast must be a pointer or reference to a complete class type, or void *
          detected during:
            instantiation of "NEW_TYPE geos::dynamicCast<NEW_TYPE,EXISTING_TYPE>(EXISTING_TYPE *) [with NEW_TYPE=geos::DomainPartition *, EXISTING_TYPE=geos::dataRepository::Group]" 
(99): here
            instantiation of "NEW_TYPE geos::dynamicCast<NEW_TYPE,EXISTING_TYPE>(EXISTING_TYPE &) [with NEW_TYPE=geos::DomainPartition &, EXISTING_TYPE=geos::dataRepository::Group]" 
src/coreComponents/dataRepository/Group.hpp(370): here
            instantiation of "T &geos::dataRepository::Group::getGroupByPath(const geos::string &) [with T=geos::DomainPartition]" 
src/coreComponents/physicsSolvers/python/PySolver.cpp(77): here

```

This is due to an include that was removed in [PR 3064](https://github.com/GEOS-DEV/GEOS/pull/3064).

This PR reverts the needed `include`. 