### PR TITLE
fix: format statement for reporting location of max compdens change

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVM.cpp
@@ -588,11 +588,10 @@ real64 CompositionalMultiphaseFVM::scalingForSystemSolution( DomainPartition & d
                                         globalDeltaPresMax.value,
                                         globalDeltaPresMax.location ) );
   GEOS_LOG_LEVEL_INFO_RANK_0( logInfo::Solution,
-                              GEOS_FMT( "        {}: Max component density change = {:.3f} (before scaling) at cell {}",
+                              GEOS_FMT( "        {}: Max component density change = {} (before scaling) at cell {}",
                                         getName(),
-                                        globalDeltaCompDensMax.value,
-                                        massUnit,
-                                        globalDeltaCompDensMax.location ) );
+                                        GEOS_FMT( "{:.3f}", globalDeltaCompDensMax.value, massUnit ),
+                                        globalDeltaCompDensMax.location ));
 
   if( m_isThermal )
   {

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVM.cpp
@@ -587,11 +587,13 @@ real64 CompositionalMultiphaseFVM::scalingForSystemSolution( DomainPartition & d
                                         getName(),
                                         globalDeltaPresMax.value,
                                         globalDeltaPresMax.location ) );
+
   GEOS_LOG_LEVEL_INFO_RANK_0( logInfo::Solution,
-                              GEOS_FMT( "        {}: Max component density change = {} (before scaling) at cell {}",
+                              GEOS_FMT( "        {}: Max component density change = {:.3f} {} (before scaling) at cell {}",
                                         getName(),
-                                        GEOS_FMT( "{:.3f}", globalDeltaCompDensMax.value, massUnit ),
-                                        globalDeltaCompDensMax.location ));
+                                        globalDeltaCompDensMax.value,
+                                        massUnit,
+                                        globalDeltaCompDensMax.location ) );
 
   if( m_isThermal )
   {


### PR DESCRIPTION
Format statement accepted input (value, conv unit, location) but ignored cell location.  Nested format was needed.