### PR TITLE
feat: This PR makes the timestep summary information logging introduced in #3303 contingent on the log level of the solver

### DIFF
--- a/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
@@ -350,17 +350,17 @@ void PhysicsSolverBase::logEndOfCycleInformation( integer const cycleNumber,
                                                   std::vector< real64 > const & subStepDt ) const
 {
   // The formating here is a work in progress.
-  GEOS_LOG_RANK_0( "\n------------------------- TIMESTEP END -------------------------" );
-  GEOS_LOG_RANK_0( GEOS_FMT( "    - Cycle:      {}", cycleNumber ) );
-  GEOS_LOG_RANK_0( GEOS_FMT( "    - N substeps: {}", numOfSubSteps ) );
+  GEOS_LOG_LEVEL_INFO_RANK_0( logInfo::TimeStep, "\n------------------------- TIMESTEP END -------------------------" );
+  GEOS_LOG_LEVEL_INFO_RANK_0( logInfo::TimeStep, GEOS_FMT( "    - Cycle:      {}", cycleNumber ) );
+  GEOS_LOG_LEVEL_INFO_RANK_0( logInfo::TimeStep, GEOS_FMT( "    - N substeps: {}", numOfSubSteps ) );
   std::string logMessage = "    - dt:";
   for( integer i = 0; i < numOfSubSteps; ++i )
   {
     logMessage += "  " + units::TimeFormatInfo::fromSeconds( subStepDt[i] ).toString();
   }
   // Log the complete message once
-  GEOS_LOG_RANK_0( logMessage );
-  GEOS_LOG_RANK_0( "------------------------------------------------------------------\n" );
+  GEOS_LOG_LEVEL_INFO_RANK_0( logInfo::TimeStep, logMessage );
+  GEOS_LOG_LEVEL_INFO_RANK_0( logInfo::TimeStep, "------------------------------------------------------------------\n" );
 }
 
 real64 PhysicsSolverBase::setNextDt( real64 const & currentDt,


### PR DESCRIPTION
If the timesteps are very quick and in a large number (for exemple, for many wave proagation problems), the summary timestep information introduced in #3303 produces a lot of logging (tens of thousands of lines), slowing the solver down and producing unreadable log files.
This PR makes the output dependent on the user's choice for the log level. The same log-level-dependent call is used as for all other timestep logging information in the `PhysicsSolverBase` class. 