### PR TITLE
docs: Fix wrong variable names in doc after PR #3219 (GEOSX_ -> GEOS_).

### DIFF
--- a/src/docs/sphinx/buildGuide/BuildProcess.rst
+++ b/src/docs/sphinx/buildGuide/BuildProcess.rst
@@ -75,10 +75,10 @@ Option                          Default   Explanation
 ``ENABLE_TOTALVIEW_OUTPUT``     ``OFF``   Enables TotalView debugger custom view of GEOS data structures
 ``ENABLE_COV``                  ``OFF``   Enables code coverage
 ``GEOS_ENABLE_TESTS``           ``ON``    Enables unit testing targets
-``GEOSX_LA_INTERFACE``          ``Hypre`` Choiсe of Linear Algebra backend (Hypre/Petsc/Trilinos)
-``GEOSX_BUILD_OBJ_LIBS``        ``ON``    Use CMake Object Libraries build
-``GEOSX_BUILD_SHARED_LIBS``     ``OFF``   Build ``geosx_core`` as a shared library instead of static
-``GEOSX_PARALLEL_COMPILE_JOBS``           Max. number of compile jobs (when using Ninja), in addition to ``-j`` flag
-``GEOSX_PARALLEL_LINK_JOBS``              Max. number of link jobs (when using Ninja), in addition to ``-j`` flag
-``GEOSX_INSTALL_SCHEMA``        ``ON``    Enables schema generation and installation
+``GEOS_LA_INTERFACE``          ``Hypre`` Choiсe of Linear Algebra backend (Hypre/Petsc/Trilinos)
+``GEOS_BUILD_OBJ_LIBS``        ``ON``    Use CMake Object Libraries build
+``GEOS_BUILD_SHARED_LIBS``     ``OFF``   Build ``geosx_core`` as a shared library instead of static
+``GEOS_PARALLEL_COMPILE_JOBS``           Max. number of compile jobs (when using Ninja), in addition to ``-j`` flag
+``GEOS_PARALLEL_LINK_JOBS``              Max. number of link jobs (when using Ninja), in addition to ``-j`` flag
+``GEOS_INSTALL_SCHEMA``        ``ON``    Enables schema generation and installation
 =============================== ========= ==============================================================================

--- a/src/docs/sphinx/buildGuide/ContinuousIntegration.rst
+++ b/src/docs/sphinx/buildGuide/ContinuousIntegration.rst
@@ -41,7 +41,7 @@ The
 
 .. code-block:: sh
 
-    GEOSX_TPL_DIR
+    GEOS_TPL_DIR
 
 variable contains the absolute path of the installation root directory of the third party libraries.
 GEOS must use it when building.


### PR DESCRIPTION
This PR fixes a few forgotten updates in the documentation after the merge of PR #3219.

