### PR TITLE
Change uberenv repo to relative path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = ../../GEOS-DEV/hdf5_interface.git
 [submodule "scripts/uberenv"]
 	path = scripts/uberenv
-	url = git@github.com:LLNL/uberenv.git
+	url = ../../LLNL/uberenv.git


### PR DESCRIPTION
The ssh url was hardcoded into the .gitmodules file. This PR changes it back to the relative path.