### PR TITLE
Store baselines locally on streak2.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -221,7 +221,7 @@ jobs:
           fi
 
           # Extract the baseline field 
-          BASELINE_TAG=$(grep -A 1 'baselines:' "${YAML_FILE_PATH}" | grep 'baseline:' | awk '{print $2}')
+          BASELINE_TAG=$(grep -A 2 'baselines:' "${YAML_FILE_PATH}" | grep 'baseline:' | awk '{print $2}')
           echo "Baseline: ${BASELINE_TAG}"
 
           # Extract the folder name

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -210,7 +210,7 @@ jobs:
 
         if [[ -n "${{ inputs.LOCAL_BASELINE_DIR }}" ]]; then
           # Extract the 'baseline' value using grep and awk
-          ls -l ${GITHUB_WORKSPACE}
+          ls -la ${GITHUB_WORKSPACE}
           BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_TAG}
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,6 +64,9 @@ on:
       REQUIRED_LABEL:
         required: false
         type: string
+      LOCAL_BASELINE_DIR:
+        required: false
+        type: string  
     secrets:
       GOOGLE_CLOUD_GCP:
         required: false
@@ -142,7 +145,7 @@ jobs:
         SHORT_COMMIT=${COMMIT:0:7}
         script_args+=(--install-dir-basename GEOSX-${SHORT_COMMIT})
 
-        # All the data exchanged with the docker container is eventually meant to be send to the cloud. 
+        # All the data exchanged with the docker container is eventually meant to be sent to the cloud. 
         if [[ ! -z "${{ inputs.GCP_BUCKET }}" ]]; then
           if [ "${{ inputs.BUILD_TYPE }}" = "build" ]; then
             DATA_BASENAME=GEOSX-and-TPL-${SHORT_COMMIT}.tar.gz
@@ -205,6 +208,12 @@ jobs:
           script_args+=(--code-coverage)
         fi
 
+        if [[ -n "${{ inputs.LOCAL_BASELINE_DIR }}" ]]; then
+          # Extract the 'baseline' value using grep and awk
+          BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
+          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_TAG}
+          cp -r ${CURRENT_BASELINE_DIR} ${DATA_EXCHANGE_DIR}/baselines
+        fi
 
         echo running "docker run \
           ${docker_args[@]} \
@@ -242,8 +251,16 @@ jobs:
             fi
 
             # if $UPLOAD_BASELINES; then
-              if [ -f ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME} ];then
-                CLOUDSDK_PYTHON=python3 gsutil cp -a public-read ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME} gs://${{ inputs.GCP_BUCKET }}/
+              if [ -f ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME} ];then
+                
+              # we store the baselines locally
+                echo "Create folder ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_${DATA_BASENAME::-7}"
+                mkdir ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_${DATA_BASENAME::-7}
+                echo "Copy baseline_${DATA_BASENAME} to  ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_${DATA_BASENAME::-7}"   
+                cp ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME} ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_${DATA_BASENAME::-7}
+
+                # we push the baselines to the cloud
+                CLOUDSDK_PYTHON=python3 gsutil cp -a public-read ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME} gs://${{ inputs.GCP_BUCKET }}/
                 echo "Download test baselines here: https://storage.googleapis.com/${{ inputs.GCP_BUCKET }}/baseline_${DATA_BASENAME}"
                 echo "New baseline ID: baseline_${DATA_BASENAME::-7}"
               else

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -207,7 +207,6 @@ jobs:
 
         if [[ -n "${{ inputs.LOCAL_BASELINE_DIR }}" ]]; then
           # Extract the 'baseline' value 
-          ls -lR ${{ inputs.LOCAL_BASELINE_DIR }}
            
           # Define the path to the YAML file
           YAML_FILE_PATH="${GITHUB_WORKSPACE}/.integrated_tests.yaml"
@@ -231,12 +230,18 @@ jobs:
           echo "Baseline folder name: ${BASELINE_FOLDER_NAME}"
 
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_FOLDER_NAME}
+          echo "Current baseline dir: ${CURRENT_BASELINE_DIR}"
 
-          echo "Current baseline path: ${CURRENT_BASELINE_DIR}"
+          if [ -d ${CURRENT_BASELINE_DIR} ];then
+            echo "Current baseline dir found."
+            ls -l ${CURRENT_BASELINE_DIR}
                     
-          # We defined a mount point and mount it read-only inside the container.
-          CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
-          docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
+            # We defined a mount point and mount it read-only inside the container.
+            CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
+            docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
+          else
+            echo "Current baselines directory (${CURRENT_BASELINE_DIR}) not found"  
+          fi
         fi
 
         echo running "docker run \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -212,9 +212,7 @@ jobs:
           # Extract the 'baseline' value 
           # need to extract the name wiht something like: 
           # BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
-          ls -l /home/settgast1
-          wget -P ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr3125-5101-7764ffb https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz
-          ls -l /home/settgast1/baselines
+          ls -lR /home/settgast1/baselines
 
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr3125-5101-7764ffb
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -222,7 +222,6 @@ jobs:
 
           # Extract the baseline field 
           BASELINE_FULL_PATH=$(grep -A 2 'baselines:' "${YAML_FILE_PATH}" | grep 'baseline:' | awk '{print $2}')
-          echo "Baseline: ${BASELINE_TAG}"
 
           # Remove the 'integratedTests/' prefix
           BASELINE_TAG=${BASELINE_FULL_PATH#integratedTests/}
@@ -232,7 +231,7 @@ jobs:
           BASELINE_FOLDER_NAME=$(echo "${BASELINE_TAG}" | cut -d'-' -f1-2)
           echo "Baseline folder name: ${BASELINE_FOLDER_NAME}"
 
-          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_FOLDER_NAME}/${BASELINE_TAG}
+          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_FOLDER_NAME}
           
           echo "Current baseline path: ${CURRENT_BASELINE_DIR}"
           

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -241,10 +241,7 @@ jobs:
             CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
             docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
           else
-            wget -P ${CURRENT_BASELINE_DIR} https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz
             echo "Current baselines directory (${CURRENT_BASELINE_DIR}) not found"
-            CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
-            docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)  
           fi
         fi
 
@@ -291,7 +288,7 @@ jobs:
                 # 1.a Create the new target directory to store the new baselines
                 THIS_PR_NUMBER=pr${{ github.event.number }}
                 NEW_PR_BASELINE_FOLDER_NAME=baselines_${THIS_PR_NUMBER}
-                TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/NEW_PR_BASELINE_FOLDER_NAME"
+                TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/${NEW_PR_BASELINE_FOLDER_NAME}"
                 echo "Create folder ${TARGET_DIR}"
                 mkdir -p "${TARGET_DIR}"
           
@@ -309,12 +306,6 @@ jobs:
               echo "Baselines ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME} were not uploaded. Likeyly because no rebaseline was necessary."
             fi
           fi
-        fi
-        
-        # manually remove the workspace to avoid issues with the next job when using self-hosted runners
-        if [ -d "${GITHUB_WORKSPACE}/integratedTests" ]; then
-          # Matteo: IMO this is useless now.
-          rm -rf ${GITHUB_WORKSPACE}/integratedTests
         fi
 
         exit ${EXIT_STATUS}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -210,7 +210,6 @@ jobs:
           ls -lR ${{ inputs.LOCAL_BASELINE_DIR }}
            
           # Define the path to the YAML file
-          ls -la ${GITHUB_WORKSPACE}
           YAML_FILE_PATH="${GITHUB_WORKSPACE}/.integrated_tests.yaml"
           
           # Verify the YAML file path
