### PR TITLE
fix: Crashes in some wave propagation cases after some varaibles are free'd on device

### DIFF
--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/firstOrderEqn/isotropic/AcousticFirstOrderWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/firstOrderEqn/isotropic/AcousticFirstOrderWaveEquationSEM.cpp
@@ -261,8 +261,6 @@ void AcousticFirstOrderWaveEquationSEM::precomputeSourceAndReceiverTerm( MeshLev
   baseMesh.getNodeManager().elementList().toView().freeOnDevice();
   baseMesh.getFaceManager().nodeList().toView().freeOnDevice();
   baseMesh.getNodeManager().referencePosition().freeOnDevice();
-  m_sourceCoordinates.freeOnDevice();
-  m_receiverCoordinates.freeOnDevice();
   facesToNodes.freeOnDevice();
   nodesToElements.freeOnDevice();
 }

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/anisotropic/AcousticVTIWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/anisotropic/AcousticVTIWaveEquationSEM.cpp
@@ -212,8 +212,6 @@ void AcousticVTIWaveEquationSEM::precomputeSourceAndReceiverTerm( MeshLevel & ba
   baseMesh.getNodeManager().elementList().toView().freeOnDevice();
   baseMesh.getFaceManager().nodeList().toView().freeOnDevice();
   baseMesh.getNodeManager().referencePosition().freeOnDevice();
-  m_sourceCoordinates.freeOnDevice();
-  m_receiverCoordinates.freeOnDevice();
   facesToNodes.freeOnDevice();
   nodesToElements.freeOnDevice();
 }

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/isotropic/AcousticWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/isotropic/AcousticWaveEquationSEM.cpp
@@ -221,8 +221,6 @@ void AcousticWaveEquationSEM::precomputeSourceAndReceiverTerm( MeshLevel & baseM
   baseMesh.getNodeManager().elementList().toView().freeOnDevice();
   baseMesh.getFaceManager().nodeList().toView().freeOnDevice();
   baseMesh.getNodeManager().referencePosition().freeOnDevice();
-  m_sourceCoordinates.freeOnDevice();
-  m_receiverCoordinates.freeOnDevice();
   facesToNodes.freeOnDevice();
   nodesToElements.freeOnDevice();
 }
@@ -1080,6 +1078,7 @@ void AcousticWaveEquationSEM::synchronizeUnknowns( real64 const & time_n,
         acousticfields::AuxiliaryVar1PML::key(),
         acousticfields::AuxiliaryVar4PML::key() } );
   }
