### PR TITLE
fix: Investigate potential memory bug in StackArray1d

### DIFF
--- a/src/coreComponents/common/GEOS_RAJA_Interface.hpp
+++ b/src/coreComponents/common/GEOS_RAJA_Interface.hpp
@@ -83,6 +83,8 @@ using parallelDeviceEvent = RAJA::resources::Event;
 using parallelDeviceReduce = RAJA::cuda_reduce;
 using parallelDeviceAtomic = RAJA::cuda_atomic;
 
+using parallelDeviceMultiReduce = RAJA::cuda_multi_reduce_atomic;
+
 void RAJA_INLINE parallelDeviceSync() { RAJA::synchronize< RAJA::cuda_synchronize >(); }
 
 template< typename POLICY, typename RESOURCE, typename LAMBDA >
@@ -106,6 +108,8 @@ using parallelDeviceEvent = RAJA::resources::Event;
 
 using parallelDeviceReduce = RAJA::hip_reduce;
 using parallelDeviceAtomic = RAJA::hip_atomic;
+
+using parallelDeviceMultiReduce = RAJA::hip_multi_reduce_atomic;
 
 void RAJA_INLINE parallelDeviceSync() { RAJA::synchronize< RAJA::hip_synchronize >( ); }
 
@@ -134,6 +138,12 @@ using parallelDeviceEvent = parallelHostEvent;
 
 using parallelDeviceReduce = parallelHostReduce;
 using parallelDeviceAtomic = parallelHostAtomic;
+
+#if defined( GEOS_USE_OPENMP )
+using parallelDeviceMultiReduce = RAJA::omp_multi_reduce;
+#else
+using parallelDeviceMultiReduce = RAJA::seq_multi_reduce;
+#endif
 
 void RAJA_INLINE parallelDeviceSync() { parallelHostSync( ); }
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWellKernels.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWellKernels.cpp
@@ -514,7 +514,7 @@ PresTempCompFracInitializationKernel::
 
   RAJA::ReduceSum< parallelDeviceReduce, real64 > sumTotalMassDens( 0 );
   RAJA::ReduceSum< parallelDeviceReduce, real64 > sumTemp( 0 );