@@ -236,9 +235,7 @@ jobs:
           wget -P ${CURRENT_BASELINE_DIR} https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz
           
           echo "Current baseline path: ${CURRENT_BASELINE_DIR}"
-
-          ls -lR ${{ inputs.LOCAL_BASELINE_DIR }}
-          
+                    
           # We defined a mount point and mount it read-only inside the container.
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
           docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -210,9 +210,10 @@ jobs:
 
         if [[ -n "${{ inputs.LOCAL_BASELINE_DIR }}" ]]; then
           # Extract the 'baseline' value using grep and awk
+          ls -l ${GITHUB_WORKSPACE}
           BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_TAG}
-          CURRENT_BASELINE_DIR_MOUNT = /tmp/geos/baselines
+          CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
           docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
         fi
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -274,7 +274,7 @@ jobs:
               echo "Download integrated test logs here: https://storage.googleapis.com/${{ inputs.GCP_BUCKET }}/test_logs_${DATA_BASENAME}"
             fi
 
-            if [ -f ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME} ];then
+            if [ -f ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME} ];then
 
               if [[ -n "${{ inputs.LOCAL_BASELINE_DIR }}" ]]; then
                 # 1. We copy the baselines to a local directory to store them 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -221,7 +221,11 @@ jobs:
           fi
 
           # Extract the baseline field 
-          BASELINE_TAG=$(grep -A 2 'baselines:' "${YAML_FILE_PATH}" | grep 'baseline:' | awk '{print $2}')
+          BASELINE_FULL_PATH=$(grep -A 2 'baselines:' "${YAML_FILE_PATH}" | grep 'baseline:' | awk '{print $2}')
+          echo "Baseline: ${BASELINE_TAG}"
+
+          # Remove the 'integratedTests/' prefix
+          BASELINE_TAG=${BASELINE_FULL_PATH#integratedTests/}
           echo "Baseline: ${BASELINE_TAG}"
 
           # Extract the folder name

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -211,7 +211,10 @@ jobs:
         if [[ -n "${{ inputs.LOCAL_BASELINE_DIR }}" ]]; then
           # Extract the 'baseline' value using grep and awk
           ls -la ${GITHUB_WORKSPACE}
+          
+          # need to extract the name wiht something like: 
           # BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
+          
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
           docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
@@ -254,15 +257,21 @@ jobs:
 
             # if $UPLOAD_BASELINES; then
               if [ -f ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME} ];then
+                # 1. We copy the baselines to a local directory to store them 
+                LOCAL_BASELINE_DIR="${{ inputs.LOCAL_BASELINE_DIR }}"
+          
+                # 1.a Create the target directory to store the new baselines
+                TARGET_DIR="${LOCAL_BASELINE_DIR}/baseline_${DATA_BASENAME::-7}"
+                echo "Create folder ${TARGET_DIR}"
+                mkdir -p "${TARGET_DIR}"
+          
+                # 1.b Copy the baseline file to the target directory
+                SOURCE_FILE="${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME}"
+                echo "Copy ${SOURCE_FILE} to ${TARGET_DIR}"
+                cp "${SOURCE_FILE}" "${TARGET_DIR}"
                 
-              # we store the baselines locally
-                echo "Create folder ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_${DATA_BASENAME::-7}"
-                mkdir ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_${DATA_BASENAME::-7}
-                echo "Copy baseline_${DATA_BASENAME} to  ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_${DATA_BASENAME::-7}"   
-                cp ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME} ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_${DATA_BASENAME::-7}
-
-                # we push the baselines to the cloud
-                CLOUDSDK_PYTHON=python3 gsutil cp -a public-read ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME} gs://${{ inputs.GCP_BUCKET }}/
+                # 2. We push the baselines to the cloud
+                CLOUDSDK_PYTHON=python3 gsutil cp -a public-read ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME} gs://${{ inputs.GCP_BUCKET }}/
                 echo "Download test baselines here: https://storage.googleapis.com/${{ inputs.GCP_BUCKET }}/baseline_${DATA_BASENAME}"
                 echo "New baseline ID: baseline_${DATA_BASENAME::-7}"
               else

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -213,7 +213,9 @@ jobs:
           # need to extract the name wiht something like: 
           # BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
           lsblk
-          
+          df -h /home
+          ls -lR /data 
+
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
           docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -228,9 +228,9 @@ jobs:
           # Extract the folder name
           PR_NUMBER=$(echo "$BASELINE_TAG" | grep -o 'pr[0-9]*')
           PR_BASELINE_FOLDER_NAME=baselines_${PR_NUMBER}
-          echo "Baseline folder name: ${BASELINE_FOLDER_NAME}"
+          echo "Baseline folder name: ${PR_BASELINE_FOLDER_NAME}"
 
-          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_FOLDER_NAME}
+          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${PR_BASELINE_FOLDER_NAME}
           echo "Current baseline dir: ${CURRENT_BASELINE_DIR}"
 
           if [ -d ${CURRENT_BASELINE_DIR} ];then

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -242,7 +242,9 @@ jobs:
             docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
           else
             wget -P ${CURRENT_BASELINE_DIR} https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz
-            echo "Current baselines directory (${CURRENT_BASELINE_DIR}) not found"  
+            echo "Current baselines directory (${CURRENT_BASELINE_DIR}) not found"
+            CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
+            docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)  
           fi
         fi
 
@@ -288,7 +290,7 @@ jobs:
                 
                 # 1.a Create the new target directory to store the new baselines
                 THIS_PR_NUMBER=pr${{ github.event.number }}
-                NEW_PR_BASELINE_FOLDER_NAME=baselines_${PR_NUMBER}
+                NEW_PR_BASELINE_FOLDER_NAME=baselines_${THIS_PR_NUMBER}
                 TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/NEW_PR_BASELINE_FOLDER_NAME"
                 echo "Create folder ${TARGET_DIR}"
                 mkdir -p "${TARGET_DIR}"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -231,9 +231,7 @@ jobs:
           echo "Baseline folder name: ${BASELINE_FOLDER_NAME}"
 
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_FOLDER_NAME}
-          mkdir -p ${CURRENT_BASELINE_DIR}
 
-          wget -P ${CURRENT_BASELINE_DIR} https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz
           
           echo "Current baseline path: ${CURRENT_BASELINE_DIR}"
                     
@@ -281,7 +279,7 @@ jobs:
               # 1. We copy the baselines to a local directory to store them 
                 
               # 1.a Create the new target directory to store the new baselines
-              TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr-${{ github.event.number }}"
+              TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/pr-${{ github.event.number }}"
               echo "Create folder ${TARGET_DIR}"
               mkdir -p "${TARGET_DIR}"
           

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -210,6 +210,7 @@ jobs:
           ls -lR ${{ inputs.LOCAL_BASELINE_DIR }}
            
           # Define the path to the YAML file
+          ls -la ${GITHUB_WORKSPACE}
           YAML_FILE_PATH="${GITHUB_WORKSPACE}/.integrated_test.yaml"
 
           # Extract the baseline field 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -210,9 +210,10 @@ jobs:
 
         if [[ -n "${{ inputs.LOCAL_BASELINE_DIR }}" ]]; then
           # Extract the 'baseline' value using grep and awk
-          BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
+          BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_TAG}
-          cp -r ${CURRENT_BASELINE_DIR} ${DATA_EXCHANGE_DIR}/baselines
+          CURRENT_BASELINE_DIR_MOUNT = /tmp/geos/baselines
+          docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
         fi
 
         echo running "docker run \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -212,9 +212,9 @@ jobs:
           # Extract the 'baseline' value 
           # need to extract the name wiht something like: 
           # BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
