### PR TITLE
fix: mesh partioning table duplication

### DIFF
--- a/src/coreComponents/mesh/DomainPartition.cpp
+++ b/src/coreComponents/mesh/DomainPartition.cpp
@@ -384,7 +384,7 @@ void DomainPartition::outputPartitionInformation() const
   {
     meshBody.getMeshLevels().forSubGroupsIndex< MeshLevel >( [&]( int const level, MeshLevel const & meshLevel )
     {
-      if( level!=0 )
+      if( level ==0  )
       {
         // formatting is done on rank 0
         std::vector< RankMeshStats > allRankStats;

--- a/src/coreComponents/mesh/DomainPartition.cpp
+++ b/src/coreComponents/mesh/DomainPartition.cpp
@@ -384,7 +384,7 @@ void DomainPartition::outputPartitionInformation() const
   {
     meshBody.getMeshLevels().forSubGroupsIndex< MeshLevel >( [&]( int const level, MeshLevel const & meshLevel )
     {
-      if( level ==0  )
+      if( level == 0 )
       {
         // formatting is done on rank 0
         std::vector< RankMeshStats > allRankStats;


### PR DESCRIPTION
The `mesh partioning over ranks` table is duplicated with the same values when he have more than one discretization in `NumericalMethods` .
For example :
```
<NumericalMethods>
    <FiniteElements>
      <FiniteElementSpace
        name="FE1"
        order="1"/>
    </FiniteElements>
    <FiniteVolume>
      <TwoPointFluxApproximation
        name="fluidTPFA"/>
    </FiniteVolume>
  </NumericalMethods>
  ```