### PR TITLE
ci: add code coverage label requirement

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -250,6 +250,8 @@ jobs:
       ENABLE_TRILINOS: OFF
       GCP_BUCKET: geosx/ubuntu22.04-gcc11
       RUNS_ON: Runner_4core_16GB
+      REQUIRED_LABEL: "ci: run code coverage"
+
 
   # mac_builds:
   #   needs:


### PR DESCRIPTION
We waste a lot of money running code coverage on PRs that are not in the final stages of development. This PR adds a check for the "run code coverage" label in order to run the code coverage tests. 

- [x] Add label check
- [x] verify that code coverage doesn't run without label
- [x] verify that code coverage does run with label