-          lsblk
-          mkdir -p ${{ inputs.LOCAL_BASELINE_DIR }}
-          ls -l /home
+          ls -l /home/settgast1
+          wget -P /home/settgast1/baselines/baseline_integratedTests-pr3125-5101-7764ffb https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz
+          ls -l /home/settgast1/baselines
 
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -212,9 +212,9 @@ jobs:
           # Extract the 'baseline' value 
           # need to extract the name wiht something like: 
           # BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
-          ls -lR /home/settgast1/baselines
-
-          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr3125-5101-7764ffb
+          wget -P ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr3125 https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz 
+          ls -lR ${{ inputs.LOCAL_BASELINE_DIR }}
+          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr3125
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
           docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
         fi
@@ -257,14 +257,13 @@ jobs:
             # if $UPLOAD_BASELINES; then
               if [ -f ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME} ];then
                 # 1. We copy the baselines to a local directory to store them 
-                LOCAL_BASELINE_DIR="${{ inputs.LOCAL_BASELINE_DIR }}"
-          
-                # 1.a Create the target directory to store the new baselines
-                TARGET_DIR="${LOCAL_BASELINE_DIR}/baseline_${DATA_BASENAME::-7}"
+                
+                # 1.a Create the new target directory to store the new baselines
+                TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr-${{ github.event.number }}"
                 echo "Create folder ${TARGET_DIR}"
                 mkdir -p "${TARGET_DIR}"
           
-                # 1.b Copy the baseline file to the target directory
+                # 1.b We copy the new baselines to the new target directory
                 SOURCE_FILE="${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME}"
                 echo "Copy ${SOURCE_FILE} to ${TARGET_DIR}"
                 cp "${SOURCE_FILE}" "${TARGET_DIR}"
@@ -282,6 +281,7 @@ jobs:
         
         # manually remove the workspace to avoid issues with the next job when using self-hosted runners
         if [ -d "${GITHUB_WORKSPACE}/integratedTests" ]; then
+          # Matteo: IMO this is useless now.
           rm -rf ${GITHUB_WORKSPACE}/integratedTests
         fi
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -280,7 +280,7 @@ jobs:
                 # 1. We copy the baselines to a local directory to store them 
                 
                 # 1.a Create the new target directory to store the new baselines
-                TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/pr-${{ github.event.number }}"
+                TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/pr${{ github.event.number }}"
                 echo "Create folder ${TARGET_DIR}"
                 mkdir -p "${TARGET_DIR}"
           

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -233,8 +233,6 @@ jobs:
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${PR_BASELINE_FOLDER_NAME}
           echo "Current baseline dir: ${CURRENT_BASELINE_DIR}"
 
-          rm -r /data/GEOS/baselines/NEW_PR_BASELINE_FOLDER_NAME
-
           if [ -d ${CURRENT_BASELINE_DIR} ];then
             echo "Current baseline dir found."
             ls -l ${CURRENT_BASELINE_DIR}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,9 +54,6 @@ on:
       RUNS_ON:
         required: true
         type: string
-      UPLOAD_BASELINES:
-        required: false
-        type: string
       USE_SCCACHE:
         required: false
         type: boolean
@@ -267,28 +264,26 @@ jobs:
               echo "Download integrated test logs here: https://storage.googleapis.com/${{ inputs.GCP_BUCKET }}/test_logs_${DATA_BASENAME}"
             fi
 
-            # if $UPLOAD_BASELINES; then
-              if [ -f ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME} ];then
-                # 1. We copy the baselines to a local directory to store them 
+            if [ -f ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME} ];then
+              # 1. We copy the baselines to a local directory to store them 
                 
-                # 1.a Create the new target directory to store the new baselines
-                TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr-${{ github.event.number }}"
-                echo "Create folder ${TARGET_DIR}"
-                mkdir -p "${TARGET_DIR}"
+              # 1.a Create the new target directory to store the new baselines
+              TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr-${{ github.event.number }}"
+              echo "Create folder ${TARGET_DIR}"
+              mkdir -p "${TARGET_DIR}"
           
-                # 1.b We copy the new baselines to the new target directory
-                SOURCE_FILE="${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME}"
-                echo "Copy ${SOURCE_FILE} to ${TARGET_DIR}"
-                cp "${SOURCE_FILE}" "${TARGET_DIR}"
+              # 1.b We copy the new baselines to the new target directory
+              SOURCE_FILE="${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME}"
+              echo "Copy ${SOURCE_FILE} to ${TARGET_DIR}"
+              cp "${SOURCE_FILE}" "${TARGET_DIR}"
                 
-                # 2. We push the baselines to the cloud
-                CLOUDSDK_PYTHON=python3 gsutil cp -a public-read ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME} gs://${{ inputs.GCP_BUCKET }}/
-                echo "Download test baselines here: https://storage.googleapis.com/${{ inputs.GCP_BUCKET }}/baseline_${DATA_BASENAME}"
-                echo "New baseline ID: baseline_${DATA_BASENAME::-7}"
-              else
-                echo "Baselines ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME} were not uploaded. Likeyly because no rebaseline was necessary."
-              fi
-            # fi
+              # 2. We push the baselines to the cloud
+              CLOUDSDK_PYTHON=python3 gsutil cp -a public-read ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME} gs://${{ inputs.GCP_BUCKET }}/
+              echo "Download test baselines here: https://storage.googleapis.com/${{ inputs.GCP_BUCKET }}/baseline_${DATA_BASENAME}"
+              echo "New baseline ID: baseline_${DATA_BASENAME::-7}"
+            else
+              echo "Baselines ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME} were not uploaded. Likeyly because no rebaseline was necessary."
+            fi
           fi
         fi
         

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -227,10 +227,11 @@ jobs:
           echo "Baseline: ${BASELINE_TAG}"
 
           # Extract the folder name
-          BASELINE_FOLDER_NAME=$(echo "${BASELINE_TAG}" | cut -d'-' -f1-2)
+          BASELINE_FOLDER_NAME=$(echo "$BASELINE_TAG" | grep -o 'pr[0-9]*')
           echo "Baseline folder name: ${BASELINE_FOLDER_NAME}"
 
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_FOLDER_NAME}
+          mkdir -p ${CURRENT_BASELINE_DIR}
 
           wget -P ${CURRENT_BASELINE_DIR} https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz
           

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -211,7 +211,7 @@ jobs:
            
           # Define the path to the YAML file
           ls -la ${GITHUB_WORKSPACE}
-          YAML_FILE_PATH="${GITHUB_WORKSPACE}/.integrated_test.yaml"
+          YAML_FILE_PATH="${GITHUB_WORKSPACE}/.integrated_tests.yaml"
           
           # Verify the YAML file path
           if [[ ! -f "${YAML_FILE_PATH}" ]]; then

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -210,11 +210,24 @@ jobs:
 
         if [[ -n "${{ inputs.LOCAL_BASELINE_DIR }}" ]]; then
           # Extract the 'baseline' value 
-          # need to extract the name wiht something like: 
-          # BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
-          wget -P ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr3125 https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz 
           ls -lR ${{ inputs.LOCAL_BASELINE_DIR }}
