### PR TITLE
fix: Fix segfault in table

### DIFF
--- a/src/coreComponents/fileIO/Table/TableFormatter.cpp
+++ b/src/coreComponents/fileIO/Table/TableFormatter.cpp
@@ -103,7 +103,7 @@ void formatColumnsFromLayout( std::vector< TableLayout::Column > & columns,
                               std::vector< std::vector< string > > & tableDataRows )
 {
   integer idxColumn = 0;
-  for( auto iterColumn = columns.begin(); iterColumn!=columns.end();  )
+  for( auto iterColumn = columns.begin(); iterColumn!=columns.end(); )
   {
     if( !iterColumn->m_parameter.enabled )
     {
@@ -381,7 +381,7 @@ void TableTextFormatter::outputSectionRows( std::vector< TableLayout::Column > c
       auto const & columnContent = section == TableLayout::Section::header ?
                                    columns[idxColumn].m_parameter.splitColumnNameLines :
                                    columns[idxColumn].m_columnValues;
-      string cell = columnContent.at(idxRow);
+      string cell = columnContent.at( idxRow );
       integer const cellSize = currentColumn.m_maxStringSize.length();
 
       tableOutput << buildCell( currentColumn.m_parameter.alignment, cell, cellSize );

--- a/src/coreComponents/fileIO/Table/TableFormatter.cpp
+++ b/src/coreComponents/fileIO/Table/TableFormatter.cpp
@@ -103,18 +103,21 @@ void formatColumnsFromLayout( std::vector< TableLayout::Column > & columns,
                               std::vector< std::vector< string > > & tableDataRows )
 {
   integer idxColumn = 0;
-  for( auto iterColumn = columns.begin(); iterColumn!=columns.end(); ++iterColumn )
+  for( auto iterColumn = columns.begin(); iterColumn!=columns.end();  )
   {
-    TableLayout::Column & column = *iterColumn;
-    if( !column.m_parameter.enabled )
+    if( !iterColumn->m_parameter.enabled )
     {
-      columns.erase( columns.begin() + idxColumn );
+      iterColumn = columns.erase( iterColumn );
       for( auto & row : tableDataRows )
       {
         row.erase( row.begin() + idxColumn );
       }
     }
-    ++idxColumn;
+    else
+    {
+      ++iterColumn;
+      ++idxColumn;
+    }
   }
 }
 
@@ -154,30 +157,19 @@ string TableTextFormatter::layoutToString() const
 
 string TableTextFormatter::toString( TableData const & tableData ) const
 {
-  std::cout<<"breakpoint 3.1"<<std::endl;
   std::ostringstream tableOutput;
   string sectionSeparatingLine;
   std::vector< TableLayout::Column > columns         = m_tableLayout.getColumns();
-  std::cout<<"breakpoint 3.2"<<std::endl;
   std::vector< std::vector< string > > tableDataRows = tableData.getTableDataRows();
-  std::cout<<"breakpoint 3.3"<<std::endl;
   std::vector< string > const & msgTableError        = tableData.getErrorMsgs();
-  std::cout<<"breakpoint 3.4"<<std::endl;
   integer const nbValuesRows                         = tableDataRows.size();
-  std::cout<<"breakpoint 3.5"<<std::endl;
-
 
   formatColumnsFromLayout( columns, tableDataRows );
-  std::cout<<"breakpoint 3.6"<<std::endl;
   fillTableColumnsFromRows( columns, tableDataRows );
-  std::cout<<"breakpoint 3.7"<<std::endl;
 
   outputLayout( tableOutput, columns, msgTableError, sectionSeparatingLine );
-  std::cout<<"breakpoint 3.8"<<std::endl;
-
   outputSectionRows( columns, sectionSeparatingLine, tableOutput, nbValuesRows, TableLayout::Section::values );
   tableOutput << '\n';
-  std::cout<<"breakpoint 3.9"<<std::endl;
 
   return tableOutput.str();
 }
@@ -389,7 +381,6 @@ void TableTextFormatter::outputSectionRows( std::vector< TableLayout::Column > c
       auto const & columnContent = section == TableLayout::Section::header ?
                                    columns[idxColumn].m_parameter.splitColumnNameLines :
                                    columns[idxColumn].m_columnValues;
-      std::cout<<"columnContent.size() = "<<columnContent.size()<<std::endl;
       string cell = columnContent.at(idxRow);
       integer const cellSize = currentColumn.m_maxStringSize.length();
 

--- a/src/coreComponents/fileIO/Table/TableFormatter.cpp
+++ b/src/coreComponents/fileIO/Table/TableFormatter.cpp
@@ -103,8 +103,9 @@ void formatColumnsFromLayout( std::vector< TableLayout::Column > & columns,
                               std::vector< std::vector< string > > & tableDataRows )
 {
   integer idxColumn = 0;
-  for( auto & column : columns )
+  for( auto iterColumn = columns.begin(); iterColumn!=columns.end(); ++iterColumn )
   {
+    TableLayout::Column & column = *iterColumn;
     if( !column.m_parameter.enabled )
     {
       columns.erase( columns.begin() + idxColumn );
@@ -153,19 +154,30 @@ string TableTextFormatter::layoutToString() const
 
 string TableTextFormatter::toString( TableData const & tableData ) const
 {
+  std::cout<<"breakpoint 3.1"<<std::endl;
   std::ostringstream tableOutput;
   string sectionSeparatingLine;
   std::vector< TableLayout::Column > columns         = m_tableLayout.getColumns();
+  std::cout<<"breakpoint 3.2"<<std::endl;
   std::vector< std::vector< string > > tableDataRows = tableData.getTableDataRows();
+  std::cout<<"breakpoint 3.3"<<std::endl;
   std::vector< string > const & msgTableError        = tableData.getErrorMsgs();
+  std::cout<<"breakpoint 3.4"<<std::endl;
   integer const nbValuesRows                         = tableDataRows.size();
+  std::cout<<"breakpoint 3.5"<<std::endl;
+
 
   formatColumnsFromLayout( columns, tableDataRows );
+  std::cout<<"breakpoint 3.6"<<std::endl;
   fillTableColumnsFromRows( columns, tableDataRows );
+  std::cout<<"breakpoint 3.7"<<std::endl;
 
   outputLayout( tableOutput, columns, msgTableError, sectionSeparatingLine );
+  std::cout<<"breakpoint 3.8"<<std::endl;
+
   outputSectionRows( columns, sectionSeparatingLine, tableOutput, nbValuesRows, TableLayout::Section::values );
   tableOutput << '\n';
+  std::cout<<"breakpoint 3.9"<<std::endl;
 
   return tableOutput.str();
 }
@@ -377,7 +389,8 @@ void TableTextFormatter::outputSectionRows( std::vector< TableLayout::Column > c
       auto const & columnContent = section == TableLayout::Section::header ?
                                    columns[idxColumn].m_parameter.splitColumnNameLines :
                                    columns[idxColumn].m_columnValues;
-      string cell = columnContent[idxRow];
+      std::cout<<"columnContent.size() = "<<columnContent.size()<<std::endl;
+      string cell = columnContent.at(idxRow);
       integer const cellSize = currentColumn.m_maxStringSize.length();
 
       tableOutput << buildCell( currentColumn.m_parameter.alignment, cell, cellSize );

--- a/src/coreComponents/fileIO/Table/unitTests/testTable.cpp
+++ b/src/coreComponents/fileIO/Table/unitTests/testTable.cpp
@@ -127,11 +127,19 @@ TEST( testTable, tableHiddenColumn )
     TableLayout::ColumnParam{{"Next\nelement"}, TableLayout::Alignment::center, false},
   }, "Cras egestas ipsum a nisl. Vivamus variu dolor utsisicdis parturient montes, nascetur ridiculus mus. Duis" );
 
+  std::cout<<"breakpoint 1"<<std::endl;
+
   TableData tableData;
   tableData.addRow( "value1", " ", "3.0", 3.0129877, 2.0f, 1 );
   tableData.addRow( "val1", "v", "[3.045,42.02,89.25]", 3.0, 10.0f, 3 );
 
+  std::cout<<"breakpoint 2"<<std::endl;
   TableTextFormatter const tableText( tableLayout );
+  std::cout<<"breakpoint 3"<<std::endl;
+
+  string const tableString = tableText.toString( tableData );
+  std::cout<<"breakpoint 4"<<std::endl;
+
   EXPECT_EQ( tableText.toString( tableData ),
              "\n----------------------------------------------------------------------------------------------------------------\n"
              "|  Cras egestas ipsum a nisl. Vivamus variu dolor utsisicdis parturient montes, nascetur ridiculus mus. Duis   |\n"

--- a/src/coreComponents/fileIO/Table/unitTests/testTable.cpp
+++ b/src/coreComponents/fileIO/Table/unitTests/testTable.cpp
@@ -127,19 +127,11 @@ TEST( testTable, tableHiddenColumn )
     TableLayout::ColumnParam{{"Next\nelement"}, TableLayout::Alignment::center, false},
   }, "Cras egestas ipsum a nisl. Vivamus variu dolor utsisicdis parturient montes, nascetur ridiculus mus. Duis" );
 
-  std::cout<<"breakpoint 1"<<std::endl;
-
   TableData tableData;
   tableData.addRow( "value1", " ", "3.0", 3.0129877, 2.0f, 1 );
   tableData.addRow( "val1", "v", "[3.045,42.02,89.25]", 3.0, 10.0f, 3 );
 
-  std::cout<<"breakpoint 2"<<std::endl;
   TableTextFormatter const tableText( tableLayout );
-  std::cout<<"breakpoint 3"<<std::endl;
-
-  string const tableString = tableText.toString( tableData );
-  std::cout<<"breakpoint 4"<<std::endl;
-
   EXPECT_EQ( tableText.toString( tableData ),
              "\n----------------------------------------------------------------------------------------------------------------\n"
              "|  Cras egestas ipsum a nisl. Vivamus variu dolor utsisicdis parturient montes, nascetur ridiculus mus. Duis   |\n"


### PR DESCRIPTION
This PR fixes a segfault in the table formatter due to erasing part of a container inside a range based for loop on that container.

fixes #3264