### PR TITLE
Refactoring  flow `StackVariables` to use `DerivOffset`

### DIFF
--- a/src/coreComponents/constitutive/CMakeLists.txt
+++ b/src/coreComponents/constitutive/CMakeLists.txt
@@ -83,6 +83,7 @@ set( constitutive_headers
      fluid/multifluid/reactive/chemicalReactions/EquilibriumReactions.hpp
      fluid/multifluid/reactive/chemicalReactions/KineticReactions.hpp
      fluid/multifluid/reactive/chemicalReactions/ReactionsBase.hpp
+     fluid/singlefluid/Layouts.hpp
      fluid/singlefluid/CompressibleSinglePhaseFluid.hpp
      fluid/singlefluid/ParticleFluid.hpp
      fluid/singlefluid/ParticleFluidBase.hpp

--- a/src/coreComponents/constitutive/fluid/singlefluid/Layouts.hpp
+++ b/src/coreComponents/constitutive/fluid/singlefluid/Layouts.hpp
@@ -1,0 +1,47 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2018-2020 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2020 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2018-2020 TotalEnergies
+ * Copyright (c) 2019-     GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file Layouts.hpp
+ */
+
+#ifndef GEOS_CONSTITUTIVE_FLUID_SINGLEFLUID_LAYOUTS_HPP
+#define GEOS_CONSTITUTIVE_FLUID_SINGLEFLUID_LAYOUTS_HPP
+
+#include "common/DataTypes.hpp"
+#include "common/GeosxConfig.hpp"
+
+#include "LvArray/src/typeManipulation.hpp"
+#include "RAJA/RAJA.hpp"
+
+namespace geos
+{
+namespace constitutive
+{
+namespace singlefluid
+{
+
+struct DerivativeOffset
+{
+  /// index of derivative wrt pressure
+  static integer constexpr dP = 0;
+  /// index of derivative wrt temperature
+  static integer constexpr dT = 1;
+};
+
+}
+}
+}
+
+#endif //GEOS_CONSTITUTIVE_FLUID_LAYOUTS_HPP

--- a/src/coreComponents/physicsSolvers/fluidFlow/IsothermalCompositionalMultiphaseFVMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/IsothermalCompositionalMultiphaseFVMKernels.hpp
@@ -579,7 +579,7 @@ public:
                     StackVariables & stack,
                     FUNC && compFluxKernelOp = NoOpFunc{} ) const
   {
-      using Deriv = multifluid::DerivativeOffset;
+    using Deriv = multifluid::DerivativeOffset;
 
     // first, compute the transmissibilities at this face
     m_stencilWrapper.computeWeights( iconn,

--- a/src/coreComponents/physicsSolvers/fluidFlow/ReactiveCompositionalMultiphaseOBLKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/ReactiveCompositionalMultiphaseOBLKernels.hpp
@@ -20,6 +20,7 @@
 #define GEOS_PHYSICSSOLVERS_FLUIDFLOW_REACTIVECOMPOSITIONALMULTIPHASEOBLKERNELS_HPP
 
 #include "common/DataLayouts.hpp"
+#include "constitutive/fluid/singlefluid/Layouts.hpp"
 #include "common/DataTypes.hpp"
 #include "common/GEOS_RAJA_Interface.hpp"
 #include "constitutive/permeability/PermeabilityFields.hpp"
@@ -737,6 +738,7 @@ class FaceBasedAssemblyKernel : public FaceBasedAssemblyKernelBase
 {
 public:
 
+  using Deriv = constitutive::singlefluid::DerivativeOffset;
   /// Compile time value for the number of phases
   static constexpr integer numPhases = NUM_PHASES;
   /// Compile time value for the number of components
@@ -836,7 +838,7 @@ public:
     /// Thermal Transmissibility
     real64 diffusiveTransmissibility[maxNumConns][2]{};
     /// Derivatives of transmissibility with respect to pressure
-    real64 dTrans_dPres[maxNumConns][2]{};
+    real64 dTrans[1][maxNumConns][2]{}; // only deps is pressure
 
     // Local degrees of freedom and local residual/jacobian
 
@@ -901,11 +903,11 @@ public:
                                      m_permeability,
                                      m_dPerm_dPres,
                                      stack.transmissibility,
-                                     stack.dTrans_dPres );
+                                     stack.dTrans[Deriv::dP] );
 
     m_stencilWrapper.computeWeights( iconn,
                                      stack.diffusiveTransmissibility,
-                                     stack.dTrans_dPres );
+                                     stack.dTrans[Deriv::dP] );
 
 
     // As a first iteration, do everything in TPFA style: i is the left (minus) element, j is the right(plus) element.

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseFVMKernels.hpp
@@ -180,6 +180,8 @@ class FaceBasedAssemblyKernel : public FaceBasedAssemblyKernelBase
 {
 public:
 
+  using Deriv = constitutive::singlefluid::DerivativeOffset;
+
   /// Compute time value for the number of degrees of freedom
   static constexpr integer numDof = NUM_DOF;
 
@@ -265,7 +267,7 @@ public:
     /// Transmissibility
     real64 transmissibility[maxNumConns][2]{};
     /// Derivatives of transmissibility with respect to pressure
-    real64 dTrans_dPres[maxNumConns][2]{};
+    real64 dTrans[1][maxNumConns][2]{};//only pressure here
 
     // Local degrees of freedom and local residual/jacobian
 
@@ -336,7 +338,7 @@ public:
                                      m_permeability,
                                      m_dPerm_dPres,
                                      stack.transmissibility,
-                                     stack.dTrans_dPres );
+                                     stack.dTrans[Deriv::dP] );
 
     localIndex k[2];
     localIndex connectionIndex = 0;