-          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr3125
+           
+          # Define the path to the YAML file
+          yaml_file="${GITHUB_WORKSPACE}/.integrated_test.yaml"
+
+          # Extract the baseline field using grep and awk 
+          BASELINE_TAG=$(grep -A 1 'baselines:' "$yaml_file" | grep 'baseline:' | awk '{print $2}')
+          echo "Baseline: $BASELINE_TAG"
+
+          # Extract the folder name
+          BASELINE_FOLDER_NAME=$(echo "$baseline_full" | cut -d'-' -f1-2)
+          echo "Baseline folder name: $BASELINE_FOLDER_NAME"
+
+          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_FOLDER_NAME}/${BASELINE_TAG}
+          
+          echo "Current baseline path: ${CURRENT_BASELINE_DIR}"
+          
+          # We defined a mount point and mount it read-only inside the container.
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
           docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -232,8 +232,12 @@ jobs:
           echo "Baseline folder name: ${BASELINE_FOLDER_NAME}"
 
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_FOLDER_NAME}
+
+          wget -P ${CURRENT_BASELINE_DIR} https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz
           
           echo "Current baseline path: ${CURRENT_BASELINE_DIR}"
+
+          ls -lR ${{ inputs.LOCAL_BASELINE_DIR }}
           
           # We defined a mount point and mount it read-only inside the container.
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -226,7 +226,8 @@ jobs:
           echo "Baseline: ${BASELINE_TAG}"
 
           # Extract the folder name
-          BASELINE_FOLDER_NAME=$(echo "$BASELINE_TAG" | grep -o 'pr[0-9]*')
+          PR_NUMBER=$(echo "$BASELINE_TAG" | grep -o 'pr[0-9]*')
+          PR_BASELINE_FOLDER_NAME=baselines_${PR_NUMBER}
           echo "Baseline folder name: ${BASELINE_FOLDER_NAME}"
 
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_FOLDER_NAME}
@@ -240,6 +241,7 @@ jobs:
             CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
             docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
           else
+            wget -P ${CURRENT_BASELINE_DIR} https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz
             echo "Current baselines directory (${CURRENT_BASELINE_DIR}) not found"  
           fi
         fi
@@ -285,7 +287,9 @@ jobs:
                 # 1. We copy the baselines to a local directory to store them 
                 
                 # 1.a Create the new target directory to store the new baselines
-                TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/pr${{ github.event.number }}"
+                THIS_PR_NUMBER=pr${{ github.event.number }}
+                NEW_PR_BASELINE_FOLDER_NAME=baselines_${PR_NUMBER}
+                TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/NEW_PR_BASELINE_FOLDER_NAME"
                 echo "Create folder ${TARGET_DIR}"
                 mkdir -p "${TARGET_DIR}"
           

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -213,10 +213,10 @@ jobs:
           ls -lR ${{ inputs.LOCAL_BASELINE_DIR }}
            
           # Define the path to the YAML file
-          yaml_file="${GITHUB_WORKSPACE}/.integrated_test.yaml"
+          YAML_FILE_PATH="${GITHUB_WORKSPACE}/.integrated_test.yaml"
 
-          # Extract the baseline field using grep and awk 
-          BASELINE_TAG=$(grep -A 1 'baselines:' "$yaml_file" | grep 'baseline:' | awk '{print $2}')
+          # Extract the baseline field 
+          BASELINE_TAG=$(grep -A 1 'baselines:' "$YAML_FILE_PATH" | grep 'baseline:' | awk '{print $2}')
           echo "Baseline: $BASELINE_TAG"
 
           # Extract the folder name

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -212,14 +212,22 @@ jobs:
           # Define the path to the YAML file
           ls -la ${GITHUB_WORKSPACE}
           YAML_FILE_PATH="${GITHUB_WORKSPACE}/.integrated_test.yaml"
+          
+          # Verify the YAML file path
+          if [[ ! -f "${YAML_FILE_PATH}" ]]; then
+            echo "Error: File $YAML_FILE_PATH does not exist."
+            exit 1
+          else
+            echo "Found integratedTests file: $YAML_FILE_PATH."
+          fi
 
           # Extract the baseline field 
-          BASELINE_TAG=$(grep -A 1 'baselines:' "$YAML_FILE_PATH" | grep 'baseline:' | awk '{print $2}')
-          echo "Baseline: $BASELINE_TAG"
+          BASELINE_TAG=$(grep -A 1 'baselines:' "${YAML_FILE_PATH}" | grep 'baseline:' | awk '{print $2}')
+          echo "Baseline: ${BASELINE_TAG}"
 
           # Extract the folder name
-          BASELINE_FOLDER_NAME=$(echo "$baseline_full" | cut -d'-' -f1-2)
-          echo "Baseline folder name: $BASELINE_FOLDER_NAME"
+          BASELINE_FOLDER_NAME=$(echo "${BASELINE_TAG}" | cut -d'-' -f1-2)
+          echo "Baseline folder name: ${BASELINE_FOLDER_NAME}"
 
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_FOLDER_NAME}/${BASELINE_TAG}
           

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -213,10 +213,10 @@ jobs:
           # need to extract the name wiht something like: 
           # BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
           ls -l /home/settgast1
-          wget -P /home/settgast1/baselines/baseline_integratedTests-pr3125-5101-7764ffb https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz
+          wget -P ${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr3125-5101-7764ffb https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb.tar.gz
           ls -l /home/settgast1/baselines
 
-          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb
+          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/baseline_integratedTests-pr3125-5101-7764ffb
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
           docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -233,6 +233,8 @@ jobs:
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${PR_BASELINE_FOLDER_NAME}
           echo "Current baseline dir: ${CURRENT_BASELINE_DIR}"
 
+          rm -r /data/GEOS/baselines/NEW_PR_BASELINE_FOLDER_NAME
+
           if [ -d ${CURRENT_BASELINE_DIR} ];then
             echo "Current baseline dir found."
             ls -l ${CURRENT_BASELINE_DIR}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -213,8 +213,8 @@ jobs:
           # need to extract the name wiht something like: 
           # BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
           lsblk
-          df -h /home
-          ls -lR /data 
+          mkdir -p ${{ inputs.LOCAL_BASELINE_DIR }}
+          ls -l /home
 
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -211,8 +211,8 @@ jobs:
         if [[ -n "${{ inputs.LOCAL_BASELINE_DIR }}" ]]; then
           # Extract the 'baseline' value using grep and awk
           ls -la ${GITHUB_WORKSPACE}
-          BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
-          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_TAG}
+          # BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
+          CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines
           docker_args+=(--volume=${CURRENT_BASELINE_DIR}:${CURRENT_BASELINE_DIR_MOUNT}:ro)
         fi

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -209,11 +209,10 @@ jobs:
         fi
 
         if [[ -n "${{ inputs.LOCAL_BASELINE_DIR }}" ]]; then
-          # Extract the 'baseline' value using grep and awk
-          ls -la ${GITHUB_WORKSPACE}
-          
+          # Extract the 'baseline' value 
           # need to extract the name wiht something like: 
           # BASELINE_TAG=$(grep -A 1 'baselines:' "$.${GITHUB_WORKSPACE}/.integrated_test.yaml" | grep 'baseline:' | awk '{print $2}')
+          lsblk
           
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/integratedTests/baseline_integratedTests-pr3125-5101-7764ffb
           CURRENT_BASELINE_DIR_MOUNT=/tmp/geos/baselines

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -232,7 +232,6 @@ jobs:
 
           CURRENT_BASELINE_DIR=${{ inputs.LOCAL_BASELINE_DIR }}/${BASELINE_FOLDER_NAME}
 
-          
           echo "Current baseline path: ${CURRENT_BASELINE_DIR}"
                     
           # We defined a mount point and mount it read-only inside the container.
