### PR TITLE
fix: Feature/byer3/mass inj constraint fix

### DIFF
--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3384-9542-4e0f693
+  baseline: integratedTests/baseline_integratedTests-pr3495-9552-257c87e
 allow_fail:
   all: ''
   streak: ''

--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3495-9543-7046e61
+  baseline: integratedTests/baseline_integratedTests-pr3495-9547-caaa88a
 allow_fail:
   all: ''
   streak: ''

--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3486-9492-f0c817c
+  baseline: integratedTests/baseline_integratedTests-pr3495-9543-7046e61
 allow_fail:
   all: ''
   streak: ''

--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3495-9547-caaa88a
+  baseline: integratedTests/baseline_integratedTests-pr3495-9548-40ed7e2
 allow_fail:
   all: ''
   streak: ''

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -6,6 +6,10 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
+PR #3495 (2024-01-08)
+=====================
+Add missing logic to support switching from fixed mass rate injection rate constraint to max injection pressure.
+
 PR #3384 (2024-01-07)
 =====================
 Added plastic strain output.

--- a/inputFiles/compositionalMultiphaseWell/compositionalMultiphaseWell.ats
+++ b/inputFiles/compositionalMultiphaseWell/compositionalMultiphaseWell.ats
@@ -81,7 +81,7 @@ decks = [
         name="isothm_mass_inj_table",
         description=
         "Isothermal mass injection constraint testing control switching",
-        partitions=[(1, 1, 1), (2, 1, 1)],
+        partitions=[(1, 1, 1), (1, 2, 1)],
         restart_step=24,
         check_step=28,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
@@ -89,7 +89,7 @@ decks = [
         name="isothm_vol_inj_table",
         description=
         "Isothermal vol injection constraint testing control switching, should have same results as isothm_mass_inj_table.xml",
-        partitions=[(1, 1, 1), (2, 1, 1)],
+        partitions=[(1, 1, 1), (1, 2, 1)],
         restart_step=24,
         check_step=28,
         restartcheck_params=RestartcheckParameters(**restartcheck_params))

--- a/inputFiles/compositionalMultiphaseWell/compositionalMultiphaseWell.ats
+++ b/inputFiles/compositionalMultiphaseWell/compositionalMultiphaseWell.ats
@@ -76,7 +76,7 @@ decks = [
         partitions=[(1, 1, 1), (2, 2, 1)],
         restart_step=12,
         check_step=25,
-        restartcheck_params=RestartcheckParameters(**restartcheck_params))
+        restartcheck_params=RestartcheckParameters(**restartcheck_params)),
     TestDeck(
         name="isothm_mass_inj_table",
         description=
@@ -84,7 +84,7 @@ decks = [
         partitions=[(1, 1, 1), (2, 1, 1)],
         restart_step=24,
         check_step=28,
-        restartcheck_params=RestartcheckParameters(**restartcheck_params))
+        restartcheck_params=RestartcheckParameters(**restartcheck_params)),
     TestDeck(
         name="isothm_vol_inj_table",
         description=

--- a/inputFiles/compositionalMultiphaseWell/compositionalMultiphaseWell.ats
+++ b/inputFiles/compositionalMultiphaseWell/compositionalMultiphaseWell.ats
@@ -77,6 +77,22 @@ decks = [
         restart_step=12,
         check_step=25,
         restartcheck_params=RestartcheckParameters(**restartcheck_params))
+    TestDeck(
+        name="isothm_mass_inj_table",
+        description=
+        "Isothermal mass injection constraint testing control switching",
+        partitions=[(1, 1, 1), (2, 1, 1)],
+        restart_step=24,
+        check_step=28,
+        restartcheck_params=RestartcheckParameters(**restartcheck_params))
+    TestDeck(
+        name="isothm_vol_inj_table",
+        description=
+        "Isothermal vol injection constraint testing control switching, should have same results as isothm_mass_inj_table.xml",
+        partitions=[(1, 1, 1), (2, 1, 1)],
+        restart_step=24,
+        check_step=28,
+        restartcheck_params=RestartcheckParameters(**restartcheck_params))
 ]
 
 generate_geos_tests(decks)

--- a/inputFiles/compositionalMultiphaseWell/isothm_mass_inj_table.xml
+++ b/inputFiles/compositionalMultiphaseWell/isothm_mass_inj_table.xml
@@ -112,7 +112,7 @@
 
     <PeriodicEvent
       name="restarts"