@@ -354,7 +356,7 @@ public:
         real64 dFlux_dP[2]{0.0, 0.0};
 
         real64 const trans[2] = { stack.transmissibility[connectionIndex][0], stack.transmissibility[connectionIndex][1] };
-        real64 const dTrans_dP[2] = { stack.dTrans_dPres[connectionIndex][0], stack.dTrans_dPres[connectionIndex][1] };
+        real64 const dTrans_dP[2] = { stack.dTrans[Deriv::dP][connectionIndex][0], stack.dTrans[Deriv::dP][connectionIndex][1] };
 
         real64 presGrad = 0.0;
         real64 dPresGrad_dP[2]{0.0, 0.0};

--- a/src/coreComponents/physicsSolvers/fluidFlow/StabilizedCompositionalMultiphaseFVMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/StabilizedCompositionalMultiphaseFVMKernels.hpp
@@ -164,7 +164,7 @@ public:
     using Base::StackVariables::stencilSize;
     using Base::StackVariables::numConnectedElems;
     using Base::StackVariables::transmissibility;
-    using Base::StackVariables::dTrans_dPres;
+    using Base::StackVariables::dTrans;
     using Base::StackVariables::dofColIndices;
     using Base::StackVariables::localFlux;
     using Base::StackVariables::localFluxJacobian;

--- a/src/coreComponents/physicsSolvers/fluidFlow/ThermalCompositionalMultiphaseFVMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/ThermalCompositionalMultiphaseFVMKernels.hpp
@@ -284,7 +284,7 @@ public:
     using Base::StackVariables::stencilSize;
     using Base::StackVariables::numConnectedElems;
     using Base::StackVariables::transmissibility;
-    using Base::StackVariables::dTrans_dPres;
+    using Base::StackVariables::dTrans;
     using Base::StackVariables::dofColIndices;
     using Base::StackVariables::localFlux;
     using Base::StackVariables::localFluxJacobian;
@@ -509,7 +509,7 @@ public:
                                      m_thermalConductivity,
                                      m_thermalConductivity, // we have to pass something here, so we just use thermal conductivity
                                      stack.thermalTransmissibility,
-                                     stack.dTrans_dPres ); // again, we have to pass something here, but this is unused for now
+                                     stack.dTrans[Deriv::dP] );           // again, we have to pass something here, but this is unused for now
 
 
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/ThermalCompositionalMultiphaseFVMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/ThermalCompositionalMultiphaseFVMKernels.hpp
@@ -509,7 +509,8 @@ public:
                                      m_thermalConductivity,
                                      m_thermalConductivity, // we have to pass something here, so we just use thermal conductivity
                                      stack.thermalTransmissibility,