@@ -276,17 +275,20 @@ jobs:
             fi
 
             if [ -f ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME} ];then
-              # 1. We copy the baselines to a local directory to store them 
+
+              if [[ -n "${{ inputs.LOCAL_BASELINE_DIR }}" ]]; then
+                # 1. We copy the baselines to a local directory to store them 
                 
-              # 1.a Create the new target directory to store the new baselines
-              TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/pr-${{ github.event.number }}"
-              echo "Create folder ${TARGET_DIR}"
-              mkdir -p "${TARGET_DIR}"
+                # 1.a Create the new target directory to store the new baselines
+                TARGET_DIR="${{ inputs.LOCAL_BASELINE_DIR }}/pr-${{ github.event.number }}"
+                echo "Create folder ${TARGET_DIR}"
+                mkdir -p "${TARGET_DIR}"
           
-              # 1.b We copy the new baselines to the new target directory
-              SOURCE_FILE="${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME}"
-              echo "Copy ${SOURCE_FILE} to ${TARGET_DIR}"
-              cp "${SOURCE_FILE}" "${TARGET_DIR}"
+                # 1.b We copy the new baselines to the new target directory
+                SOURCE_FILE="${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME}"
+                echo "Copy ${SOURCE_FILE} to ${TARGET_DIR}"
+                cp "${SOURCE_FILE}" "${TARGET_DIR}"
+              fi
                 
               # 2. We push the baselines to the cloud
               CLOUDSDK_PYTHON=python3 gsutil cp -a public-read ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME} gs://${{ inputs.GCP_BUCKET }}/

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -216,7 +216,6 @@ jobs:
           # Verify the YAML file path
           if [[ ! -f "${YAML_FILE_PATH}" ]]; then
             echo "Error: File $YAML_FILE_PATH does not exist."
-            exit 1
           else
             echo "Found integratedTests file: $YAML_FILE_PATH."
           fi

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -206,7 +206,7 @@ jobs:
       DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
       REQUIRED_LABEL: "ci: run integrated tests"
       UPLOAD_BASELINES: "ci: upload test baselines"
-      LOCAL_BASELINE_DIR: /home/runner/work/GEOS/baselines
+      LOCAL_BASELINE_DIR: /home/baselines
 
   baseline_log:
     needs: [is_not_draft_pull_request]

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -118,17 +118,17 @@ jobs:
       fail-fast : false
       matrix:
         include:
-          - name: Ubuntu (20.04, gcc 9.4.0, open-mpi 4.0.3)
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc9
+          # - name: Ubuntu (20.04, gcc 9.4.0, open-mpi 4.0.3)
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc9
 
-          - name: Ubuntu debug (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
-            CMAKE_BUILD_TYPE: Debug
-            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
+          # - name: Ubuntu debug (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
+          #   CMAKE_BUILD_TYPE: Debug
+          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
 
-          - name: Ubuntu (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
+          # - name: Ubuntu (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
 
           - name: Ubuntu (22.04, gcc 11.4.0, open-mpi 4.1.2)
             CMAKE_BUILD_TYPE: Release
@@ -137,38 +137,38 @@ jobs:
             ENABLE_TRILINOS: OFF
             GCP_BUCKET: geosx/ubuntu22.04-gcc11
 
-          - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2)
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
+          # - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2)
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
+          #   ENABLE_HYPRE: ON
+          #   ENABLE_TRILINOS: OFF
 
-          - name: Ubuntu (22.04, clang 15.0.7, open-mpi 4.1.2)
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/ubuntu22.04-clang15
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
+          # - name: Ubuntu (22.04, clang 15.0.7, open-mpi 4.1.2)
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/ubuntu22.04-clang15
+          #   ENABLE_HYPRE: ON
+          #   ENABLE_TRILINOS: OFF
 
-          - name: Pecan CPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5)
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
-            HOST_CONFIG: host-configs/TOTAL/pecan-CPU.cmake
-            GCP_BUCKET: geosx/Pecan-CPU
+          # - name: Pecan CPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5)
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
+          #   HOST_CONFIG: host-configs/TOTAL/pecan-CPU.cmake
+          #   GCP_BUCKET: geosx/Pecan-CPU
 
-          - name: Pangea 2 (centos 7.6, gcc 8.3.0, open-mpi 2.1.5, mkl 2019.3)
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            GCP_BUCKET: geosx/Pangea2
+          # - name: Pangea 2 (centos 7.6, gcc 8.3.0, open-mpi 2.1.5, mkl 2019.3)
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
+          #   ENABLE_HYPRE: ON
+          #   ENABLE_TRILINOS: OFF
+          #   GCP_BUCKET: geosx/Pangea2
 
-          - name: Sherlock CPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10)
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-openblas0.3.10-zlib1.2.11
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            GCP_BUCKET: geosx/Sherlock-CPU
-            HOST_CONFIG: host-configs/Stanford/sherlock-gcc10-ompi4.1.2-openblas0.3.10.cmake
+          # - name: Sherlock CPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10)
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-openblas0.3.10-zlib1.2.11
+          #   ENABLE_HYPRE: ON
+          #   ENABLE_TRILINOS: OFF
+          #   GCP_BUCKET: geosx/Sherlock-CPU
+          #   HOST_CONFIG: host-configs/Stanford/sherlock-gcc10-ompi4.1.2-openblas0.3.10.cmake
 
     uses: ./.github/workflows/build_and_test.yml
     with:
@@ -263,47 +263,47 @@ jobs:
             DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
             DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
       
-          - name: Ubuntu CUDA (20.04, clang 10.0.0 + gcc 9.4.0, open-mpi 4.0.3, cuda-11.8.89)
-            BUILD_AND_TEST_CLI_ARGS: "--no-install-schema"
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/ubuntu20.04-clang10.0.0-cuda11.8.89
-            ENABLE_HYPRE_DEVICE: CUDA
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            RUNS_ON: streak
-            NPROC: 8
-            DOCKER_RUN_ARGS: "--cpus=8 --memory=256g --runtime=nvidia --gpus all -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
-            DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
-            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
+          # - name: Ubuntu CUDA (20.04, clang 10.0.0 + gcc 9.4.0, open-mpi 4.0.3, cuda-11.8.89)
+          #   BUILD_AND_TEST_CLI_ARGS: "--no-install-schema"
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-clang10.0.0-cuda11.8.89
+          #   ENABLE_HYPRE_DEVICE: CUDA
+          #   ENABLE_HYPRE: ON
+          #   ENABLE_TRILINOS: OFF
+          #   RUNS_ON: streak
+          #   NPROC: 8
+          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=256g --runtime=nvidia --gpus all -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
+          #   DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
+          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
 
-          - name: Centos (7.7, gcc 8.3.1, open-mpi 1.10.7, cuda 11.8.89)
-            BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/centos7.7-gcc8.3.1-cuda11.8.89
-            RUNS_ON: streak2
-            NPROC: 16
-            DOCKER_RUN_ARGS: "--cpus=16 --memory=256g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
-            DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
-            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
+          # - name: Centos (7.7, gcc 8.3.1, open-mpi 1.10.7, cuda 11.8.89)
+          #   BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/centos7.7-gcc8.3.1-cuda11.8.89
+          #   RUNS_ON: streak2
+          #   NPROC: 16
+          #   DOCKER_RUN_ARGS: "--cpus=16 --memory=256g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
+          #   DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
+          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
 
