### PR TITLE
docs: change GEOSX to GEOS in documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -27,7 +27,7 @@ If applicable, add screenshots to help explain your problem.
 **Platform (please complete the following information):**
 - Machine [e.g. LLNL/Quartz] 
 - Compiler: [e.g. gcc 8.1.0]
-- GEOSX Version [e.g. 0.2]
+- GEOS Version [e.g. 0.2]
 
 **Additional context**
 Add any other context about the problem here.

--- a/src/conf.py
+++ b/src/conf.py
@@ -79,9 +79,9 @@ if read_the_docs_build:
 
 # -- Project information -----------------------------------------------------
 
-project = u'GEOSX'
-copyright = u'2018-2021 Lawrence Livermore National Security, The Board of Trustees of the Leland Stanford Junior University, TotalEnergies, and GEOSX Contributors.'
-author = u'GEOSX Contributors'
+project = u'GEOS'
+copyright = u'2016-2024 Lawrence Livermore National Security LLC, 2018-2024 Total, S.A, The Board of Trustees of the Leland Stanford Junior University, 2023-2024 Chevron, 2019- GEOS/GEOSX Contributors'
+author = u'GEOS/GEOSX Contributors'
 
 # The short X.Y version
 version = u''
@@ -220,8 +220,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'GEOSX.tex', u'GEOSX Documentation',
-     u'Randolph Settgast', 'manual'),
+    (master_doc, 'GEOS.tex', u'GEOS Documentation',
+     u'GEOS/GEOSX Developers', 'manual'),
 ]
 
 
@@ -230,7 +230,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'geosx', u'GEOSX Documentation',
+    (master_doc, 'geos', u'GEOS Documentation',
      [author], 1)
 ]
 
@@ -241,8 +241,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'GEOSX', u'GEOSX Documentation',
-     author, 'GEOSX', 'One line description of project.',
+    (master_doc, 'GEOS', u'GEOS Documentation',
+     author, 'GEOS', 'GEOS simulation framework.',
      'Miscellaneous'),
 ]
 

--- a/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/DruckerPrager/Example.rst
+++ b/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/DruckerPrager/Example.rst
@@ -121,4 +121,4 @@ To go further
 
 **Feedback on this example**
 
-For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOSX/GEOSX/issues>`_.
+For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOS-DEV/GEOS/issues>`_.

--- a/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/ExtendedDruckerPrager/Example.rst
+++ b/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/ExtendedDruckerPrager/Example.rst
@@ -126,4 +126,4 @@ To go further
 
 **Feedback on this example**
 
-For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOSX/GEOSX/issues>`_.
+For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOS-DEV/GEOS/issues>`_.

--- a/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/ModifiedCamClay/Example.rst
+++ b/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/ModifiedCamClay/Example.rst
@@ -97,4 +97,4 @@ To go further
 
 **Feedback on this example**
 
-For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOSX/GEOSX/issues>`_.
+For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOS-DEV/GEOS/issues>`_.

--- a/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/ViscoDruckerPrager/Example.rst
+++ b/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/ViscoDruckerPrager/Example.rst
@@ -112,4 +112,4 @@ To go further
 
 **Feedback on this example**
 
-For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOSX/GEOSX/issues>`_.
+For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOS-DEV/GEOS/issues>`_.

--- a/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/ViscoExtendedDruckerPrager/Example.rst
+++ b/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/ViscoExtendedDruckerPrager/Example.rst
@@ -112,4 +112,4 @@ To go further
 
 **Feedback on this example**
 
-For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOSX/GEOSX/issues>`_.
+For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOS-DEV/GEOS/issues>`_.

--- a/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/ViscoModifiedCamClay/Example.rst
+++ b/src/docs/sphinx/advancedExamples/validationStudies/viscoplasticity/ViscoModifiedCamClay/Example.rst
@@ -103,4 +103,4 @@ To go further
 
 **Feedback on this example**
 
-For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOSX/GEOSX/issues>`_.
+For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOS-DEV/GEOS/issues>`_.

--- a/src/docs/sphinx/advancedExamples/validationStudies/wellboreProblems/casedContactElasticWellbore/Example.rst
+++ b/src/docs/sphinx/advancedExamples/validationStudies/wellboreProblems/casedContactElasticWellbore/Example.rst
@@ -149,4 +149,4 @@ To go further
 **Feedback on this example**
 
 This concludes the cased wellbore example.
-For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOSX/GEOSX/issues>`_.
+For any feedback on this example, please submit a `GitHub issue on the project's GitHub page <https://github.com/GEOS-DEV/GEOS/issues>`_.


### PR DESCRIPTION
This PR changes `GEOSX` to `GEOS` in the documentation.

https://github.com/GEOS-DEV/LvArray/pull/326