### PR TITLE
Compilation failure on pangea-3 if ENABLE_CUDA is OFF

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "GEOS_TPL_TAG": "264-271"
+            "GEOS_TPL_TAG": "264-338"
         }
     },
     "runArgs": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "GEOS_TPL_TAG": "263-252"
+            "GEOS_TPL_TAG": "264-259"
         }
     },
     "runArgs": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "GEOS_TPL_TAG": "264-259"
+            "GEOS_TPL_TAG": "264-271"
         }
     },
     "runArgs": [

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,7 +127,7 @@ if( ENABLE_CUDA )
   list( APPEND extraComponentsLinkList cuda )
 endif()
 
-if( ENABLE_CUDA_NVTOOLSEXT )
+if( ENABLE_CUDA AND ENABLE_CUDA_NVTOOLSEXT )
   list( APPEND extraComponentsLinkList CUDA::nvToolsExt )
 endif()
 

--- a/src/coreComponents/CMakeLists.txt
+++ b/src/coreComponents/CMakeLists.txt
@@ -28,7 +28,7 @@ if ( ENABLE_CUDA )
   list( APPEND parallelDeps cuda )
 endif()
 
-if( ENABLE_CUDA_NVTOOLSEXT )
+if( ENABLE_CUDA AND ENABLE_CUDA_NVTOOLSEXT )
   list( APPEND parallelDeps CUDA::nvToolsExt )
 endif()
 

--- a/src/coreComponents/common/TimingMacros.hpp
+++ b/src/coreComponents/common/TimingMacros.hpp
@@ -40,7 +40,7 @@ namespace timingHelpers
 }
 
 
-#if defined( GEOS_USE_CUDA_NVTOOLSEXT )
+#if defined( GEOS_USE_CUDA ) && defined( GEOS_USE_CUDA_NVTOOLSEXT )
 
 #include "nvToolsExt.h"
 

--- a/src/coreComponents/constitutive/unitTests/CMakeLists.txt
+++ b/src/coreComponents/constitutive/unitTests/CMakeLists.txt
@@ -17,7 +17,7 @@ set( gtest_geosx_tests
 
 set( dependencyList gtest blas lapack constitutive ${parallelDeps} )
 
-if( ENABLE_CUDA_NVTOOLSEXT )
+if( ENABLE_CUDA AND ENABLE_CUDA_NVTOOLSEXT )
   list( APPEND dependencyList CUDA::nvToolsExt )
 endif()
 

--- a/src/coreComponents/dataRepository/unitTests/CMakeLists.txt
+++ b/src/coreComponents/dataRepository/unitTests/CMakeLists.txt
@@ -7,7 +7,7 @@ set( dataRepository_tests
 
 set( dependencyList ${parallelDeps} gtest dataRepository )
 
-if( ENABLE_CUDA_NVTOOLSEXT )
+if( ENABLE_CUDA AND ENABLE_CUDA_NVTOOLSEXT )
   list( APPEND dependencyList CUDA::nvToolsExt )
 endif()
 

--- a/src/coreComponents/fileIO/CMakeLists.txt
+++ b/src/coreComponents/fileIO/CMakeLists.txt
@@ -75,7 +75,7 @@ if( ENABLE_VTK )
     list( APPEND dependencyList VTK::IOLegacy VTK::IOXML )
 endif()
 
-if( ENABLE_CUDA_NVTOOLSEXT )
+if( ENABLE_CUDA AND ENABLE_CUDA_NVTOOLSEXT )
   list( APPEND dependencyList CUDA::nvToolsExt )
 endif()
 

--- a/src/coreComponents/finiteElement/unitTests/CMakeLists.txt
+++ b/src/coreComponents/finiteElement/unitTests/CMakeLists.txt
@@ -12,7 +12,7 @@ set(testSources
 
 set( dependencyList gtest finiteElement ${parallelDeps} )
 
-if( ENABLE_CUDA_NVTOOLSEXT )
+if( ENABLE_CUDA AND ENABLE_CUDA_NVTOOLSEXT )
   list( APPEND dependencyList CUDA::nvToolsExt )
 endif()
 


### PR DESCRIPTION
Configuring and compiling geos with the `TOTAL/pangea3-gcc8.4.1-openmpi-4.1.2.cmake` host-config file and the `-DENABLE_CUDA=OFF` option fails.

This PR fixes inconsistencies in the adding of the `NvToolExt` component:  the value of the `ENABLE_CUDA` variable is tested and `NvToolExt` is not added if `ENABLE_CUDA` is `OFF` (previously it was partially added, leading to compilation errors).

Associated to the [PR 264](https://github.com/GEOS-DEV/thirdPartyLibs/pull/264) of TPLs, it allows to easily build Geos without Cuda on Pangea. 

Linked to:
  - https://github.com/GEOS-DEV/thirdPartyLibs/pull/264

Resolves:
  -  #3128 