-          # Below this line, jobs that deploy to Google Cloud.
-          - name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 11.5.119)
-            BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda11.5.119
-            HOST_CONFIG: host-configs/TOTAL/pecan-GPU.cmake
-            RUNS_ON: Runner_4core_16GB
+          # # Below this line, jobs that deploy to Google Cloud.
+          # - name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 11.5.119)
+          #   BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda11.5.119
+          #   HOST_CONFIG: host-configs/TOTAL/pecan-GPU.cmake
+          #   RUNS_ON: Runner_4core_16GB
 
-          - name: Sherlock GPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10, cuda 11.7.1,)
-            BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-cuda11.7.1-openblas0.3.10-zlib1.2.11
-            ENABLE_HYPRE_DEVICE: CUDA
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            GCP_BUCKET: geosx/Sherlock-GPU
-            HOST_CONFIG: host-configs/Stanford/sherlock-gcc10-ompi4.1.2-openblas0.3.10-cuda11.7.1-sm70.cmake
-            RUNS_ON: Runner_4core_16GB
+          # - name: Sherlock GPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10, cuda 11.7.1,)
+          #   BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-cuda11.7.1-openblas0.3.10-zlib1.2.11
+          #   ENABLE_HYPRE_DEVICE: CUDA
+          #   ENABLE_HYPRE: ON
+          #   ENABLE_TRILINOS: OFF
+          #   GCP_BUCKET: geosx/Sherlock-GPU
+          #   HOST_CONFIG: host-configs/Stanford/sherlock-gcc10-ompi4.1.2-openblas0.3.10-cuda11.7.1-sm70.cmake
+          #   RUNS_ON: Runner_4core_16GB
 
     uses: ./.github/workflows/build_and_test.yml
     with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -137,38 +137,38 @@ jobs:
             ENABLE_TRILINOS: OFF
             GCP_BUCKET: geosx/ubuntu22.04-gcc11
 
-          # - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2)
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
-          #   ENABLE_HYPRE: ON
-          #   ENABLE_TRILINOS: OFF
+          - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2)
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
 
-          # - name: Ubuntu (22.04, clang 15.0.7, open-mpi 4.1.2)
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/ubuntu22.04-clang15
-          #   ENABLE_HYPRE: ON
-          #   ENABLE_TRILINOS: OFF
+          - name: Ubuntu (22.04, clang 15.0.7, open-mpi 4.1.2)
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/ubuntu22.04-clang15
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
 
-          # - name: Pecan CPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5)
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
-          #   HOST_CONFIG: host-configs/TOTAL/pecan-CPU.cmake
-          #   GCP_BUCKET: geosx/Pecan-CPU
+          - name: Pecan CPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5)
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/pecan-cpu-gcc8.2.0-openmpi4.0.1-mkl2019.5
+            HOST_CONFIG: host-configs/TOTAL/pecan-CPU.cmake
+            GCP_BUCKET: geosx/Pecan-CPU
 
-          # - name: Pangea 2 (centos 7.6, gcc 8.3.0, open-mpi 2.1.5, mkl 2019.3)
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
-          #   ENABLE_HYPRE: ON
-          #   ENABLE_TRILINOS: OFF
-          #   GCP_BUCKET: geosx/Pangea2
+          - name: Pangea 2 (centos 7.6, gcc 8.3.0, open-mpi 2.1.5, mkl 2019.3)
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/pangea2-gcc8.3.0-openmpi2.1.5-mkl2019.3
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            GCP_BUCKET: geosx/Pangea2
 
-          # - name: Sherlock CPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10)
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-openblas0.3.10-zlib1.2.11
-          #   ENABLE_HYPRE: ON
-          #   ENABLE_TRILINOS: OFF
-          #   GCP_BUCKET: geosx/Sherlock-CPU
-          #   HOST_CONFIG: host-configs/Stanford/sherlock-gcc10-ompi4.1.2-openblas0.3.10.cmake
+          - name: Sherlock CPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10)
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-openblas0.3.10-zlib1.2.11
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            GCP_BUCKET: geosx/Sherlock-CPU
+            HOST_CONFIG: host-configs/Stanford/sherlock-gcc10-ompi4.1.2-openblas0.3.10.cmake
 
     uses: ./.github/workflows/build_and_test.yml
     with:
@@ -187,7 +187,7 @@ jobs:
   run_integrated_tests:
     needs:
       - is_not_draft_pull_request
-      # - cpu_builds
+      - cpu_builds
     uses: ./.github/workflows/build_and_test.yml
     secrets: inherit
     with:
@@ -262,47 +262,47 @@ jobs:
             DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
             DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
       
-          # - name: Ubuntu CUDA (20.04, clang 10.0.0 + gcc 9.4.0, open-mpi 4.0.3, cuda-11.8.89)
-          #   BUILD_AND_TEST_CLI_ARGS: "--no-install-schema"
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-clang10.0.0-cuda11.8.89
-          #   ENABLE_HYPRE_DEVICE: CUDA
-          #   ENABLE_HYPRE: ON
-          #   ENABLE_TRILINOS: OFF
-          #   RUNS_ON: streak
-          #   NPROC: 8
-          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=256g --runtime=nvidia --gpus all -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
-          #   DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
-          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
+          - name: Ubuntu CUDA (20.04, clang 10.0.0 + gcc 9.4.0, open-mpi 4.0.3, cuda-11.8.89)
+            BUILD_AND_TEST_CLI_ARGS: "--no-install-schema"
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/ubuntu20.04-clang10.0.0-cuda11.8.89
+            ENABLE_HYPRE_DEVICE: CUDA
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            RUNS_ON: streak
+            NPROC: 8
+            DOCKER_RUN_ARGS: "--cpus=8 --memory=256g --runtime=nvidia --gpus all -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
+            DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
+            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
 
-          # - name: Centos (7.7, gcc 8.3.1, open-mpi 1.10.7, cuda 11.8.89)
-          #   BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/centos7.7-gcc8.3.1-cuda11.8.89
-          #   RUNS_ON: streak2
-          #   NPROC: 16
-          #   DOCKER_RUN_ARGS: "--cpus=16 --memory=256g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
-          #   DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
-          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
+          - name: Centos (7.7, gcc 8.3.1, open-mpi 1.10.7, cuda 11.8.89)
+            BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/centos7.7-gcc8.3.1-cuda11.8.89
+            RUNS_ON: streak2
+            NPROC: 16
+            DOCKER_RUN_ARGS: "--cpus=16 --memory=256g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
+            DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
+            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
 
-          # # Below this line, jobs that deploy to Google Cloud.
-          # - name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 11.5.119)
-          #   BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda11.5.119
-          #   HOST_CONFIG: host-configs/TOTAL/pecan-GPU.cmake
-          #   RUNS_ON: Runner_4core_16GB
+          # Below this line, jobs that deploy to Google Cloud.
+          - name: Pecan GPU (centos 7.7, gcc 8.2.0, open-mpi 4.0.1, mkl 2019.5, cuda 11.5.119)
+            BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/pecan-gpu-gcc8.2.0-openmpi4.0.1-mkl2019.5-cuda11.5.119
+            HOST_CONFIG: host-configs/TOTAL/pecan-GPU.cmake
+            RUNS_ON: Runner_4core_16GB
 
