### PR TITLE
Debug the restart for Hydrofracture solver 

### DIFF
--- a/inputFiles/hydraulicFracturing/Hydrofracturing.ats
+++ b/inputFiles/hydraulicFracturing/Hydrofracturing.ats
@@ -26,8 +26,8 @@ kgd_toughness_dominated = {
     "name": "kgdToughnessDominated_smoke",
     "description": "KGD fracture in toughness-dominated regime",
     "partitions": ((1, 1, 1), (2, 3, 1)),
-    "restart_step": 0,
-    "check_step": 1,
+    "restart_step": 5,
+    "check_step": 6,
     "tolerance": [1e-5, 21000.0],
     "aperture_curve_method": "kgd_toughness_dominated_aperture_curve",
     "pressure_curve_method": "kgd_toughness_dominated_pressure_curve"

--- a/inputFiles/hydraulicFracturing/kgdToughnessDominated_smoke.xml
+++ b/inputFiles/hydraulicFracturing/kgdToughnessDominated_smoke.xml
@@ -75,8 +75,7 @@
 
     <PeriodicEvent
       name="restarts"
-      timeFrequency="20.0"
-      targetExactTimestep="1"
+      cycleFrequency="5"
       target="/Outputs/restartOutput"/>
   </Events> 
 </Problem>


### PR DESCRIPTION
This PR is to debug the restart issue #3286 when running `Hydrofracture` solver. To help debug the issue, I've turned on the restart check for `kgdToughnessDominated_smoke` in integrated tests. 