### PR TITLE
 Fix bug when we take minTime < 0 in wave solvers

### DIFF
--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/firstOrderEqn/isotropic/AcousticFirstOrderWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/firstOrderEqn/isotropic/AcousticFirstOrderWaveEquationSEM.cpp
@@ -457,6 +457,10 @@ real64 AcousticFirstOrderWaveEquationSEM::explicitStepInternal( real64 const & t
       {
         using FE_TYPE = TYPEOFREF( finiteElement );
 
+        //Modification of cycleNember useful when minTime < 0
+        EventManager const & event = getGroupByPath< EventManager >( "/Problem/Events" );
+        real64 const & minTime = event.getReference< real64 >( EventManager::viewKeyStruct::minTimeString() );
+        integer const cycleForSource = int(round( -minTime / dt + cycleNumber ));
 
 
         acousticFirstOrderWaveEquationSEMKernels::
@@ -490,7 +494,7 @@ real64 AcousticFirstOrderWaveEquationSEM::explicitStepInternal( real64 const & t
           sourceElem,
           sourceRegion,
           dt,
-          cycleNumber,
+          cycleForSource,
           p_np1 );
       } );
       arrayView2d< real32 > const uxReceivers = m_uxNp1AtReceivers.toView();

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/isotropic/AcousticWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/isotropic/AcousticWaveEquationSEM.cpp
@@ -955,7 +955,7 @@ void AcousticWaveEquationSEM::computeUnknowns( real64 const & time_n,
                                                           getDiscretizationName(),
                                                           "",
                                                           kernelFactory );
-
+  //Modification of cycleNember useful when minTime < 0
   EventManager const & event = getGroupByPath< EventManager >( "/Problem/Events" );
   real64 const & minTime = event.getReference< real64 >( EventManager::viewKeyStruct::minTimeString() );
   integer const cycleForSource = int(round( -minTime / dt + cycleNumber ));

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEM.cpp
@@ -564,7 +564,7 @@ real64 ElasticFirstOrderWaveEquationSEM::explicitStepInternal( real64 const & ti
           sourceRegion,
           sourceValue,
           dt,
-          cycleNumber,
+          cycleForSource,
           stressxx,
           stressyy,
           stresszz,

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEM.cpp
@@ -538,6 +538,11 @@ real64 ElasticFirstOrderWaveEquationSEM::explicitStepInternal( real64 const & ti
       {
         using FE_TYPE = TYPEOFREF( finiteElement );
 
+        //Modification of cycleNember useful when minTime < 0
+        EventManager const & event = getGroupByPath< EventManager >( "/Problem/Events" );
+        real64 const & minTime = event.getReference< real64 >( EventManager::viewKeyStruct::minTimeString() );
+        integer const cycleForSource = int(round( -minTime / dt + cycleNumber ));
+
         elasticFirstOrderWaveEquationSEMKernels::
           StressComputation< FE_TYPE > kernel( finiteElement );
         kernel.template launch< EXEC_POLICY, ATOMIC_POLICY >

--- a/src/coreComponents/physicsSolvers/wavePropagation/shared/WaveSolverUtils.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/shared/WaveSolverUtils.hpp
@@ -46,11 +46,6 @@ struct WaveSolverUtils
   {
     real32 const delay = t0 > 0 ? t0 : 1 / f0;
     real32 pulse = 0.0;
-    if( time_n <= -0.9 * delay || time_n >= 2.9 * delay )
-    {
-      return pulse;
-    }
-
     real32 const alpha = -pow( f0 * M_PI, 2 );
     real32 const time_d = time_n - delay;
     real32 const gaussian = exp( alpha * pow( time_d, 2 ));


### PR DESCRIPTION
This PR fix a bug when we want to start a simulation with a negative minTime.

Such issue have been fixed in the past inside the acoustic solver but not propagate inside the other wave solvers, which is done inside this PR.

The main change is on the value of cycleNumber: 
-If minTime is positive, the value of cycleNumber is taken as it is computed in GEOS
- If not, we shift the value to made it positive using the value of minTime