### PR TITLE
Example: CO2 injection - Give specific config

### DIFF
--- a/src/docs/sphinx/basicExamples/co2Injection/Example.rst
+++ b/src/docs/sphinx/basicExamples/co2Injection/Example.rst
@@ -264,13 +264,13 @@ The simulation can be launched with 4 cores using MPI-parallelism:
 
 .. code-block:: console
 
-  mpirun -np 4 geosx -i simpleCo2InjTutorial.xml -x 1 -y 1 -z 4
+  mpirun -np 4 geosx -i simpleCo2InjTutorial_smoke.xml -x 1 -y 1 -z 4
 
 A restart from a checkpoint file `simpleCo2InjTutorial_restart_000000024.root` is always available thanks to the following command line :
 
 .. code-block:: console
 
-  mpirun -np 4 geosx -i simpleCo2InjTutorial.xml -r simpleCo2InjTutorial_restart_000000024 -x 1 -y 1 -z 4
+  mpirun -np 4 geosx -i simpleCo2InjTutorial_smoke.xml -r simpleCo2InjTutorial_restart_000000024 -x 1 -y 1 -z 4
 
 The output then shows the loading of HDF5 restart files by each core. 
 


### PR DESCRIPTION
I understand the distinction between base, smoke, and benchmark config files (as described in the [documentation](https://geosx-geosx.readthedocs-hosted.com/en/latest/docs/sphinx/developerGuide/Contributing/InputFiles.html)). However, in this tutorial I don't see any benchmark config file.

For simplicity, I suggest directly referring to the `smoke` config. I have no idea whether there are more similar issues in other tutorials.

If the results shown in the visualization are not with the smoke config, then there should also be a statement for that.