### PR TITLE
specify self hosted runner labels explicitly

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -206,7 +206,7 @@ jobs:
       ENABLE_HYPRE: ON
       ENABLE_TRILINOS: OFF
       GCP_BUCKET: geosx/integratedTests
-      RUNS_ON: self-hosted
+      RUNS_ON: streak
       DOCKER_RUN_ARGS: "--cpus=8 --memory=128g"
 
   code_coverage:
@@ -253,7 +253,7 @@ jobs:
             ENABLE_HYPRE_DEVICE: CUDA
             ENABLE_HYPRE: ON
             ENABLE_TRILINOS: OFF
-            RUNS_ON: self-hosted
+            RUNS_ON: streak
             DOCKER_RUN_ARGS: "--cpus=8 --memory=256g --runtime=nvidia --gpus all"
 
           - name: Centos (7.7, gcc 8.3.1, open-mpi 1.10.7, cuda 11.8.89)


### PR DESCRIPTION
The self-hosted runners are referred to by "self-hosted" in the yaml files. This is a default label that is applied to every self-hosted runner and is not removable from a runner. We want greater granularity between`streak` and `streak2`.