-          # - name: Sherlock GPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10, cuda 11.7.1,)
-          #   BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-cuda11.7.1-openblas0.3.10-zlib1.2.11
-          #   ENABLE_HYPRE_DEVICE: CUDA
-          #   ENABLE_HYPRE: ON
-          #   ENABLE_TRILINOS: OFF
-          #   GCP_BUCKET: geosx/Sherlock-GPU
-          #   HOST_CONFIG: host-configs/Stanford/sherlock-gcc10-ompi4.1.2-openblas0.3.10-cuda11.7.1-sm70.cmake
-          #   RUNS_ON: Runner_4core_16GB
+          - name: Sherlock GPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10, cuda 11.7.1,)
+            BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-cuda11.7.1-openblas0.3.10-zlib1.2.11
+            ENABLE_HYPRE_DEVICE: CUDA
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            GCP_BUCKET: geosx/Sherlock-GPU
+            HOST_CONFIG: host-configs/Stanford/sherlock-gcc10-ompi4.1.2-openblas0.3.10-cuda11.7.1-sm70.cmake
+            RUNS_ON: Runner_4core_16GB
 
     uses: ./.github/workflows/build_and_test.yml
     with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -118,17 +118,17 @@ jobs:
       fail-fast : false
       matrix:
         include:
-          # - name: Ubuntu (20.04, gcc 9.4.0, open-mpi 4.0.3)
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc9
+          - name: Ubuntu (20.04, gcc 9.4.0, open-mpi 4.0.3)
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc9
 
-          # - name: Ubuntu debug (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
-          #   CMAKE_BUILD_TYPE: Debug
-          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
+          - name: Ubuntu debug (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
+            CMAKE_BUILD_TYPE: Debug
+            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
 
-          # - name: Ubuntu (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
+          - name: Ubuntu (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
 
           - name: Ubuntu (22.04, gcc 11.4.0, open-mpi 4.1.2)
             CMAKE_BUILD_TYPE: Release

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -206,7 +206,7 @@ jobs:
       DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
       REQUIRED_LABEL: "ci: run integrated tests"
       UPLOAD_BASELINES: "ci: upload test baselines"
-      LOCAL_BASELINE_DIR: /home/settgast1/baselines
+      LOCAL_BASELINE_DIR: /data/GEOS/baselines
 
   baseline_log:
     needs: [is_not_draft_pull_request]

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -205,7 +205,6 @@ jobs:
       DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
       DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
       REQUIRED_LABEL: "ci: run integrated tests"
-      UPLOAD_BASELINES: "ci: upload test baselines"
       LOCAL_BASELINE_DIR: /data/GEOS/baselines
 
   baseline_log:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -187,7 +187,7 @@ jobs:
   run_integrated_tests:
     needs:
       - is_not_draft_pull_request
-      - cpu_builds
+      # - cpu_builds
     uses: ./.github/workflows/build_and_test.yml
     secrets: inherit
     with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -206,7 +206,7 @@ jobs:
       DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
       REQUIRED_LABEL: "ci: run integrated tests"
       UPLOAD_BASELINES: "ci: upload test baselines"
-      LOCAL_BASELINE_DIR: /home/baselines
+      LOCAL_BASELINE_DIR: /home/settgast1/baselines
 
   baseline_log:
     needs: [is_not_draft_pull_request]

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -206,6 +206,7 @@ jobs:
       DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
       REQUIRED_LABEL: "ci: run integrated tests"
       UPLOAD_BASELINES: "ci: upload test baselines"
+      LOCAL_BASELINE_DIR: /home/runner/work/GEOS/baselines
 
   baseline_log:
     needs: [is_not_draft_pull_request]

--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,7 +1,7 @@
 ---
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3125-5101-7764ffb
+  baseline: integratedTests/baseline_integratedTests-pr3141-5289-995723a
 
 allow_fail:
   all: ''

--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,7 +1,7 @@
 ---
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3141-5279-27c49e6
+  baseline: integratedTests/baseline_integratedTests-pr3125-5101-7764ffb
 
 allow_fail:
   all: ''

--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,7 +1,7 @@
 ---
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3125-5101-7764ffb
+  baseline: integratedTests/baseline_integratedTests-pr3141-5279-27c49e6
 
 allow_fail:
   all: ''

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -6,6 +6,10 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
+PR #3141 (2024-05-28)
+=====================
+Test cashing baselines locally.
+
 PR #3125 (2024-05-16)
 =====================
 Remove field to store pressure gradient cell-wise for solvers that don't need it.

--- a/inputFiles/efemFractureMechanics/Sneddon_embeddedFrac_base.xml
+++ b/inputFiles/efemFractureMechanics/Sneddon_embeddedFrac_base.xml
@@ -105,7 +105,8 @@
     <VTK
       name="vtkOutput"
       plotLevel="2"
-      format="binary"/>
+      format="binary"
+      plotFileRoot="sneddon_embFrac"/>
       
     <TimeHistory
       name="timeHistoryOutput"

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -286,6 +286,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   # ls -lah ${DATA_EXCHANGE_DIR} | grep baseline
 
   echo "Running integrated tests..."
+  ls -l /tmp/geos/baselines
   integratedTests/geos_ats.sh --baselineCacheDirectory /tmp/geos/baselines --baselineDir ${DATA_EXCHANGE_DIR}
   tar -czf ${DATA_EXCHANGE_DIR}/test_logs_${DATA_BASENAME_WE}.tar.gz integratedTests/TestResults
 

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -282,11 +282,10 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   
   # The tests are not run using ninja (`ninja --verbose ats_run`) because it swallows the output while all the simulations are running.
   # We directly use the script instead...
-  # echo "Available baselines:"
-  # ls -lah ${DATA_EXCHANGE_DIR} | grep baseline
+  echo "Available baselines:"
+  ls -l /tmp/geos/baselines
 
   echo "Running integrated tests..."
-  ls -l /tmp/geos/baselines
   integratedTests/geos_ats.sh --baselineCacheDirectory /tmp/geos/baselines --baselineDir ${DATA_EXCHANGE_DIR}
   tar -czf ${DATA_EXCHANGE_DIR}/test_logs_${DATA_BASENAME_WE}.tar.gz integratedTests/TestResults
 

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -283,7 +283,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   # The tests are not run using ninja (`ninja --verbose ats_run`) because it swallows the output while all the simulations are running.
   # We directly use the script instead...
   echo "Available baselines:"
-  ls -l /tmp/geos/baselines
+  ls -lR /tmp/geos/baselines
 
   echo "Running integrated tests..."
   integratedTests/geos_ats.sh --baselineCacheDirectory /tmp/geos/baselines

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -286,7 +286,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   # ls -lah ${DATA_EXCHANGE_DIR} | grep baseline
 
   echo "Running integrated tests..."
-  integratedTests/geos_ats.sh --baselineCacheDirectory /tmp/geos/baselines -b ${DATA_EXCHANGE_DIR}/baselines
+  integratedTests/geos_ats.sh --baselineCacheDirectory /tmp/geos/baselines --baselineDir ${DATA_EXCHANGE_DIR}
   tar -czf ${DATA_EXCHANGE_DIR}/test_logs_${DATA_BASENAME_WE}.tar.gz integratedTests/TestResults
 
   echo "Checking results..."
@@ -304,7 +304,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
     integratedTests/geos_ats.sh -a rebaselinefailed
 
     echo "Packing baselines..."
-    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME_WE}.tar.gz -b ${DATA_EXCHANGE_DIR}/baselines
+    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME_WE}.tar.gz -baselineCacheDir ${DATA_EXCHANGE_DIR}
     INTEGRATED_TEST_EXIT_STATUS=1
   fi
 

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -286,7 +286,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   ls -l /tmp/geos/baselines
 
   echo "Running integrated tests..."