-                                     stack.dTrans[Deriv::dP] );           // again, we have to pass something here, but this is unused for now
+                                     stack.dTrans[Deriv::dT] );           // again, we have to pass something here, but this is unused for
+                                                                          // now
 
 
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/ThermalSinglePhaseFVMKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/ThermalSinglePhaseFVMKernels.hpp
@@ -44,6 +44,7 @@ class FaceBasedAssemblyKernel : public singlePhaseFVMKernels::FaceBasedAssemblyK
 {
 public:
 
+  using Deriv = constitutive::singlefluid::DerivativeOffset;
   /**
    * @brief The type for element-based data. Consists entirely of ArrayView's.
    *
@@ -152,7 +153,7 @@ public:
     using Base::StackVariables::stencilSize;
     using Base::StackVariables::numFluxElems;
     using Base::StackVariables::transmissibility;
-    using Base::StackVariables::dTrans_dPres;
+    using Base::StackVariables::dTrans;
     using Base::StackVariables::dofColIndices;
     using Base::StackVariables::localFlux;
     using Base::StackVariables::localFluxJacobian;
@@ -331,7 +332,7 @@ public:
                                      m_thermalConductivity,
                                      m_thermalConductivity, // we have to pass something here, so we just use thermal conductivity
                                      stack.thermalTransmissibility,
-                                     stack.dTrans_dPres ); // again, we have to pass something here, but this is unused for now
+                                     stack.dTrans[Deriv::dP] ); // again, we have to pass something here, but this is unused for now
 
     localIndex k[2];
     localIndex connectionIndex = 0;

--- a/src/coreComponents/physicsSolvers/multiphysics/poromechanicsKernels/SinglePhasePoromechanicsConformingFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/poromechanicsKernels/SinglePhasePoromechanicsConformingFractures.hpp
@@ -36,6 +36,8 @@ class ConnectorBasedAssemblyKernel : public singlePhaseFVMKernels::FaceBasedAsse
 {
 public:
 
+  using Deriv = constitutive::singlefluid::DerivativeOffset;
+
   /**
    * @brief The type for element-based data. Consists entirely of ArrayView's.
    *
@@ -170,7 +172,7 @@ public:
                                      m_dPerm_dPres,
                                      m_dPerm_dDispJump,
                                      stack.transmissibility,
-                                     stack.dTrans_dPres,
+                                     stack.dTrans[Deriv::dP],
                                      stack.dTrans_dDispJump );
 
 
@@ -186,7 +188,7 @@ public:
         real64 mobility = 0.0;
         real64 potGrad = 0.0;
         real64 const trans[2] = { stack.transmissibility[connectionIndex][0], stack.transmissibility[connectionIndex][1] };
-        real64 const dTrans[2] = { stack.dTrans_dPres[connectionIndex][0], stack.dTrans_dPres[connectionIndex][1] };
+        real64 const dTrans[2] = { stack.dTrans[Deriv::dP][connectionIndex][0], stack.dTrans[Deriv::dP][connectionIndex][1] };
         real64 dFlux_dP[2] = { 0.0, 0.0 };
         localIndex const regionIndex[2]    = {m_seri[iconn][k[0]], m_seri[iconn][k[1]]};
         localIndex const subRegionIndex[2] = {m_sesri[iconn][k[0]], m_sesri[iconn][k[1]]};

--- a/src/coreComponents/physicsSolvers/multiphysics/poromechanicsKernels/SinglePhasePoromechanicsEmbeddedFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/poromechanicsKernels/SinglePhasePoromechanicsEmbeddedFractures.hpp
@@ -36,6 +36,7 @@ class ConnectorBasedAssemblyKernel : public singlePhaseFVMKernels::FaceBasedAsse
 {
 public:
 
+  using Deriv = constitutive::singlefluid::DerivativeOffset;
   /**
    * @brief The type for element-based data. Consists entirely of ArrayView's.
    *
@@ -165,7 +166,7 @@ public:
                                      m_dPerm_dPres,
                                      m_dPerm_dDispJump,
                                      stack.transmissibility,
-                                     stack.dTrans_dPres,
+                                     stack.dTrans[Deriv::dP],
                                      stack.dTrans_dDispJump );
 
 
@@ -173,7 +174,7 @@ public:
     real64 dFlux_dTrans = 0.0;
     /// EDFM connections are always only between 2 elements. There are no star connections.
     real64 trans[2] = {stack.transmissibility[0][0], stack.transmissibility[0][1]};
-    real64 dTrans[2] = { stack.dTrans_dPres[0][0], stack.dTrans_dPres[0][1] };
+    real64 dTrans[2] = { stack.dTrans[Deriv::dP][0][0], stack.dTrans[Deriv::dP][0][1] };
     real64 dFlux_dP[2] = {0.0, 0.0};
     localIndex const regionIndex[2]    = {m_seri[iconn][0], m_seri[iconn][1]};
     localIndex const subRegionIndex[2] = {m_sesri[iconn][0], m_sesri[iconn][1]};

--- a/src/coreComponents/physicsSolvers/multiphysics/poromechanicsKernels/ThermalSinglePhasePoromechanicsConformingFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/poromechanicsKernels/ThermalSinglePhasePoromechanicsConformingFractures.hpp
@@ -35,6 +35,8 @@ class ConnectorBasedAssemblyKernel : public singlePhasePoromechanicsConformingFr
 {
 public:
 
+  using Deriv = constitutive::singlefluid::DerivativeOffset;
+
   /**
    * @brief The type for element-based data. Consists entirely of ArrayView's.
    *
@@ -149,7 +151,7 @@ public:
     using SinglePhaseFVMBase::StackVariables::stencilSize;
     using SinglePhaseFVMBase::StackVariables::numFluxElems;
     using SinglePhaseFVMBase::StackVariables::transmissibility;
-    using SinglePhaseFVMBase::StackVariables::dTrans_dPres;
+    using SinglePhaseFVMBase::StackVariables::dTrans;
     using SinglePhaseFVMBase::StackVariables::dofColIndices;
     using SinglePhaseFVMBase::StackVariables::localFlux;
     using SinglePhaseFVMBase::StackVariables::localFluxJacobian;
@@ -246,7 +248,7 @@ public:
                                      m_thermalConductivity,
                                      m_thermalConductivity, // we have to pass something here, so we just use thermal conductivity
                                      stack.thermalTransmissibility,
-                                     stack.dTrans_dPres ); // again, we have to pass something here, but this is unused for now
+                                     stack.dTrans[Deriv::dP] ); // again, we have to pass something here, but this is unused for now
 
     localIndex k[2];
     localIndex connectionIndex = 0;

--- a/src/coreComponents/physicsSolvers/multiphysics/poromechanicsKernels/ThermalSinglePhasePoromechanicsEmbeddedFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/poromechanicsKernels/ThermalSinglePhasePoromechanicsEmbeddedFractures.hpp
@@ -35,6 +35,8 @@ class ConnectorBasedAssemblyKernel : public singlePhasePoromechanicsEmbeddedFrac
 {
 public:
 
+  using Deriv = constitutive::singlefluid::DerivativeOffset;
+
   /**
    * @brief The type for element-based data. Consists entirely of ArrayView's.
    *
@@ -149,7 +151,7 @@ public:
     using SinglePhaseFVMBase::StackVariables::stencilSize;
     using SinglePhaseFVMBase::StackVariables::numFluxElems;
     using SinglePhaseFVMBase::StackVariables::transmissibility;
-    using SinglePhaseFVMBase::StackVariables::dTrans_dPres;
+    using SinglePhaseFVMBase::StackVariables::dTrans;
     using SinglePhaseFVMBase::StackVariables::dofColIndices;
     using SinglePhaseFVMBase::StackVariables::localFlux;
     using SinglePhaseFVMBase::StackVariables::localFluxJacobian;
@@ -257,7 +259,7 @@ public:
                                      m_thermalConductivity,
                                      m_thermalConductivity, // we have to pass something here, so we just use thermal conductivity
                                      stack.thermalTransmissibility,
-                                     stack.dTrans_dPres ); // again, we have to pass something here, but this is unused for now
+                                     stack.dTrans[Deriv::dP] ); // again, we have to pass something here, but this is unused for now
 
     localIndex k[2];
     localIndex connectionIndex = 0;


### PR DESCRIPTION
As it is used in `isothermalCompositionalMultiphaseFVMKernel` or `MultifluidBase`, derivative offset helps readability and would made extension easier.

The refactoring though left out for now 
- `dTrans_dDisJump` as this derivative is multidimensional
- Hybrid Kernels with pressure both at cell center and face.
