### PR TITLE
run integrated tests on dedicated runner to avoid overloading of streak2

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -199,7 +199,7 @@ jobs:
       ENABLE_HYPRE: ON
       ENABLE_TRILINOS: OFF
       GCP_BUCKET: geosx/integratedTests
-      RUNS_ON: streak2
+      RUNS_ON: streak2-32core
       NPROC: 32
       DOCKER_RUN_ARGS: "--cpus=32 --memory=384g -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
       DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"


### PR DESCRIPTION
This PR specifies running of integrated tests on dedicated runner to avoid multiple integratedTest jobs overloading streak2.

this should help with stability, but only a single `integratedTests` job runs at a time.