-      timeFrequency="7.5e5"
+      timeFrequency="2.5e4"
       target="/Outputs/sidreRestart"/>
   </Events>
 

--- a/inputFiles/compositionalMultiphaseWell/isothm_mass_inj_table.xml
+++ b/inputFiles/compositionalMultiphaseWell/isothm_mass_inj_table.xml
@@ -1,0 +1,229 @@
+<?xml version="1.0" ?>
+
+<Problem>
+  <Solvers>
+    <CompositionalMultiphaseReservoir
+      name="coupledFlowAndWells"
+      flowSolverName="compflow"
+      wellSolverName="compositionalMultiphaseWell"
+      logLevel="4"
+      initialDt="1e2"
+      targetRegions="{ region, injwell }">
+      <NonlinearSolverParameters
+         logLevel="4"
+        newtonTol="1.0e-3"
+        timeStepDecreaseIterLimit="0.41"
+        newtonMaxIter="40"
+        lineSearchAction="None"/>
+      <LinearSolverParameters
+        logLevel="4"
+        solverType="fgmres"
+        krylovTol="1e-4"/>
+    </CompositionalMultiphaseReservoir>
+
+    <CompositionalMultiphaseFVM
+      name="compflow"
+      logLevel="4"
+      discretization="fluidTPFA"
+      temperature="368.15"
+      useMass="1"
+      initialDt="1e2"
+      maxCompFractionChange="0.5"
+      targetRegions="{ region }">
+    </CompositionalMultiphaseFVM>
+
+    <CompositionalMultiphaseWell
+      name="compositionalMultiphaseWell"
+      targetRegions="{ injwell }"
+      writeCSV="1"
+      logLevel="1"
+      useMass="1">
+      <WellControls
+        name="WC_CO2_INJ"
+        logLevel="2"
+        type="injector"
+        control="massRate"
+        referenceElevation="-0.01"
+        enableCrossflow="0"
+        useSurfaceConditions="1"
+        surfacePressure="1.45e7"
+        surfaceTemperature="300.15"
+        targetTotalRate="15"
+        targetBHPTableName="totalBHPTable"
+        targetMassRateTableName="totalMassRateTable"
+        injectionTemperature="300.15"
+        injectionStream="{ 1.0, 0.000 }"/>
+     </CompositionalMultiphaseWell>
+  </Solvers>
+
+  <Mesh>
+    <InternalMesh
+      name="mesh1"
+      elementTypes="{ C3D8 }"
+      xCoords="{ 0, 2000 }"
+      yCoords="{ 0, 2000 }"
+      zCoords="{ 0, 2000 }"
+      nx="{ 1 }"
+      ny="{ 4 }"
+      nz="{ 1 }"
+      cellBlockNames="{ cb }">
+      <InternalWell
+        name="inj1"
+        wellRegionName="injwell"
+        wellControlsName="WC_CO2_INJ"
+        logLevel="1"
+        polylineNodeCoords="{ { 50.0, 30.0, 51.01 },
+                              { 50.0, 1450.0, 51.00 } }"
+        polylineSegmentConn="{ { 0, 1 } }"
+        radius="0.1"
+        numElementsPerSegment="2">
+        <Perforation
+          name="injector1_perf3"
+          distanceFromHead="171.93"/>
+        <Perforation
+          name="injector1_perf17"
+          distanceFromHead="1334.738"/>
+
+      </InternalWell>
+    </InternalMesh>
+
+  </Mesh>
+
+  <Geometry>
+    <Box
+      name="sink"
+      xMin="{ 89.99, 89.99, -0.01 }"
+      xMax="{ 101.01, 101.01, 1.01 }"/>
+
+    
+  </Geometry>
+
+  <Events
+    maxTime="2.5e5">
+    <PeriodicEvent
+      name="outputs"
+      timeFrequency="2.5e4"
+      target="/Outputs/vtkOutput"/>
+
+    <PeriodicEvent
+      name="solverApplications"
+      maxEventDt="2.5e4"
+      target="/Solvers/coupledFlowAndWells"/>
+
+    <PeriodicEvent
+      name="restarts"
+      timeFrequency="7.5e5"
+      target="/Outputs/sidreRestart"/>
+  </Events>
+
+  <Functions>
+   <TableFunction
+      name="totalBHPTable" 
+      inputVarNames="{time}"
+      coordinates="{  0 , 300, 10000,  50000, 75000, 125000}"
+      values="{       1.45e7,  1.0e7, 1.45e7, 1.45e7,  1.45e7,    1.45e7 }"
+      interpolation="lower"/>
+   <TableFunction
+      name="totalMassRateTable" 
+      inputVarNames="{time}"
+      coordinates="{  0 , 300, 50000, 75000, 100000, 125000}"
+      values="{       0,  900, 940,  980., 800,  1200 }"
+      interpolation="lower"/>
+  </Functions>
+
+  <NumericalMethods>
+    <FiniteVolume>
+      <TwoPointFluxApproximation
+        name="fluidTPFA"/>
+    </FiniteVolume>
+  </NumericalMethods>
+
+  <ElementRegions>
+    <CellElementRegion
+      name="region"
+      cellBlocks="{ cb }"
+      materialList="{ fluid, rock, relperm }"/>
+    <WellElementRegion
+      name="injwell"
+      materialList="{ fluid, relperm }"/>
+  </ElementRegions>
+
+  <Constitutive>
+
+    <CompressibleSolidConstantPermeability
+      name="rock"
+      solidModelName="nullSolid"
+      porosityModelName="rockPorosity"
+      permeabilityModelName="rockPerm"/>
+    <NullModel
+      name="nullSolid"/>
+    <PressurePorosity
+      name="rockPorosity"
+      defaultReferencePorosity="0.2"
+      referencePressure="0.0"
+      compressibility="1.0e-9"/>
+    <ConstantPermeability
+      name="rockPerm"
+      permeabilityComponents="{ 1.0e-13, 1.0e-13, 1.0e-13 }"/>
+
+    <CO2BrinePhillipsFluid
+      name="fluid"
+      logLevel="1"
+      phaseNames="{ gas, water }"
+      componentNames="{ co2, water }"
+      componentMolarWeight="{ 44e-3, 18e-3 }"
+      phasePVTParaFiles="{ pvtgas.txt, pvtliquid.txt }"
+      flashModelParaFile="co2flash.txt"/>
+
+    <BrooksCoreyRelativePermeability
+      name="relperm"
+      phaseNames="{ gas, water }"
+      phaseMinVolumeFraction="{ 0.0, 0.0 }"
+      phaseRelPermExponent="{ 1.5, 1.5 }"
+      phaseRelPermMaxValue="{ 0.9, 0.9 }"/>
+
+  </Constitutive>
+
+  <FieldSpecifications>
+
+    <FieldSpecification
+      name="initialPressure"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="pressure"
+      scale="9e6"/>
+    <FieldSpecification
+      name="initialTemperature"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="temperature"
+      scale="368.15"/>
+    <FieldSpecification
+      name="initialComposition_co2"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="globalCompFraction"
+      component="0"
+      scale="0.005"/>
+    <FieldSpecification
+      name="initialComposition_water"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="globalCompFraction"
+      component="1"
+      scale="0.995"/>
+
+  </FieldSpecifications>
+
+  <Outputs>
+    <VTK
+      name="vtkOutput"/>
+
+    <Restart
+      name="sidreRestart"/>
+  </Outputs>
+</Problem>