-  RAJA::ReduceSum< parallelDeviceReduce, real64 > sumCompFrac[MAX_NUM_COMP]{};
+  RAJA::MultiReduceSum< parallelDeviceMultiReduce, real64 > sumCompFrac(MAX_NUM_COMP,0.0);
   RAJA::ReduceMin< parallelDeviceReduce, real64 > localMinGravCoefDiff( 1e9 );
 
   forAll< parallelDevicePolicy<> >( perforationSize, [=] GEOS_HOST_DEVICE ( localIndex const iperf )

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWellKernels.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWellKernels.cpp
@@ -557,7 +557,10 @@ PresTempCompFracInitializationKernel::
   // for total mass density, we always use the values of the perforated reservoir elements, even for injectors
   real64 const avgTotalMassDens = MpiWrapper::sum( sumTotalMassDens.get() ) / numPerforations;
 
-  stackArray1d< real64, MAX_NUM_COMP > avgCompFrac( numComps );
+//  stackArray1d< real64, MAX_NUM_COMP > avgCompFrac( numComps );
+  array1d< real64 > aveCompFracArray( numComps );
+  arrayView1d< real64 > const avgCompFrac = aveCompFracArray.toView();
+
   real64 avgTemp = 0;
 
   // for a producer, we use the temperature and component fractions from the reservoir


### PR DESCRIPTION
The following compilation error was reported by Soren...who isn't in the org??
```
[ 52%] Building CXX object coreComponents/physicsSolvers/CMakeFiles/physicsSolvers.dir/inducedSeismicity/SeismicityRate.cpp.o
In file included from /home/GEOS/src/coreComponents/LvArray/src/ArrayView.hpp:21,
                 from /home/GEOS/src/coreComponents/LvArray/src/Array.hpp:17,
                 from /home/GEOS/src/coreComponents/common/DataLayouts.hpp:25,
                 from /home/GEOS/src/coreComponents/common/DataTypes.hpp:30,
                 from /home/GEOS/src/coreComponents/common/format/StringUtilities.hpp:23,
                 from /home/GEOS/src/coreComponents/codingUtilities/Utilities.hpp:23,
                 from /home/GEOS/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWellKernels.hpp:23,
                 from /home/GEOS/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWellKernels.cpp:20:
In function ‘void LvArray::bufferManipulation::copyInto(DST_BUFFER&, std::ptrdiff_t, const SRC_BUFFER&, std::ptrdiff_t) [with DST_BUFFER = LvArray::StackBuffer<double, 9>; SRC_BUFFER = LvArray::StackBuffer<double, 9>]’,
    inlined from ‘LvArray::Array<T, NDIM, PERMUTATION, INDEX_TYPE, BUFFER_TYPE>& LvArray::Array<T, NDIM, PERMUTATION, INDEX_TYPE, BUFFER_TYPE>::operator=(const LvArray::Array<T, NDIM, PERMUTATION, INDEX_TYPE, BUFFER_TYPE>&) [with T = double; int NDIM = 1; PERMUTATION = camp::int_seq<long int, 0>; INDEX_TYPE = int; BUFFER_TYPE = LvArray::internal::StackArrayHelper<double, 1, camp::int_seq<long int, 0>, int, 9>::BufferType]’ at /home/GEOS/src/coreComponents/LvArray/src/Array.hpp:175:33,
    inlined from ‘LvArray::Array<T, NDIM, PERMUTATION, INDEX_TYPE, BUFFER_TYPE>::Array(const LvArray::Array<T, NDIM, PERMUTATION, INDEX_TYPE, BUFFER_TYPE>&) [with T = double; int NDIM = 1; PERMUTATION = camp::int_seq<long int, 0>; INDEX_TYPE = int; BUFFER_TYPE = LvArray::internal::StackArrayHelper<double, 1, camp::int_seq<long int, 0>, int, 9>::BufferType]’ at /home/GEOS/src/coreComponents/LvArray/src/Array.hpp:140:11,
    inlined from ‘static void geos::compositionalMultiphaseWellKernels::PresTempCompFracInitializationKernel::launch(geos::localIndex, geos::localIndex, geos::integer, geos::integer, geos::localIndex, const geos::WellControls&, const geos::real64&, ElementViewConst<LvArray::ArrayView<const double, 1, 0, int, LvArray::ChaiBuffer> >&, ElementViewConst<LvArray::ArrayView<const double, 1, 0, int, LvArray::ChaiBuffer> >&, ElementViewConst<LvArray::ArrayView<const double, 2, 1, int, LvArray::ChaiBuffer> >&, ElementViewConst<LvArray::ArrayView<const double, 2, 1, int, LvArray::ChaiBuffer> >&, ElementViewConst<LvArray::ArrayView<const double, 3, 2, int, LvArray::ChaiBuffer> >&, geos::arrayView1d<const int>&, geos::arrayView1d<const int>&, geos::arrayView1d<const int>&, geos::arrayView1d<const double>&, geos::arrayView1d<const double>&, geos::arrayView1d<double>&, geos::arrayView1d<double>&, geos::arrayView2d<double>&)’ at /home/GEOS/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWellKernels.cpp:635:52:
/home/GEOS/src/coreComponents/LvArray/src/bufferManipulation.hpp:409:18: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ forming offset [80, 87] is out of the bounds [0, 80] of object ‘avgCompFrac’ with type ‘geos::stackArray1d<double, 9>’ {aka ‘LvArray::Array<double, 1, camp::int_seq<long int, 0>, int, LvArray::internal::StackArrayHelper<double, 1, camp::int_seq<long int, 0>, int, 9>::BufferType>’} [-Werror=array-bounds=]
  409 |     dstData[ i ] = srcData[ i ]; (edited) 
```
@paveltomin has also reported some problems with this part of the code. Since we don't have access to a working valgrind build, we are grabbing at straws a bit. This PR serve as a platform for investigating this and determining if this is a bug in GEOS, or a compiler bug.