### PR TITLE
ci: Disable trigger of ci jobs when description is edited

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -5,7 +5,7 @@ on:
     branches: 
       - develop
   pull_request:
-      types: [opened, synchronize, reopened, edited]
+      types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 # Cancels in-progress workflows for a PR when updated


### PR DESCRIPTION
When this PR message is changed, it triggers a rebuild of the CI. This includes checking a box in a task list. This is unnecessary.