-  integratedTests/geos_ats.sh --baselineCacheDirectory /tmp/geos/baselines --baselineDir ${DATA_EXCHANGE_DIR}
+  integratedTests/geos_ats.sh --baselineCacheDirectory /tmp/geos/baselines
   tar -czf ${DATA_EXCHANGE_DIR}/test_logs_${DATA_BASENAME_WE}.tar.gz integratedTests/TestResults
 
   echo "Checking results..."
@@ -304,7 +304,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
     integratedTests/geos_ats.sh -a rebaselinefailed
 
     echo "Packing baselines..."
-    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME_WE}.tar.gz --baselineDir ${DATA_EXCHANGE_DIR}
+    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME_WE}.tar.gz --baselineCacheDirectory /tmp/geos/baselines
     INTEGRATED_TEST_EXIT_STATUS=1
   fi
 

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -286,7 +286,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   # ls -lah ${DATA_EXCHANGE_DIR} | grep baseline
 
   echo "Running integrated tests..."
-  integratedTests/geos_ats.sh --baselineCacheDirectory ${DATA_EXCHANGE_DIR}/baselines
+  integratedTests/geos_ats.sh --baselineCacheDirectory ${CURRENT_BASELINES_DIR} --baselineDir ${DATA_EXCHANGE_DIR}/baselines
   tar -czf ${DATA_EXCHANGE_DIR}/test_logs_${DATA_BASENAME_WE}.tar.gz integratedTests/TestResults
 
   echo "Checking results..."
@@ -304,7 +304,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
     integratedTests/geos_ats.sh -a rebaselinefailed
 
     echo "Packing baselines..."
-    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME_WE}.tar.gz --baselineCacheDirectory ${DATA_EXCHANGE_DIR}
+    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME_WE}.tar.gz ---baselineDir ${DATA_EXCHANGE_DIR}/baselines
     INTEGRATED_TEST_EXIT_STATUS=1
   fi
 

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -286,7 +286,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   # ls -lah ${DATA_EXCHANGE_DIR} | grep baseline
 
   echo "Running integrated tests..."
-  integratedTests/geos_ats.sh --baselineCacheDirectory ${DATA_EXCHANGE_DIR}
+  integratedTests/geos_ats.sh --baselineCacheDirectory ${DATA_EXCHANGE_DIR}/baselines
   tar -czf ${DATA_EXCHANGE_DIR}/test_logs_${DATA_BASENAME_WE}.tar.gz integratedTests/TestResults
 
   echo "Checking results..."
@@ -304,7 +304,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
     integratedTests/geos_ats.sh -a rebaselinefailed
 
     echo "Packing baselines..."
-    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME_WE}.tar.gz --baselineCacheDirectory ${DATA_EXCHANGE_DIR}
+    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME_WE}.tar.gz --baselineCacheDirectory ${DATA_EXCHANGE_DIR}
     INTEGRATED_TEST_EXIT_STATUS=1
   fi
 

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -286,7 +286,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   # ls -lah ${DATA_EXCHANGE_DIR} | grep baseline
 
   echo "Running integrated tests..."
-  integratedTests/geos_ats.sh --baselineCacheDirectory ${CURRENT_BASELINES_DIR} -b ${DATA_EXCHANGE_DIR}/baselines
+  integratedTests/geos_ats.sh --baselineCacheDirectory /tmp/geos/baselines -b ${DATA_EXCHANGE_DIR}/baselines
   tar -czf ${DATA_EXCHANGE_DIR}/test_logs_${DATA_BASENAME_WE}.tar.gz integratedTests/TestResults
 
   echo "Checking results..."

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -304,7 +304,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
     integratedTests/geos_ats.sh -a rebaselinefailed
 
     echo "Packing baselines..."
-    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME_WE}.tar.gz -baselineCacheDir ${DATA_EXCHANGE_DIR}
+    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baseline_${DATA_BASENAME_WE}.tar.gz --baselineDir ${DATA_EXCHANGE_DIR}
     INTEGRATED_TEST_EXIT_STATUS=1
   fi
 

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -286,7 +286,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   # ls -lah ${DATA_EXCHANGE_DIR} | grep baseline
 
   echo "Running integrated tests..."
-  integratedTests/geos_ats.sh --baselineCacheDirectory ${CURRENT_BASELINES_DIR} --baselineDir ${DATA_EXCHANGE_DIR}/baselines
+  integratedTests/geos_ats.sh --baselineCacheDirectory ${CURRENT_BASELINES_DIR} -b ${DATA_EXCHANGE_DIR}/baselines
   tar -czf ${DATA_EXCHANGE_DIR}/test_logs_${DATA_BASENAME_WE}.tar.gz integratedTests/TestResults
 
   echo "Checking results..."
@@ -304,7 +304,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
     integratedTests/geos_ats.sh -a rebaselinefailed
 
     echo "Packing baselines..."
-    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME_WE}.tar.gz ---baselineDir ${DATA_EXCHANGE_DIR}/baselines
+    integratedTests/geos_ats.sh -a pack_baselines --baselineArchiveName ${DATA_EXCHANGE_DIR}/baselines/baseline_${DATA_BASENAME_WE}.tar.gz -b ${DATA_EXCHANGE_DIR}/baselines
     INTEGRATED_TEST_EXIT_STATUS=1
   fi
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -232,8 +232,8 @@ install( FILES ${CMAKE_BINARY_DIR}/schema.xsd
 ################################
 # Add python environment setup
 ################################
-message(WARNING "Temporarily changing the geosPythonBranch to cusini/fix-streak-cert-fail")
-set(GEOS_PYTHON_PACKAGES_BRANCH "cusini/fix-streak-cert-fail" CACHE STRING "" FORCE)
+# message(WARNING "Temporarily changing the geosPythonBranch to cusini/fix-streak-cert-fail")
+# set(GEOS_PYTHON_PACKAGES_BRANCH "cusini/fix-streak-cert-fail" CACHE STRING "" FORCE)
 
 
 if ( Python3_EXECUTABLE )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -232,8 +232,8 @@ install( FILES ${CMAKE_BINARY_DIR}/schema.xsd
 ################################
 # Add python environment setup
 ################################
-# message(WARNING "Temporarily changing the geosPythonBranch to feature/sherman/baselineStorage")
-# set(GEOS_PYTHON_PACKAGES_BRANCH "branch name" CACHE STRING "" FORCE)
+message(WARNING "Temporarily changing the geosPythonBranch to cusini/fix-streak-cert-fail")
+set(GEOS_PYTHON_PACKAGES_BRANCH "cusini/fix-streak-cert-fail" CACHE STRING "" FORCE)
 
 
 if ( Python3_EXECUTABLE )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -232,8 +232,8 @@ install( FILES ${CMAKE_BINARY_DIR}/schema.xsd
 ################################
 # Add python environment setup
 ################################
-# message(WARNING "Temporarily changing the geosPythonBranch to cusini/fix-streak-cert-fail")
-# set(GEOS_PYTHON_PACKAGES_BRANCH "cusini/fix-streak-cert-fail" CACHE STRING "" FORCE)
+message(WARNING "Temporarily changing the geosPythonBranch to cusini/fix-streak-cert-fail")
+set(GEOS_PYTHON_PACKAGES_BRANCH "cusini/fix-streak-cert-fail" CACHE STRING "" FORCE)
 
 
 if ( Python3_EXECUTABLE )


### PR DESCRIPTION
Introduces the use a persistent folder on streak2 to store baselines locally instead of downloading them.

The folder is:

`/data/GEOS/baselines`

and baselines are stored as:

`/data/GEOS/baselines/baselines_pr#pr/baseline_integratedTests-pr-#pr-${{ github.run_number }}-${SHORT_COMMIT}.tar.gz`