### PR TITLE
ci: add pangea-4 build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "GEOS_TPL_TAG": "293-608"
+            "GEOS_TPL_TAG": "296-613"
         }
     },
     "runArgs": [

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -205,6 +205,14 @@ jobs:
 #            HOST_CONFIG: host-configs/Stanford/sherlock-gcc10.cmake
             BUILD_SHARED_LIBS: ON
 
+          - name: Pangea4 (centos 8, gcc 12.1.0, hpcx 2.20.0, mkl 2023.2.0)
+            BUILD_AND_TEST_CLI_ARGS: "--build-exe-only"
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/pangea4-gcc12.1-hpcxompi2.20.0-onemkl2023.2.0
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            HOST_CONFIG: /spack-generated.cmake
+
     uses: ./.github/workflows/build_and_test.yml
     with:
       BUILD_SHARED_LIBS: ${{ matrix.BUILD_SHARED_LIBS }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -215,6 +215,7 @@ jobs:
 
     uses: ./.github/workflows/build_and_test.yml
     with:
+      BUILD_AND_TEST_CLI_ARGS: ${{ matrix.BUILD_AND_TEST_CLI_ARGS }}
       BUILD_SHARED_LIBS: ${{ matrix.BUILD_SHARED_LIBS }}
       CMAKE_BUILD_TYPE: ${{ matrix.CMAKE_BUILD_TYPE }}
       DOCKER_IMAGE_TAG: ${{ needs.is_not_draft_pull_request.outputs.DOCKER_IMAGE_TAG }}


### PR DESCRIPTION
Add build based on pangea-4 config :

- gcc@12.2.1
- hpcx@2.20.0
- intel-oneapi-mkl@2023.2.0

Linked to [TPL-296](https://github.com/GEOS-DEV/thirdPartyLibs/pull/296)