+
 
   CommunicationTools & syncFields = CommunicationTools::getInstance();
   syncFields.synchronizeFields( fieldsToBeSync,

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEM.cpp
@@ -313,8 +313,6 @@ void ElasticFirstOrderWaveEquationSEM::precomputeSourceAndReceiverTerm( MeshLeve
   baseMesh.getNodeManager().elementList().toView().freeOnDevice();
   baseMesh.getFaceManager().nodeList().toView().freeOnDevice();
   baseMesh.getNodeManager().referencePosition().freeOnDevice();
-  m_sourceCoordinates.freeOnDevice();
-  m_receiverCoordinates.freeOnDevice();
   facesToNodes.freeOnDevice();
   nodesToElements.freeOnDevice();
 }

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/secondOrderEqn/isotropic/ElasticWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/secondOrderEqn/isotropic/ElasticWaveEquationSEM.cpp
@@ -336,8 +336,6 @@ void ElasticWaveEquationSEM::precomputeSourceAndReceiverTerm( MeshLevel & baseMe
   baseMesh.getNodeManager().elementList().toView().freeOnDevice();
   baseMesh.getFaceManager().nodeList().toView().freeOnDevice();
   baseMesh.getNodeManager().referencePosition().freeOnDevice();
-  m_sourceCoordinates.freeOnDevice();
-  m_receiverCoordinates.freeOnDevice();
   facesToNodes.freeOnDevice();
   nodesToElements.freeOnDevice();
 }


### PR DESCRIPTION
After #2610, a crash is seen in some cases with wave propagators:

```
** StackTrace of XX frames **
[...]
Frame 11: chai::ArrayManager::move(chai::PointerRecord*, chai::ExecutionSpace) 
Frame 12: chai::ArrayManager::move(void*, chai::PointerRecord*, chai::ExecutionSpace) 
Frame 13: PATH/lib/libdataRepository.so 
Frame 14: std::enable_if<can_memcpy<float>, int>::type geos::bufferOps::UnpackDataByIndexDevice<float, 1, 0, LvArray::ArrayView<int const, 1, 0, int, LvArray::ChaiBuffer> >(signed char const*&, LvArray::ArrayView<float, 1, 0, int, LvArray::ChaiBuffer> const&, LvArray::ArrayView<int const, 1, 0, int, LvArray::ChaiBuffer> const&, std::vector<camp::resources::v1::Event, std::allocator<camp::resources::v1::Event> >&, ompi_op_t*) 
Frame 15: std::enable_if<can_memcpy<float>, int>::type geos::bufferOps::UnpackByIndexDevice<float, 1, 0, LvArray::ArrayView<int const, 1, 0, int, LvArray::ChaiBuffer> >(signed char const*&, LvArray::ArrayView<float, 1, 0, int, LvArray::ChaiBuffer> const&, LvArray::ArrayView<int const, 1, 0, int, LvArray::ChaiBuffer> const&, std::vector<camp::resources::v1::Event, std::allocator<camp::resources::v1::Event> >&, ompi_op_t*) 
Frame 16: geos::dataRepository::Wrapper<LvArray::Array<float, 1, camp::int_seq<long, 0l>, int, LvArray::ChaiBuffer> >::unpackByIndex(signed char const*&, LvArray::ArrayView<int const, 1, 0, int, LvArray::ChaiBuffer> const&, bool, bool, std::vector<camp::resources::v1::Event, std::allocator<camp::resources::v1::Event> >&, ompi_op_t*) 
Frame 17: geos::ObjectManagerBase::unpack(signed char const*&, LvArray::ArrayView<int, 1, 0, int, LvArray::ChaiBuffer>&, int, bool, std::vector<camp::resources::v1::Event, std::allocator<camp::resources::v1::Event> >&, ompi_op_t*) 
Frame 18: geos::NeighborCommunicator::unpackBufferForSync(geos::FieldIdentifiers const&, geos::MeshLevel&, int, bool, std::vector<camp::resources::v1::Event, std::allocator<camp::resources::v1::Event> >&, ompi_op_t*) 
Frame 19: geos::CommunicationTools::asyncUnpack(geos::MeshLevel&, std::vector<geos::NeighborCommunicator, std::allocator<geos::NeighborCommunicator> >&, geos::MPI_iCommData&, bool, std::vector<camp::resources::v1::Event, std::allocator<camp::resources::v1::Event> >&, ompi_op_t*) 
Frame 20: geos::CommunicationTools::finalizeUnpack(geos::MeshLevel&, std::vector<geos::NeighborCommunicator, std::allocator<geos::NeighborCommunicator> >&, geos::MPI_iCommData&, bool, std::vector<camp::resources::v1::Event, std::allocator<camp::resources::v1::Event> >&, ompi_op_t*) 
Frame 21: geos::CommunicationTools::synchronizeUnpack(geos::MeshLevel&, std::vector<geos::NeighborCommunicator, std::allocator<geos::NeighborCommunicator> >&, geos::MPI_iCommData&, bool) 
Frame 22: geos::CommunicationTools::synchronizeFields(geos::FieldIdentifiers const&, geos::MeshLevel&, std::vector<geos::NeighborCommunicator, std::allocator<geos::NeighborCommunicator> >&, bool) 
Frame 23: geos::AcousticWaveEquationSEM::synchronizeUnknowns(double const&, double const&, int, geos::DomainPartition&, geos::MeshLevel&, LvArray::ArrayView<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, 1, 0, int, LvArray::ChaiBuffer> const&) 
Frame 24: geos::AcousticWaveEquationSEM::explicitStepInternal(double const&, double const&, int, geos::DomainPartition&) 
=====
```

this is apparently due to an overly zealous `freeOnDevice` usage. In particular, freeing the variables `m_sourceCoordinates` and `m_receiverCoordinates` seems to trigger this problem. This PR should fix the issue. 