--- a/inputFiles/compositionalMultiphaseWell/isothm_vol_inj_table.xml
+++ b/inputFiles/compositionalMultiphaseWell/isothm_vol_inj_table.xml
@@ -111,7 +111,7 @@
 
     <PeriodicEvent
       name="restarts"
-      timeFrequency="7.5e5"
+      timeFrequency="2.5e4"
       target="/Outputs/sidreRestart"/>
   </Events>
 

--- a/inputFiles/compositionalMultiphaseWell/isothm_vol_inj_table.xml
+++ b/inputFiles/compositionalMultiphaseWell/isothm_vol_inj_table.xml
@@ -1,0 +1,234 @@
+<?xml version="1.0" ?>
+
+<Problem>
+  <Solvers>
+    <CompositionalMultiphaseReservoir
+      name="coupledFlowAndWells"
+      flowSolverName="compflow"
+      wellSolverName="compositionalMultiphaseWell"
+      logLevel="4"
+      initialDt="1e2"
+      targetRegions="{ region, injwell }">
+      <NonlinearSolverParameters
+         logLevel="4"
+        newtonTol="1.0e-3"
+        timeStepDecreaseIterLimit="0.41"
+        newtonMaxIter="40"
+        lineSearchAction="None"/>
+      <LinearSolverParameters
+        logLevel="4"
+        solverType="fgmres"
+        krylovTol="1e-4"/>
+    </CompositionalMultiphaseReservoir>
+
+    <CompositionalMultiphaseFVM
+      name="compflow"
+      logLevel="4"
+      discretization="fluidTPFA"
+      temperature="368.15"
+      useMass="1"
+      initialDt="1e2"
+      maxCompFractionChange="0.5"
+      targetRegions="{ region }">
+    </CompositionalMultiphaseFVM>
+
+    <CompositionalMultiphaseWell
+      name="compositionalMultiphaseWell"
+      targetRegions="{ injwell }"
+      writeCSV="1"
+      logLevel="1"
+      useMass="1">
+      <WellControls
+        name="WC_CO2_INJ"
+        logLevel="2"
+        type="injector"
+        control="totalVolRate"
+        referenceElevation="-0.01"
+        enableCrossflow="0"
+        useSurfaceConditions="1"
+        surfacePressure="1.45e7"
+        surfaceTemperature="300.15"
+        targetBHPTableName="totalBHPTable"
+        targetTotalRateTableName="totalRateTable"
+        injectionTemperature="300.15"
+        injectionStream="{ 1.0, 0.000 }"/>
+     </CompositionalMultiphaseWell>
+  </Solvers>
+
+  <Mesh>
+    <InternalMesh
+      name="mesh1"
+      elementTypes="{ C3D8 }"
+      xCoords="{ 0, 2000 }"
+      yCoords="{ 0, 2000 }"
+      zCoords="{ 0, 2000 }"
+      nx="{ 1 }"
+      ny="{ 4 }"
+      nz="{ 1 }"
+      cellBlockNames="{ cb }">
+      <InternalWell
+        name="inj1"
+        wellRegionName="injwell"
+        wellControlsName="WC_CO2_INJ"
+        logLevel="1"
+        polylineNodeCoords="{ { 50.0, 30.0, 51.01 },
+                              { 50.0, 1450.0, 51.00 } }"
+        polylineSegmentConn="{ { 0, 1 } }"
+        radius="0.1"
+        numElementsPerSegment="2">
+        <Perforation
+          name="injector1_perf3"
+          distanceFromHead="171.93"/>
+        <Perforation
+          name="injector1_perf17"
+          distanceFromHead="1334.738"/>
+
+      </InternalWell>
+    </InternalMesh>
+
+  </Mesh>
+
+  <Geometry>
+    <Box
+      name="sink"
+      xMin="{ 89.99, 89.99, -0.01 }"
+      xMax="{ 101.01, 101.01, 1.01 }"/>
+
+    
+  </Geometry>
+
+  <Events
+    maxTime="2.5e5">
+    <PeriodicEvent
+      name="outputs"
+      timeFrequency="2.5e4"
+      target="/Outputs/vtkOutput"/>
+
+    <PeriodicEvent
+      name="solverApplications"
+      maxEventDt="2.5e4"
+      target="/Solvers/coupledFlowAndWells"/>
+
+    <PeriodicEvent
+      name="restarts"
+      timeFrequency="7.5e5"
+      target="/Outputs/sidreRestart"/>
+  </Events>
+
+  <Functions>
+   <TableFunction
+      name="totalBHPTable" 
+      inputVarNames="{time}"
+      coordinates="{  0 , 300, 10000,  50000, 75000, 125000}"
+      values="{       1.45e7,  1.0e7, 1.45e7, 1.45e7,  1.45e7,    1.45e7 }"
+      interpolation="lower"/>
+   <TableFunction
+      name="totalMassRateTable" 
+      inputVarNames="{time}"
+      coordinates="{  0 , 300, 50000, 75000, 100000, 125000}"
+      values="{       0,  900, 940,  980., 800,  1200 }"
+      interpolation="lower"/>
+   <TableFunction
+      name="totalRateTable" 
+      inputVarNames="{time}"
+      coordinates="{  0 , 300, 50000, 75000, 100000, 125000}"
+      values="{       0,  1.04705, 1.09358, 1.14012, 1.14012 , 1.1404 }"
+      interpolation="lower"/>
+  </Functions>
+
+  <NumericalMethods>
+    <FiniteVolume>
+      <TwoPointFluxApproximation
+        name="fluidTPFA"/>
+    </FiniteVolume>
+  </NumericalMethods>
+
+  <ElementRegions>
+    <CellElementRegion
+      name="region"
+      cellBlocks="{ cb }"
+      materialList="{ fluid, rock, relperm }"/>
+    <WellElementRegion
+      name="injwell"
+      materialList="{ fluid, relperm }"/>
+  </ElementRegions>
+
+  <Constitutive>
+
+    <CompressibleSolidConstantPermeability
+      name="rock"
+      solidModelName="nullSolid"
+      porosityModelName="rockPorosity"
+      permeabilityModelName="rockPerm"/>
+    <NullModel
+      name="nullSolid"/>
+    <PressurePorosity
+      name="rockPorosity"
+      defaultReferencePorosity="0.2"
+      referencePressure="0.0"
+      compressibility="1.0e-9"/>
+    <ConstantPermeability
+      name="rockPerm"
+      permeabilityComponents="{ 1.0e-13, 1.0e-13, 1.0e-13 }"/>
+
+    <CO2BrinePhillipsFluid
+      name="fluid"
+      logLevel="1"
+      phaseNames="{ gas, water }"
+      componentNames="{ co2, water }"
+      componentMolarWeight="{ 44e-3, 18e-3 }"
+      phasePVTParaFiles="{ pvtgas.txt, pvtliquid.txt }"
+      flashModelParaFile="co2flash.txt"/>
+
+    <BrooksCoreyRelativePermeability
+      name="relperm"
+      phaseNames="{ gas, water }"
+      phaseMinVolumeFraction="{ 0.0, 0.0 }"
+      phaseRelPermExponent="{ 1.5, 1.5 }"
+      phaseRelPermMaxValue="{ 0.9, 0.9 }"/>
+
+  </Constitutive>
+
+  <FieldSpecifications>
+
+    <FieldSpecification
+      name="initialPressure"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="pressure"
+      scale="9e6"/>
+    <FieldSpecification
+      name="initialTemperature"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="temperature"
+      scale="368.15"/>
+    <FieldSpecification
+      name="initialComposition_co2"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="globalCompFraction"
+      component="0"
+      scale="0.005"/>
+    <FieldSpecification
+      name="initialComposition_water"
+      initialCondition="1"
+      setNames="{ all }"
+      objectPath="ElementRegions/region/cb"
+      fieldName="globalCompFraction"
+      component="1"
+      scale="0.995"/>
+
+  </FieldSpecifications>
+
+  <Outputs>
+    <VTK
+      name="vtkOutput"/>
+
+    <Restart
+      name="sidreRestart"/>
+  </Outputs>
+</Problem>

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -454,6 +454,7 @@ void CompositionalMultiphaseWell::validateWellConstraints( real64 const & time_n
   WellControls::Control const currentControl = wellControls.getControl();
   real64 const & targetTotalRate = wellControls.getTargetTotalRate( time_n + dt );
   real64 const & targetPhaseRate = wellControls.getTargetPhaseRate( time_n + dt );
+  real64 const & targetMassRate = wellControls.getTargetMassRate( time_n + dt );
 
   GEOS_THROW_IF( wellControls.isInjector() && currentControl == WellControls::Control::PHASEVOLRATE,
                  "WellControls " << wellControls.getDataContext() <<
@@ -471,6 +472,18 @@ void CompositionalMultiphaseWell::validateWellConstraints( real64 const & time_n
   GEOS_THROW_IF( wellControls.isInjector() && !isZero( targetPhaseRate ),
                  "WellControls " << wellControls.getDataContext() <<
                  ": Target phase rate cannot be used for injectors",
+                 InputError );
+  GEOS_THROW_IF( wellControls.isProducer() && !isZero( targetTotalRate ),
+                 "WellControls " << wellControls.getDataContext() <<
+                 ": Target total rate cannot be used for producers",
+                 InputError );
+  GEOS_THROW_IF( wellControls.isProducer() && !isZero( targetMassRate ),
+                 "WellControls " << wellControls.getDataContext() <<
+                 ": Target mass rate cannot be used for producers",
+                 InputError );
+  GEOS_THROW_IF( !m_useMass && !isZero( targetMassRate ),
+                 "WellControls " << wellControls.getDataContext() <<
+                 ": Target mass rate cannot with m_useMass=0",
                  InputError );
 
   // The user always provides positive rates, but these rates are later multiplied by -1 internally for producers

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -260,6 +260,8 @@ void CompositionalMultiphaseWell::registerDataOnMesh( Group & meshBodies )
 
       wellControls.registerWrapper< real64 >( viewKeyStruct::massDensityString() );
 
+      wellControls.registerWrapper< real64 >( viewKeyStruct::currentMassRateString() );
+
       // write rates output header
       // the rank that owns the reference well element is responsible
       if( m_writeCSV > 0 && subRegion.isLocallyOwned() )
@@ -686,6 +688,10 @@ void CompositionalMultiphaseWell::updateVolRatesForConstraint( WellElementSubReg
 
   real64 & currentTotalVolRate =
     wellControls.getReference< real64 >( CompositionalMultiphaseWell::viewKeyStruct::currentTotalVolRateString() );
+
+  real64 & currentMassRate =
+    wellControls.getReference< real64 >( CompositionalMultiphaseWell::viewKeyStruct::currentMassRateString() );
+
   arrayView1d< real64 > const & dCurrentTotalVolRate =
     wellControls.getReference< array1d< real64 > >( CompositionalMultiphaseWell::viewKeyStruct::dCurrentTotalVolRateString() );
 
@@ -721,6 +727,7 @@ void CompositionalMultiphaseWell::updateVolRatesForConstraint( WellElementSubReg
                                   dCurrentTotalVolRate,
                                   currentPhaseVolRate,
                                   dCurrentPhaseVolRate,
+                                  &currentMassRate,
                                   &iwelemRef,
                                   &logLevel,
                                   &wellControlsName,
@@ -757,7 +764,8 @@ void CompositionalMultiphaseWell::updateVolRatesForConstraint( WellElementSubReg
         // Step 2: update the total volume rate
 
         real64 const currentTotalRate = connRate[iwelemRef];
-
+        // Assumes useMass is true
+        currentMassRate = currentTotalRate;
         // Step 2.1: compute the inverse of the total density and derivatives
         massDensity = totalDens[iwelemRef][0];
         real64 const totalDensInv = 1.0 / totalDens[iwelemRef][0];
@@ -1950,6 +1958,12 @@ void CompositionalMultiphaseWell::assemblePressureRelations( real64 const & time
               wellControls.switchToPhaseRateControl( wellControls.getTargetPhaseRate( timeAtEndOfStep ) );
               GEOS_LOG_LEVEL_INFO_RANK_0( logInfo::WellControl,
                                           GEOS_FMT( "Control switch for well {} from BHP constraint to phase volumetric rate constraint", subRegion.getName() ) );
+            }
+            else if( wellControls.getInputControl() == WellControls::Control::MASSRATE )
+            {
+              wellControls.switchToMassRateControl( wellControls.getTargetMassRate( timeAtEndOfStep ) );
+              GEOS_LOG_LEVEL_INFO_RANK_0( logInfo::WellControl,
+                                          GEOS_FMT( "Control switch for well {} from BHP constraint to mass rate constraint", subRegion.getName()) );
             }
             else
             {

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -483,7 +483,7 @@ void CompositionalMultiphaseWell::validateWellConstraints( real64 const & time_n
                  InputError );
   GEOS_THROW_IF( !m_useMass && !isZero( targetMassRate ),
                  "WellControls " << wellControls.getDataContext() <<
-                 ": Target mass rate cannot with m_useMass=0",
+                 ": Target mass rate cannot with useMass=0",
                  InputError );
 
   // The user always provides positive rates, but these rates are later multiplied by -1 internally for producers

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.hpp
@@ -296,6 +296,8 @@ public:
     static constexpr char const * currentTotalVolRateString() { return "currentTotalVolumetricRate"; }
     static constexpr char const * dCurrentTotalVolRateString() { return "dCurrentTotalVolumetricRate"; }
 
+    static constexpr char const * currentMassRateString() { return "currentMassRate"; }
+
     static constexpr char const * dCurrentTotalVolRate_dPresString() { return "dCurrentTotalVolumetricRate_dPres"; }
 
     static constexpr char const * dCurrentTotalVolRate_dCompDensString() { return "dCurrentTotalVolumetricRate_dCompDens"; }

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/WellControls.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/WellControls.cpp
@@ -71,27 +71,32 @@ WellControls::WellControls( string const & name, Group * const parent )
   registerWrapper( viewKeyStruct::targetBHPString(), &m_targetBHP ).
     setDefaultValue( 0.0 ).
     setInputFlag( InputFlags::OPTIONAL ).
+    setRestartFlags( RestartFlags::WRITE_AND_READ ).
     setDescription( "Target bottom-hole pressure [Pa]" );
 
   registerWrapper( viewKeyStruct::targetTotalRateString(), &m_targetTotalRate ).
     setDefaultValue( 0.0 ).
     setInputFlag( InputFlags::OPTIONAL ).
+    setRestartFlags( RestartFlags::WRITE_AND_READ ).
     setDescription( "Target total volumetric rate (if useSurfaceConditions: [surface m^3/s]; else [reservoir m^3/s])" );
 
   registerWrapper( viewKeyStruct::targetPhaseRateString(), &m_targetPhaseRate ).
     setDefaultValue( 0.0 ).
     setInputFlag( InputFlags::OPTIONAL ).
+    setRestartFlags( RestartFlags::WRITE_AND_READ ).
     setDescription( "Target phase volumetric rate (if useSurfaceConditions: [surface m^3/s]; else [reservoir m^3/s])" );
 
   registerWrapper( viewKeyStruct::targetMassRateString(), &m_targetMassRate ).
     setDefaultValue( 0.0 ).
     setInputFlag( InputFlags::OPTIONAL ).
+    setRestartFlags( RestartFlags::WRITE_AND_READ ).
     setDescription( "Target Mass Rate rate ( [kg^3/s])" );
 
   registerWrapper( viewKeyStruct::targetPhaseNameString(), &m_targetPhaseName ).
     setRTTypeName( rtTypes::CustomTypes::groupNameRef ).
     setDefaultValue( "" ).
     setInputFlag( InputFlags::OPTIONAL ).
+    setRestartFlags( RestartFlags::WRITE_AND_READ ).
     setDescription( "Name of the target phase" );
 
   registerWrapper( viewKeyStruct::refElevString(), &m_refElevation ).

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/WellControls.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/WellControls.hpp
@@ -150,6 +150,12 @@ public:
   Control getControl() const { return m_currentControl; }
 
   /**
+   * @brief Get the input control type for the well.
+   * @return the Control enum enforced at the well
+   */
+  Control getInputControl() const { return m_inputControl; }
+
+  /**
    * @brief Getter for the reference elevation where the BHP control is enforced
    * @return the reference elevation
    */

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/kernels/CompositionalMultiphaseWellKernels.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/kernels/CompositionalMultiphaseWellKernels.cpp
@@ -37,6 +37,7 @@ inline
 void
 ControlEquationHelper::
   switchControl( bool const isProducer,
+                 WellControls::Control const & inputControl,
                  WellControls::Control const & currentControl,
                  integer const phasePhaseIndex,
                  real64 const & targetBHP,
@@ -46,6 +47,7 @@ ControlEquationHelper::
                  real64 const & currentBHP,
                  arrayView1d< real64 const > const & currentPhaseVolRate,
                  real64 const & currentTotalVolRate,
+                 real64 const & currentMassRate,
                  WellControls::Control & newControl )
 {
   // if isViable is true at the end of the following checks, no need to switch
@@ -58,7 +60,7 @@ ControlEquationHelper::
 
   // Currently, the available constraints are:
   //   - Producer: BHP, PHASEVOLRATE
-  //   - Injector: BHP, TOTALVOLRATE
+  //   - Injector: BHP, TOTALVOLRATE, MASSRATE
 
   // TODO: support GRAT, WRAT, LIQUID for producers and check if any of the active constraint is violated
 
@@ -71,6 +73,10 @@ ControlEquationHelper::
       controlIsViable = ( LvArray::math::abs( currentPhaseVolRate[phasePhaseIndex] ) <= LvArray::math::abs( targetPhaseRate ) );
     }
     // the control is viable if the reference total rate is below the max rate for injectors
+    else if( inputControl == WellControls::Control::MASSRATE )
+    {
+      controlIsViable = ( LvArray::math::abs( currentMassRate ) <= LvArray::math::abs( targetMassRate ) );
+    }
     else
     {
       controlIsViable = ( LvArray::math::abs( currentTotalVolRate ) <= LvArray::math::abs( targetTotalRate ) );
@@ -219,17 +225,6 @@ ControlEquationHelper::
     if constexpr ( IS_THERMAL )
       dControlEqn[COFFSET_WJ::dT] = massDensity*dCurrentTotalVolRate[COFFSET_WJ::dT];
   }
-  // Total mass rate control
-  else if( currentControl == WellControls::Control::MASSRATE )
-  {
-    controlEqn = massDensity*currentTotalVolRate - targetMassRate;
-    dControlEqn[COFFSET_WJ::dP] = massDensity*dCurrentTotalVolRate[COFFSET_WJ::dP];
-    dControlEqn[COFFSET_WJ::dQ] = massDensity*dCurrentTotalVolRate[COFFSET_WJ::dQ];
-    for( integer ic = 0; ic < NC; ++ic )
-    {
-      dControlEqn[COFFSET_WJ::dC+ic] = massDensity*dCurrentTotalVolRate[COFFSET_WJ::dC+ic];
-    }
-  }
   else
   {
     GEOS_ERROR( "This constraint is not supported in CompositionalMultiphaseWell" );
@@ -323,6 +318,7 @@ PressureRelationKernel::
   // static well control data
   bool const isProducer = wellControls.isProducer();
   WellControls::Control const currentControl = wellControls.getControl();
+  WellControls::Control const inputControl = wellControls.getInputControl();
   real64 const targetBHP = wellControls.getTargetBHP( timeAtEndOfStep );
   real64 const targetTotalRate = wellControls.getTargetTotalRate( timeAtEndOfStep );
   real64 const targetPhaseRate = wellControls.getTargetPhaseRate( timeAtEndOfStep );
@@ -344,6 +340,9 @@ PressureRelationKernel::
   arrayView1d< real64 const > const & dCurrentTotalVolRate =
     wellControls.getReference< array1d< real64 > >( CompositionalMultiphaseWell::viewKeyStruct::dCurrentTotalVolRateString() );
 
+  real64 const & currentMassRate =
+    wellControls.getReference< real64 >( CompositionalMultiphaseWell::viewKeyStruct::currentMassRateString() );
+
   real64 const & massDensity  =
     wellControls.getReference< real64 >( CompositionalMultiphaseWell::viewKeyStruct::massDensityString() );
 
@@ -358,6 +357,7 @@ PressureRelationKernel::
     {
       WellControls::Control newControl = currentControl;
       ControlEquationHelper::switchControl( isProducer,
+                                            inputControl,
                                             currentControl,
                                             targetPhaseIndex,
                                             targetBHP,
@@ -367,6 +367,7 @@ PressureRelationKernel::
                                             currentBHP,
                                             currentPhaseVolRate,
                                             currentTotalVolRate,
+                                            currentMassRate,
                                             newControl );
       if( currentControl != newControl )
       {
@@ -737,7 +738,6 @@ RateInitializationKernel::
     else if( control == WellControls::Control::MASSRATE )
     {
       connRate[iwelem] = targetMassRate;
-      connRate[iwelem] = targetMassRate* totalDens[iwelem][0];
     }
     else
     {

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/kernels/CompositionalMultiphaseWellKernels.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/kernels/CompositionalMultiphaseWellKernels.hpp
@@ -134,6 +134,7 @@ struct ControlEquationHelper
   static
   void
   switchControl( bool const isProducer,
+                 WellControls::Control const & inputControl,
                  WellControls::Control const & currentControl,
                  integer const phasePhaseIndex,
                  real64 const & targetBHP,
@@ -143,6 +144,7 @@ struct ControlEquationHelper
                  real64 const & currentBHP,
                  arrayView1d< real64 const > const & currentPhaseVolRate,
                  real64 const & currentTotalVolRate,
+                 real64 const & currentMassRate,
                  WellControls::Control & newControl );
 
   template< integer NC, integer IS_THERMAL >


### PR DESCRIPTION
Add missing logic to support switching from fixed mass rate injection rate constraint to max injection pressure.  The code will crash if running a model where this condition is encountered.   No issues with mass injection constraint in scenarios where pressure associated with injection rate is less than maximum injection pressure.   2 test cases added to demonstrate constraint switching using mass injection rate constraint and total injection rate tables.  The cases should produce nearly identical results.   