### PR TITLE
chore: update codeowners for integrated_tests.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 /.github/ @rrsettgast
 
 /BASELINE_NOTES.md
-/.integrated_tests.yaml                               @CusiniM @cssherman @rrsettgast @wrtobin @castelletto1
+/.integrated_tests.yaml                               @CusiniM @cssherman @rrsettgast @wrtobin @castelletto1 @jhuang2601
 /inputFiles/                                          @CusiniM @cssherman @jhuang2601 @rrsettgast
 /src/coreComponents/LvArray                           @rrsettgast @wrtobin @corbett5 @CusiniM 
 /src/coreComponents/codingUtilities                   @rrsettgast @untereiner @corbett5 @wrtobin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,7 @@
 /.github/ @rrsettgast
 
 /BASELINE_NOTES.md
+/.integrated_tests.yaml                               @CusiniM @cssherman @rrsettgast @wrtobin @castelletto1
 /inputFiles/                                          @CusiniM @cssherman @jhuang2601 @rrsettgast
 /src/coreComponents/LvArray                           @rrsettgast @wrtobin @corbett5 @CusiniM 
 /src/coreComponents/codingUtilities                   @rrsettgast @untereiner @corbett5 @wrtobin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 /.github/ @rrsettgast
 
 /BASELINE_NOTES.md
-/.integrated_tests.yaml                               @CusiniM @cssherman @rrsettgast @wrtobin @castelletto1 @jhuang2601
+/.integrated_tests.yaml                               @CusiniM @cssherman @rrsettgast @wrtobin @castelletto1 @jhuang2601 @paveltomin
 /inputFiles/                                          @CusiniM @cssherman @jhuang2601 @rrsettgast
 /src/coreComponents/LvArray                           @rrsettgast @wrtobin @corbett5 @CusiniM 
 /src/coreComponents/codingUtilities                   @rrsettgast @untereiner @corbett5 @wrtobin


### PR DESCRIPTION
We have not assigned the `integrated_tests.yaml` file to anybody so @rrsettgast has to approve every PR that needs a rebaseline. We can either add some codeowners or exclude this file. 