### PR TITLE
fix: Add mathpresso to spack

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
     "build": {
         "dockerfile": "Dockerfile",
         "args": {
-            "GEOS_TPL_TAG": "293-608"
+            "GEOS_TPL_TAG": "298-621"
         }
     },
     "runArgs": [

--- a/host-configs/LLNL/dane-toss_4_x86_64_ib-gcc@12.1.1.cmake
+++ b/host-configs/LLNL/dane-toss_4_x86_64_ib-gcc@12.1.1.cmake
@@ -58,15 +58,15 @@ set(ENABLE_CUDA OFF CACHE BOOL "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-iev43uxnll3jsod7jloak5iwmox6owlv" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-iev43uxnll3jsod7jloak5iwmox6owlv" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-ikig7gipi7bsuxopxfac7uvrup3kd4rx" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-ikig7gipi7bsuxopxfac7uvrup3kd4rx" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-4t7pxjbfakzclltrwpajtryfkntshmwu" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-4t7pxjbfakzclltrwpajtryfkntshmwu" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-fv2sc4dnl7tma5k3wpu5r2tgcinfpz7u" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-fv2sc4dnl7tma5k3wpu5r2tgcinfpz7u" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -74,21 +74,21 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-bno6d6qyyvivznkozzdh27ljrj3yqbv2" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-bno6d6qyyvivznkozzdh27ljrj3yqbv2" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/adiak-0.4.0-dimwte7ij4naho6hhcqowidlxnespn7e/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/adiak-0.4.0-dimwte7ij4naho6hhcqowidlxnespn7e/lib/cmake/adiak" CACHE PATH "")
 
-set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/hdf5-1.12.1-ijx73yvfrhxnjls4acfy2sdqtiekvyec" CACHE PATH "")
+set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/hdf5-1.12.1-ijx73yvfrhxnjls4acfy2sdqtiekvyec" CACHE PATH "")
 
-set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-jwijeuulb6xfflmsmh4snh6qvmmvenve" CACHE PATH "")
+set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-jwijeuulb6xfflmsmh4snh6qvmmvenve" CACHE PATH "")
 
-set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/silo-4.11.1-bsd-nrzzqos7534qy74dk5anmp3pvsgdovrq" CACHE PATH "")
+set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/silo-4.11.1-bsd-nrzzqos7534qy74dk5anmp3pvsgdovrq" CACHE PATH "")
 
-set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/pugixml-1.13-7v6zhre6pi7ibnief5tqhmqxowllqo2w" CACHE PATH "")
+set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/pugixml-1.13-7v6zhre6pi7ibnief5tqhmqxowllqo2w" CACHE PATH "")
 
-set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/vtk-9.3.1-6rs7wpfvmzw7pdsdl6mifdrg7nhuidqd" CACHE PATH "")
+set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/vtk-9.3.1-6rs7wpfvmzw7pdsdl6mifdrg7nhuidqd" CACHE PATH "")
 
-set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/fmt-10.0.0-4wcnmovbi74zd66vdk6xhjo6hefdbxbp" CACHE PATH "")
+set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/fmt-10.0.0-4wcnmovbi74zd66vdk6xhjo6hefdbxbp" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # System Math Libraries
@@ -110,19 +110,19 @@ set(MKL_LIBRARIES /usr/tce/packages/mkl/mkl-2022.1.0/mkl/2022.1.0/lib/intel64/li
 # Math TPLs
 #--------------------------------------------------------------------------------
 
-set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/metis-5.1.0-jrpyyvbvi5zzxt3mraydgurmfk7pjj77" CACHE PATH "")
+set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/metis-5.1.0-jrpyyvbvi5zzxt3mraydgurmfk7pjj77" CACHE PATH "")
 
-set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/parmetis-4.0.3-i2lkaqn2onxsvx3rcssafh7zkgv4xgcb" CACHE PATH "")
+set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/parmetis-4.0.3-i2lkaqn2onxsvx3rcssafh7zkgv4xgcb" CACHE PATH "")
 
-set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/scotch-7.0.3-fl625kpmhevzvzmuotssykvvhaqovqk3" CACHE PATH "")
+set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/scotch-7.0.3-ts6ppq45qy3me5wdlnb4dzhtnnyleop5" CACHE PATH "")
 
-set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-kul235x6jkdwxbdntczlhho7h6x65pwh" CACHE PATH "")
+set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-kul235x6jkdwxbdntczlhho7h6x65pwh" CACHE PATH "")
 
-set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/suite-sparse-5.10.1-fbm7gbwba72t4ggduvynvnbcr43uxxs4" CACHE PATH "")
+set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/suite-sparse-5.10.1-fbm7gbwba72t4ggduvynvnbcr43uxxs4" CACHE PATH "")
 
-set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/trilinos-16.0.0-tlpnzz4auhkqtnirn3sduww6xpxgbtyn" CACHE PATH "")
+set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/trilinos-16.0.0-pouamvqn7cggh62ew6ahy5qfomipu6g3" CACHE PATH "")
 
-set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-n2ggx632hcpy4nznfy5lehdnb4azkrft" CACHE PATH "")
+set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-n2ggx632hcpy4nznfy5lehdnb4azkrft" CACHE PATH "")
 
 set(ENABLE_PETSC OFF CACHE BOOL "")
 
@@ -146,7 +146,7 @@ set(ENABLE_PYGEOSX ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/python/quartz-gcc-python/python/bin/sphinx-build" CACHE PATH "")
 
-set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/doxygen-1.8.20-hbxmvlkrwmpt5mvibhths6cdo5rlor3s/bin/doxygen" CACHE PATH "")
+set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/doxygen-1.8.20-hbxmvlkrwmpt5mvibhths6cdo5rlor3s/bin/doxygen" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Development tools
@@ -154,7 +154,7 @@ set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_t
 
 set(ENABLE_UNCRUSTIFY ON CACHE BOOL "")
 
-set(UNCRUSTIFY_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/dane-gcc-12_tpls/gcc-12.1.1/uncrustify-git.401a4098bce9dcc47e024987403f2d59d9ba7bd2_0.70.1-git.319-bsad7cne3ccgu3munuxms52yxxhxeob5/bin/uncrustify" CACHE PATH "")
+set(UNCRUSTIFY_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/uncrustify-git.401a4098bce9dcc47e024987403f2d59d9ba7bd2_0.70.1-git.319-bsad7cne3ccgu3munuxms52yxxhxeob5/bin/uncrustify" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # addr2line
@@ -168,9 +168,11 @@ set(ADDR2LINE_EXEC  "/usr/bin/addr2line" CACHE PATH "")
 # Other
 #--------------------------------------------------------------------------------
 
-set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
+set(ENABLE_MATHPRESSO ON CACHE BOOL "")
 
-set(ENABLE_XML_UPDATES OFF CACHE BOOL "")
+set(MATHPRESSO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/dane-gcc-12_tpls/gcc-12.1.1/mathpresso-geos-duhbqwijvovnk2drgvvh2fs647mqitjj" CACHE PATH "")
+
+set(ENABLE_XML_UPDATES ON CACHE BOOL "")
 
 set(ATS_ARGUMENTS "--machine slurm56" CACHE STRING "")
 

--- a/host-configs/LLNL/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1-cuda.cmake
+++ b/host-configs/LLNL/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1-cuda.cmake
@@ -77,15 +77,15 @@ set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-ogxmfhtalme6gpcoykptldthjmg4rm4q" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-ogxmfhtalme6gpcoykptldthjmg4rm4q" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-lsyisibfnsvy4fo3qfc6ohj5l4cheu3g" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-lsyisibfnsvy4fo3qfc6ohj5l4cheu3g" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-jmbjlbdi44jyb6yjcgpmnvavj7opvgmk" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-jmbjlbdi44jyb6yjcgpmnvavj7opvgmk" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-v3j74o2uag4ty7xyngak7ogbmvireubt" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-v3j74o2uag4ty7xyngak7ogbmvireubt" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -93,21 +93,21 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-xiwon23mamhn2tkcnqks5crznnqaovjt" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-xiwon23mamhn2tkcnqks5crznnqaovjt" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/adiak-0.4.0-tp3jxzzp7ifbreg2erbvusm34w64jau7/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/adiak-0.4.0-tp3jxzzp7ifbreg2erbvusm34w64jau7/lib/cmake/adiak" CACHE PATH "")
 
-set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/hdf5-1.12.1-ga44aabjnhf34hg5ns7kwkt4wkamofpl" CACHE PATH "")
+set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/hdf5-1.12.1-ga44aabjnhf34hg5ns7kwkt4wkamofpl" CACHE PATH "")
 
-set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-kukbdfbxcpyabdugeewvpaaifiyysdhu" CACHE PATH "")
+set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-kukbdfbxcpyabdugeewvpaaifiyysdhu" CACHE PATH "")
 
-set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/silo-4.11.1-bsd-ah6h4u6ukx3kyxgknlx75bk65uscgnft" CACHE PATH "")
+set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/silo-4.11.1-bsd-ah6h4u6ukx3kyxgknlx75bk65uscgnft" CACHE PATH "")
 
-set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/pugixml-1.13-k4ydpdk7vsgycnj72t3u5dbdean33tql" CACHE PATH "")
+set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/pugixml-1.13-k4ydpdk7vsgycnj72t3u5dbdean33tql" CACHE PATH "")
 
-set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/vtk-9.3.1-6y4upz33jg7xl3vzbaerb6ztsqjxgkva" CACHE PATH "")
+set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/vtk-9.3.1-6y4upz33jg7xl3vzbaerb6ztsqjxgkva" CACHE PATH "")
 
-set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/fmt-10.0.0-jp5lqtjl4bhgqr5k6dmb3sae5zpbxjl6" CACHE PATH "")
+set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/fmt-10.0.0-jp5lqtjl4bhgqr5k6dmb3sae5zpbxjl6" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # System Math Libraries
@@ -127,19 +127,19 @@ set(FORTRAN_MANGLE_NO_UNDERSCORE ON CACHE BOOL "")
 # Math TPLs
 #--------------------------------------------------------------------------------
 
-set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/metis-5.1.0-ni6dg7mhgm7nurp5iucvzkbg27c6ouaz" CACHE PATH "")
+set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/metis-5.1.0-ni6dg7mhgm7nurp5iucvzkbg27c6ouaz" CACHE PATH "")
 
-set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/parmetis-4.0.3-xqqcnael7oe72dansvr5umz7zn236th4" CACHE PATH "")
+set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/parmetis-4.0.3-xqqcnael7oe72dansvr5umz7zn236th4" CACHE PATH "")
 
-set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/scotch-7.0.3-pd6fx6lybdmtsayi2dsxdifyfpngcycy" CACHE PATH "")
+set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/scotch-7.0.3-pd6fx6lybdmtsayi2dsxdifyfpngcycy" CACHE PATH "")
 
-set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-oy253csfiumkubsj7gebdv534f6z4z3d" CACHE PATH "")
+set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-oy253csfiumkubsj7gebdv534f6z4z3d" CACHE PATH "")
 
-set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/suite-sparse-5.10.1-pi4hfahsc4gez74vd5rcgxbjbtzoxe32" CACHE PATH "")
+set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/suite-sparse-5.10.1-pi4hfahsc4gez74vd5rcgxbjbtzoxe32" CACHE PATH "")
 
-set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/trilinos-16.0.0-y5prgnz22qkhximrxaounp35ewzu3w2w" CACHE PATH "")
+set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/trilinos-16.0.0-3uu36vcyrsciaen5iebbjuwnzu6m3pco" CACHE PATH "")
 
-set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-10-cuda-11_tpls/clang-10.0.1/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-3em7frh5bssabg2zlzegf5kw73rvpbg7" CACHE PATH "")
+set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-3em7frh5bssabg2zlzegf5kw73rvpbg7" CACHE PATH "")
 
 set(ENABLE_HYPRE_DEVICE "CUDA" CACHE STRING "")
 
@@ -185,9 +185,11 @@ set(ADDR2LINE_EXEC  "/usr/bin/addr2line" CACHE PATH "")
 # Other
 #--------------------------------------------------------------------------------
 
-set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
+set(ENABLE_MATHPRESSO ON CACHE BOOL "")
 
-set(ENABLE_XML_UPDATES OFF CACHE BOOL "")
+set(MATHPRESSO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-10-cuda-11_tpls/clang-10.0.1/mathpresso-geos-5rryysdxznig37z7gsm2wfs5arla7wcy" CACHE PATH "")
+
+set(ENABLE_XML_UPDATES ON CACHE BOOL "")
 
 set(ATS_ARGUMENTS "--ats jsrun_omp --ats jsrun_bind=packed" CACHE STRING "")
 

--- a/host-configs/LLNL/lassen-blueos_3_ppc64le_ib_p9-clang@13.0.1-cuda.cmake
+++ b/host-configs/LLNL/lassen-blueos_3_ppc64le_ib_p9-clang@13.0.1-cuda.cmake
@@ -57,7 +57,7 @@ set(ENABLE_CUDA ON CACHE BOOL "")
 
 set(CMAKE_CUDA_STANDARD "17" CACHE PATH "")
 
-set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-12.0.0" CACHE PATH "")
+set(CUDA_TOOLKIT_ROOT_DIR "/usr/tce/packages/cuda/cuda-11.8.0" CACHE PATH "")
 
 set(CMAKE_CUDA_COMPILER "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc" CACHE PATH "")
 
@@ -77,15 +77,15 @@ set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-nmmjzxisecb5fpqfnvsm7q25riyc4v6n" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-7zzsg2ay5tcqrjnstmuchhksi2cnwy75" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-54zp6bxl3yepw3nh3awk455q22vakj2u" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-sypzlcrwsnljfcfv7psjijvho2v6xhp2" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-ztjsbkdojxcrgqnqrkvm7wq5oz4lm7cw" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-nr6nq3fxtf54hsmeyzlcphr6k5dr4lm7" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-fs7yeokq6dq3pql5hndzczn36ykkfhon" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-6d6bn5wfbwvqliswmlxb5mzsshvglapn" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -93,21 +93,21 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-4gu3btnlno2sbv56vhd3ux2uvgoupkgi" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-4gu3btnlno2sbv56vhd3ux2uvgoupkgi" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/adiak-0.4.0-hqwcvthhjo5zs4b3u52glnlcxk5bp34n/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/adiak-0.4.0-hqwcvthhjo5zs4b3u52glnlcxk5bp34n/lib/cmake/adiak" CACHE PATH "")
 
-set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/hdf5-1.12.1-dycb4qq65jod3vakmo4jfcknwbba4qp5" CACHE PATH "")
+set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/hdf5-1.12.1-dycb4qq65jod3vakmo4jfcknwbba4qp5" CACHE PATH "")
 
-set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-7nrioisimbmm3mqcl7uenprhkz36og6u" CACHE PATH "")
+set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-7nrioisimbmm3mqcl7uenprhkz36og6u" CACHE PATH "")
 
-set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/silo-4.11.1-bsd-bdktrlhcoynsflkrcgumryqbtu45gezb" CACHE PATH "")
+set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/silo-4.11.1-bsd-bdktrlhcoynsflkrcgumryqbtu45gezb" CACHE PATH "")
 
-set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/pugixml-1.13-dn3wo74qjiclno55tao7i6q3qsmmtbmm" CACHE PATH "")
+set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/pugixml-1.13-dn3wo74qjiclno55tao7i6q3qsmmtbmm" CACHE PATH "")
 
-set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/vtk-9.3.1-hjvim2htouza4aw6laupkeluggn7vzzl" CACHE PATH "")
+set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/vtk-9.3.1-hjvim2htouza4aw6laupkeluggn7vzzl" CACHE PATH "")
 
-set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/fmt-10.0.0-u3hormd7jprgxpemsdwy67f5wdd3rcks" CACHE PATH "")
+set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/fmt-10.0.0-u3hormd7jprgxpemsdwy67f5wdd3rcks" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # System Math Libraries
@@ -127,19 +127,19 @@ set(FORTRAN_MANGLE_NO_UNDERSCORE ON CACHE BOOL "")
 # Math TPLs
 #--------------------------------------------------------------------------------
 
-set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/metis-5.1.0-yk3zg6ifqxkue25iqr3waysqbkzjbiim" CACHE PATH "")
+set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/metis-5.1.0-yk3zg6ifqxkue25iqr3waysqbkzjbiim" CACHE PATH "")
 
-set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/parmetis-4.0.3-hfu52rbhm3xhhbi33unvxrsydvvdqejd" CACHE PATH "")
+set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/parmetis-4.0.3-hfu52rbhm3xhhbi33unvxrsydvvdqejd" CACHE PATH "")
 
-set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/scotch-7.0.3-v3r45jclgkkywzyft37lqqoguhperyxm" CACHE PATH "")
+set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/scotch-7.0.3-v3r45jclgkkywzyft37lqqoguhperyxm" CACHE PATH "")
 
-set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-2zru2u6fegs5bsz44wckbxcaxuwwdivw" CACHE PATH "")
+set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-2zru2u6fegs5bsz44wckbxcaxuwwdivw" CACHE PATH "")
 
-set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/suite-sparse-5.10.1-rxlyv2tiek7hl3ln7ps7ykguwog3tax4" CACHE PATH "")
+set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/suite-sparse-5.10.1-rxlyv2tiek7hl3ln7ps7ykguwog3tax4" CACHE PATH "")
 
-set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/trilinos-16.0.0-wo5v5rma22soustvdev64v5thopnxpct" CACHE PATH "")
+set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/trilinos-16.0.0-wo5v5rma22soustvdev64v5thopnxpct" CACHE PATH "")
 
-set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-clang-13-cuda-12_tpls/clang-13.0.1/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-piw2evtux6rpkk7w6i6rjt2wtwxjfqsa" CACHE PATH "")
+set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-hbnflruny5p6nhs3b5utboyqlbcwgxly" CACHE PATH "")
 
 set(ENABLE_HYPRE_DEVICE "CUDA" CACHE STRING "")
 
@@ -185,9 +185,11 @@ set(ADDR2LINE_EXEC  "/usr/bin/addr2line" CACHE PATH "")
 # Other
 #--------------------------------------------------------------------------------
 
-set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
+set(ENABLE_MATHPRESSO ON CACHE BOOL "")
 
-set(ENABLE_XML_UPDATES OFF CACHE BOOL "")
+set(MATHPRESSO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-clang-13-cuda-11_tpls/clang-13.0.1/mathpresso-geos-z4ebytw2o2tmltrko7jwbko5x6jvadod" CACHE PATH "")
+
+set(ENABLE_XML_UPDATES ON CACHE BOOL "")
 
 set(ATS_ARGUMENTS "--ats jsrun_omp --ats jsrun_bind=packed" CACHE STRING "")
 

--- a/host-configs/LLNL/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1-cuda.cmake
+++ b/host-configs/LLNL/lassen-blueos_3_ppc64le_ib_p9-gcc@8.3.1-cuda.cmake
@@ -77,15 +77,15 @@ set(CMAKE_CUDA_FLAGS_DEBUG "-g -G -O0 -Xcompiler -O0" CACHE STRING "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-jvnmbz3nfrjym77m2m2ddxfgyigf2hqv" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-jvnmbz3nfrjym77m2m2ddxfgyigf2hqv" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-ktim3j27la76tmlr6ryj2vjfllltmz4o" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-ktim3j27la76tmlr6ryj2vjfllltmz4o" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-xmi5nbcsff7dz76ljlmr5catjxa4hzjn" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-xmi5nbcsff7dz76ljlmr5catjxa4hzjn" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-d4ymmapzrvlzw6jwjiyenqd5l2sy7pg7" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-d4ymmapzrvlzw6jwjiyenqd5l2sy7pg7" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -93,21 +93,21 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tp
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-rw6xo4fv4xn4oapuiypwwn7cz3m73naz" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-rw6xo4fv4xn4oapuiypwwn7cz3m73naz" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/adiak-0.4.0-n3yugcwz5o3ggvi2nrwybgmfattinedh/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/adiak-0.4.0-n3yugcwz5o3ggvi2nrwybgmfattinedh/lib/cmake/adiak" CACHE PATH "")
 
-set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/hdf5-1.12.1-obzanrc4jpjjzno25h4iohq6f3hr2j27" CACHE PATH "")
+set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/hdf5-1.12.1-obzanrc4jpjjzno25h4iohq6f3hr2j27" CACHE PATH "")
 
-set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-ubpigj3aj4jsqbi7j7bbibmg2ryo7xoj" CACHE PATH "")
+set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-ubpigj3aj4jsqbi7j7bbibmg2ryo7xoj" CACHE PATH "")
 
-set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/silo-4.11.1-bsd-roheyk37frcivqqo4l3a4ldq7d5hx6st" CACHE PATH "")
+set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/silo-4.11.1-bsd-roheyk37frcivqqo4l3a4ldq7d5hx6st" CACHE PATH "")
 
-set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/pugixml-1.13-s3vycldwlzcj5s6pua2hyghvdoqm6hu3" CACHE PATH "")
+set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/pugixml-1.13-s3vycldwlzcj5s6pua2hyghvdoqm6hu3" CACHE PATH "")
 
-set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/vtk-9.3.1-xoeo4iubpe3qwprc7o2j5lglbp4y6m7t" CACHE PATH "")
+set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/vtk-9.3.1-xoeo4iubpe3qwprc7o2j5lglbp4y6m7t" CACHE PATH "")
 
-set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/fmt-10.0.0-6jiaf3rryjoxxkptvy2jcrnoajdpe6mv" CACHE PATH "")
+set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/fmt-10.0.0-6jiaf3rryjoxxkptvy2jcrnoajdpe6mv" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # System Math Libraries
@@ -127,19 +127,19 @@ set(FORTRAN_MANGLE_NO_UNDERSCORE ON CACHE BOOL "")
 # Math TPLs
 #--------------------------------------------------------------------------------
 
-set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/metis-5.1.0-nn7ngjgltv2ijx4kswtnoeyfgwbq24k2" CACHE PATH "")
+set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/metis-5.1.0-nn7ngjgltv2ijx4kswtnoeyfgwbq24k2" CACHE PATH "")
 
-set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/parmetis-4.0.3-chbckvoyrbustqebbsxhrrw7e3ngjx43" CACHE PATH "")
+set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/parmetis-4.0.3-chbckvoyrbustqebbsxhrrw7e3ngjx43" CACHE PATH "")
 
-set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/scotch-7.0.3-4n72uptvwu74yw3nplp2dbyhxt5if6jf" CACHE PATH "")
+set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/scotch-7.0.3-4n72uptvwu74yw3nplp2dbyhxt5if6jf" CACHE PATH "")
 
-set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-co27fkcshr4pdskjot7sa3bfhccymaws" CACHE PATH "")
+set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-co27fkcshr4pdskjot7sa3bfhccymaws" CACHE PATH "")
 
-set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/suite-sparse-5.10.1-rgp2xi4ihgkbjm2rzgspizeler7w6otm" CACHE PATH "")
+set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/suite-sparse-5.10.1-rgp2xi4ihgkbjm2rzgspizeler7w6otm" CACHE PATH "")
 
-set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/trilinos-16.0.0-k35ukkbitl64gzvdfe2dlvt5sg6r7t67" CACHE PATH "")
+set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/trilinos-16.0.0-k35ukkbitl64gzvdfe2dlvt5sg6r7t67" CACHE PATH "")
 
-set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-mesu7comouhq5aiqrdoj6p5hqyyu2t2f" CACHE PATH "")
+set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-mesu7comouhq5aiqrdoj6p5hqyyu2t2f" CACHE PATH "")
 
 set(ENABLE_HYPRE_DEVICE "CUDA" CACHE STRING "")
 
@@ -185,9 +185,11 @@ set(ADDR2LINE_EXEC  "/usr/bin/addr2line" CACHE PATH "")
 # Other
 #--------------------------------------------------------------------------------
 
-set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
+set(ENABLE_MATHPRESSO ON CACHE BOOL "")
 
-set(ENABLE_XML_UPDATES OFF CACHE BOOL "")
+set(MATHPRESSO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/lassen-gcc-8-cuda-11_tpls/gcc-8.3.1/mathpresso-geos-tf3bai7si63pwb6nuqqkrliyiipl7z2m" CACHE PATH "")
+
+set(ENABLE_XML_UPDATES ON CACHE BOOL "")
 
 set(ATS_ARGUMENTS "--ats jsrun_omp --ats jsrun_bind=packed" CACHE STRING "")
 

--- a/host-configs/LLNL/ruby-toss_4_x86_64_ib-clang@14.0.6.cmake
+++ b/host-configs/LLNL/ruby-toss_4_x86_64_ib-clang@14.0.6.cmake
@@ -58,15 +58,15 @@ set(ENABLE_CUDA OFF CACHE BOOL "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-thhf2i6gjy3pnvdpgxf63zm2hulvdbwu" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-thhf2i6gjy3pnvdpgxf63zm2hulvdbwu" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-7bkwfqjvbwyfg6kwi3qnu5nbwoyu7c5s" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-7bkwfqjvbwyfg6kwi3qnu5nbwoyu7c5s" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-qc6ke6ra4bw5ieyx2eiitfkzngns6b2n" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-qc6ke6ra4bw5ieyx2eiitfkzngns6b2n" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-4o6q4kk5tjy3tmlcgpns2w2ss5ibm5x6" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-4o6q4kk5tjy3tmlcgpns2w2ss5ibm5x6" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -74,21 +74,21 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clan
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-d6jzlhx4ofqairetauzhiw7rcocb3lj5" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-d6jzlhx4ofqairetauzhiw7rcocb3lj5" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/adiak-0.4.0-vxgcukydyqrm6ciuxrw4leflputw6r5e/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/adiak-0.4.0-vxgcukydyqrm6ciuxrw4leflputw6r5e/lib/cmake/adiak" CACHE PATH "")
 
-set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/hdf5-1.12.1-yqvru4fil7emvnajdmu3tq736rlzesza" CACHE PATH "")
+set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/hdf5-1.12.1-yqvru4fil7emvnajdmu3tq736rlzesza" CACHE PATH "")
 
-set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-sowkah5jcivfrcna3lbmxxhntokwin6n" CACHE PATH "")
+set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-sowkah5jcivfrcna3lbmxxhntokwin6n" CACHE PATH "")
 
-set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/silo-4.11.1-bsd-dmyx6w72zap3cqtrtrdoaggki6dbdywv" CACHE PATH "")
+set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/silo-4.11.1-bsd-dmyx6w72zap3cqtrtrdoaggki6dbdywv" CACHE PATH "")
 
-set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/pugixml-1.13-qdosppqlevwbzkbkr25tycjlts6dxuoq" CACHE PATH "")
+set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/pugixml-1.13-qdosppqlevwbzkbkr25tycjlts6dxuoq" CACHE PATH "")
 
-set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/vtk-9.3.1-sgjxp6i2a5hlvzux3ufnmvrr3zoa22su" CACHE PATH "")
+set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/vtk-9.3.1-sgjxp6i2a5hlvzux3ufnmvrr3zoa22su" CACHE PATH "")
 
-set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/fmt-10.0.0-f2lzpypwoyhiracsh44luu46ezmch72t" CACHE PATH "")
+set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/fmt-10.0.0-f2lzpypwoyhiracsh44luu46ezmch72t" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # System Math Libraries
@@ -110,19 +110,19 @@ set(MKL_LIBRARIES /usr/tce/packages/mkl/mkl-2022.1.0/mkl/2022.1.0/lib/intel64/li
 # Math TPLs
 #--------------------------------------------------------------------------------
 
-set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/metis-5.1.0-2bggpuqbh4sjefm2hisblqpofiek27dg" CACHE PATH "")
+set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/metis-5.1.0-2bggpuqbh4sjefm2hisblqpofiek27dg" CACHE PATH "")
 
-set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/parmetis-4.0.3-dy34gwdh5lk4bmzrucykto667hgj7njl" CACHE PATH "")
+set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/parmetis-4.0.3-dy34gwdh5lk4bmzrucykto667hgj7njl" CACHE PATH "")
 
-set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/scotch-7.0.3-vquie4qxvhrhcbsaagdkjlwrvxyasj7r" CACHE PATH "")
+set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/scotch-7.0.3-ylbtxqjazagbk7ombhqzxjetpub2j42r" CACHE PATH "")
 
-set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-uf3dqwltl5532qvkrcrse2nzk32drtv5" CACHE PATH "")
+set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-uf3dqwltl5532qvkrcrse2nzk32drtv5" CACHE PATH "")
 
-set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/suite-sparse-5.10.1-kgaikvqvpf5quqvhu4bfm3tbixwcoyfo" CACHE PATH "")
+set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/suite-sparse-5.10.1-kgaikvqvpf5quqvhu4bfm3tbixwcoyfo" CACHE PATH "")
 
-set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/trilinos-16.0.0-5eqxu5er6tinrn5bgthts2g6evuapscw" CACHE PATH "")
+set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/trilinos-16.0.0-kt3gwm2xmyhg3t2z4pfwx3w75wkbu3ga" CACHE PATH "")
 
-set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-cvihakjzfn6fzfmnnj32g7kbtq2m4xtb" CACHE PATH "")
+set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-cvihakjzfn6fzfmnnj32g7kbtq2m4xtb" CACHE PATH "")
 
 set(ENABLE_PETSC OFF CACHE BOOL "")
 
@@ -146,7 +146,7 @@ set(ENABLE_PYGEOSX ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/python/quartz-gcc-python/python/bin/sphinx-build" CACHE PATH "")
 
-set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/doxygen-1.8.20-xj3wmf2ztwfreg3ao4zdjyjlami7lrb4/bin/doxygen" CACHE PATH "")
+set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/doxygen-1.8.20-xj3wmf2ztwfreg3ao4zdjyjlami7lrb4/bin/doxygen" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Development tools
@@ -154,7 +154,7 @@ set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14
 
 set(ENABLE_UNCRUSTIFY ON CACHE BOOL "")
 
-set(UNCRUSTIFY_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-clang-14_tpls/clang-14.0.6/uncrustify-git.401a4098bce9dcc47e024987403f2d59d9ba7bd2_0.70.1-git.319-3tyetsqkpeonbslmn2iithvvvyfhozc6/bin/uncrustify" CACHE PATH "")
+set(UNCRUSTIFY_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/uncrustify-git.401a4098bce9dcc47e024987403f2d59d9ba7bd2_0.70.1-git.319-3tyetsqkpeonbslmn2iithvvvyfhozc6/bin/uncrustify" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # addr2line
@@ -168,9 +168,11 @@ set(ADDR2LINE_EXEC  "/usr/bin/addr2line" CACHE PATH "")
 # Other
 #--------------------------------------------------------------------------------
 
-set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
+set(ENABLE_MATHPRESSO ON CACHE BOOL "")
 
-set(ENABLE_XML_UPDATES OFF CACHE BOOL "")
+set(MATHPRESSO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-clang-14_tpls/clang-14.0.6/mathpresso-geos-pxokzqriqhovt3ggd37a3ocrhzp3p7ho" CACHE PATH "")
+
+set(ENABLE_XML_UPDATES ON CACHE BOOL "")
 
 set(ATS_ARGUMENTS "--machine slurm56" CACHE STRING "")
 

--- a/host-configs/LLNL/ruby-toss_4_x86_64_ib-gcc@12.1.1.cmake
+++ b/host-configs/LLNL/ruby-toss_4_x86_64_ib-gcc@12.1.1.cmake
@@ -58,15 +58,15 @@ set(ENABLE_CUDA OFF CACHE BOOL "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-iev43uxnll3jsod7jloak5iwmox6owlv" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-iev43uxnll3jsod7jloak5iwmox6owlv" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-ikig7gipi7bsuxopxfac7uvrup3kd4rx" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-ikig7gipi7bsuxopxfac7uvrup3kd4rx" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-4t7pxjbfakzclltrwpajtryfkntshmwu" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-4t7pxjbfakzclltrwpajtryfkntshmwu" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-fv2sc4dnl7tma5k3wpu5r2tgcinfpz7u" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-fv2sc4dnl7tma5k3wpu5r2tgcinfpz7u" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -74,21 +74,21 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-bno6d6qyyvivznkozzdh27ljrj3yqbv2" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-bno6d6qyyvivznkozzdh27ljrj3yqbv2" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/adiak-0.4.0-dimwte7ij4naho6hhcqowidlxnespn7e/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/adiak-0.4.0-dimwte7ij4naho6hhcqowidlxnespn7e/lib/cmake/adiak" CACHE PATH "")
 
-set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/hdf5-1.12.1-ijx73yvfrhxnjls4acfy2sdqtiekvyec" CACHE PATH "")
+set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/hdf5-1.12.1-ijx73yvfrhxnjls4acfy2sdqtiekvyec" CACHE PATH "")
 
-set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-jwijeuulb6xfflmsmh4snh6qvmmvenve" CACHE PATH "")
+set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-jwijeuulb6xfflmsmh4snh6qvmmvenve" CACHE PATH "")
 
-set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/silo-4.11.1-bsd-nrzzqos7534qy74dk5anmp3pvsgdovrq" CACHE PATH "")
+set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/silo-4.11.1-bsd-nrzzqos7534qy74dk5anmp3pvsgdovrq" CACHE PATH "")
 
-set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/pugixml-1.13-7v6zhre6pi7ibnief5tqhmqxowllqo2w" CACHE PATH "")
+set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/pugixml-1.13-7v6zhre6pi7ibnief5tqhmqxowllqo2w" CACHE PATH "")
 
-set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/vtk-9.3.1-6rs7wpfvmzw7pdsdl6mifdrg7nhuidqd" CACHE PATH "")
+set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/vtk-9.3.1-6rs7wpfvmzw7pdsdl6mifdrg7nhuidqd" CACHE PATH "")
 
-set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/fmt-10.0.0-4wcnmovbi74zd66vdk6xhjo6hefdbxbp" CACHE PATH "")
+set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/fmt-10.0.0-4wcnmovbi74zd66vdk6xhjo6hefdbxbp" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # System Math Libraries
@@ -110,19 +110,19 @@ set(MKL_LIBRARIES /usr/tce/packages/mkl/mkl-2022.1.0/mkl/2022.1.0/lib/intel64/li
 # Math TPLs
 #--------------------------------------------------------------------------------
 
-set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/metis-5.1.0-jrpyyvbvi5zzxt3mraydgurmfk7pjj77" CACHE PATH "")
+set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/metis-5.1.0-jrpyyvbvi5zzxt3mraydgurmfk7pjj77" CACHE PATH "")
 
-set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/parmetis-4.0.3-i2lkaqn2onxsvx3rcssafh7zkgv4xgcb" CACHE PATH "")
+set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/parmetis-4.0.3-i2lkaqn2onxsvx3rcssafh7zkgv4xgcb" CACHE PATH "")
 
-set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/scotch-7.0.3-fl625kpmhevzvzmuotssykvvhaqovqk3" CACHE PATH "")
+set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/scotch-7.0.3-ts6ppq45qy3me5wdlnb4dzhtnnyleop5" CACHE PATH "")
 
-set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-kul235x6jkdwxbdntczlhho7h6x65pwh" CACHE PATH "")
+set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-kul235x6jkdwxbdntczlhho7h6x65pwh" CACHE PATH "")
 
-set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/suite-sparse-5.10.1-fbm7gbwba72t4ggduvynvnbcr43uxxs4" CACHE PATH "")
+set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/suite-sparse-5.10.1-fbm7gbwba72t4ggduvynvnbcr43uxxs4" CACHE PATH "")
 
-set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/trilinos-16.0.0-pouamvqn7cggh62ew6ahy5qfomipu6g3" CACHE PATH "")
+set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/trilinos-16.0.0-pouamvqn7cggh62ew6ahy5qfomipu6g3" CACHE PATH "")
 
-set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-n2ggx632hcpy4nznfy5lehdnb4azkrft" CACHE PATH "")
+set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-n2ggx632hcpy4nznfy5lehdnb4azkrft" CACHE PATH "")
 
 set(ENABLE_PETSC OFF CACHE BOOL "")
 
@@ -146,7 +146,7 @@ set(ENABLE_PYGEOSX ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/python/quartz-gcc-python/python/bin/sphinx-build" CACHE PATH "")
 
-set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/doxygen-1.8.20-hbxmvlkrwmpt5mvibhths6cdo5rlor3s/bin/doxygen" CACHE PATH "")
+set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/doxygen-1.8.20-hbxmvlkrwmpt5mvibhths6cdo5rlor3s/bin/doxygen" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Development tools
@@ -154,7 +154,7 @@ set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_t
 
 set(ENABLE_UNCRUSTIFY ON CACHE BOOL "")
 
-set(UNCRUSTIFY_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12_tpls/gcc-12.1.1/uncrustify-git.401a4098bce9dcc47e024987403f2d59d9ba7bd2_0.70.1-git.319-bsad7cne3ccgu3munuxms52yxxhxeob5/bin/uncrustify" CACHE PATH "")
+set(UNCRUSTIFY_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/uncrustify-git.401a4098bce9dcc47e024987403f2d59d9ba7bd2_0.70.1-git.319-bsad7cne3ccgu3munuxms52yxxhxeob5/bin/uncrustify" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # addr2line
@@ -168,9 +168,11 @@ set(ADDR2LINE_EXEC  "/usr/bin/addr2line" CACHE PATH "")
 # Other
 #--------------------------------------------------------------------------------
 
-set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
+set(ENABLE_MATHPRESSO ON CACHE BOOL "")
 
-set(ENABLE_XML_UPDATES OFF CACHE BOOL "")
+set(MATHPRESSO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12_tpls/gcc-12.1.1/mathpresso-geos-duhbqwijvovnk2drgvvh2fs647mqitjj" CACHE PATH "")
+
+set(ENABLE_XML_UPDATES ON CACHE BOOL "")
 
 set(ATS_ARGUMENTS "--machine slurm56" CACHE STRING "")
 

--- a/host-configs/LLNL/ruby-toss_4_x86_64_ib-gcc@12noAVX.cmake
+++ b/host-configs/LLNL/ruby-toss_4_x86_64_ib-gcc@12noAVX.cmake
@@ -60,15 +60,15 @@ set(ENABLE_CUDA OFF CACHE BOOL "")
 
 set(ENABLE_CHAI ON CACHE BOOL "")
 
-set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-wtbhnhf2zdlchyvk3xfgwni2wnjxo3js" CACHE PATH "")
+set(CHAI_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/chai-git.df7741f1dbbdc5fff5f7d626151fdf1904e62b19_develop-wtbhnhf2zdlchyvk3xfgwni2wnjxo3js" CACHE PATH "")
 
-set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-e2mjbgvxgfyunnduvgkuntfkblvmrvjo" CACHE PATH "")
+set(RAJA_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/raja-git.4d7fcba55ebc7cb972b7cc9f6778b48e43792ea1_develop-e2mjbgvxgfyunnduvgkuntfkblvmrvjo" CACHE PATH "")
 
 set(ENABLE_UMPIRE ON CACHE BOOL "")
 
-set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-ixn6mth7nl44zyt34hztcdnqit6h6aqy" CACHE PATH "")
+set(UMPIRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/umpire-git.abd729f40064175e999a83d11d6b073dac4c01d2_develop-ixn6mth7nl44zyt34hztcdnqit6h6aqy" CACHE PATH "")
 
-set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-mjbymoc6da5vwtgx7kgfcg6x37ilciyg" CACHE PATH "")
+set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/camp-git.0f07de4240c42e0b38a8d872a20440cb4b33d9f5_main-mjbymoc6da5vwtgx7kgfcg6x37ilciyg" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # IO TPLs
@@ -76,21 +76,21 @@ set(CAMP_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/g
 
 set(ENABLE_CALIPER ON CACHE BOOL "")
 
-set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-olusdj2xpppf5tam6ktcysn6ogeq4i2d" CACHE PATH "")
+set(CALIPER_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/caliper-git.287b7f3ad2d12f520aad04268d44f353cd05403c_2.12.0-olusdj2xpppf5tam6ktcysn6ogeq4i2d" CACHE PATH "")
 
-set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/adiak-0.4.0-kgrknuu6drw34t7svfcen5t5u37i4jnf/lib/cmake/adiak" CACHE PATH "")
+set(adiak_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/adiak-0.4.0-kgrknuu6drw34t7svfcen5t5u37i4jnf/lib/cmake/adiak" CACHE PATH "")
 
-set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/hdf5-1.12.1-chdwkirwhv5wph3ui6yuenspycyu4o5g" CACHE PATH "")
+set(HDF5_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/hdf5-1.12.1-chdwkirwhv5wph3ui6yuenspycyu4o5g" CACHE PATH "")
 
-set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-dc5zun6rptqzosk3ntitczne2umvfvoe" CACHE PATH "")
+set(CONDUIT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/conduit-git.ad86e316ad56a75c099d30ca5ce75cff275b5924_develop-dc5zun6rptqzosk3ntitczne2umvfvoe" CACHE PATH "")
 
-set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/silo-4.11.1-bsd-wmvom3aodvg5tpn4b7tymog4j5o2bjdl" CACHE PATH "")
+set(SILO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/silo-4.11.1-bsd-wmvom3aodvg5tpn4b7tymog4j5o2bjdl" CACHE PATH "")
 
-set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/pugixml-1.13-lzydzfiimopvd46asgg6wsswe4tkzbvm" CACHE PATH "")
+set(PUGIXML_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/pugixml-1.13-lzydzfiimopvd46asgg6wsswe4tkzbvm" CACHE PATH "")
 
-set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/vtk-9.3.1-rtmsf25pdwhvyygjqmzsezgoomzqf6fi" CACHE PATH "")
+set(VTK_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/vtk-9.3.1-rtmsf25pdwhvyygjqmzsezgoomzqf6fi" CACHE PATH "")
 
-set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/fmt-10.0.0-na2mo7xln32wmq2hjrmbdyzacr7yqxev" CACHE PATH "")
+set(FMT_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/fmt-10.0.0-na2mo7xln32wmq2hjrmbdyzacr7yqxev" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # System Math Libraries
@@ -112,19 +112,19 @@ set(MKL_LIBRARIES /usr/tce/packages/mkl/mkl-2022.1.0/mkl/2022.1.0/lib/intel64/li
 # Math TPLs
 #--------------------------------------------------------------------------------
 
-set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/metis-5.1.0-klusyacs6uicwrr6t2uh4inudrz25oog" CACHE PATH "")
+set(METIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/metis-5.1.0-klusyacs6uicwrr6t2uh4inudrz25oog" CACHE PATH "")
 
-set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/parmetis-4.0.3-v5legva4mfqqce3sdgesl4th77brabgp" CACHE PATH "")
+set(PARMETIS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/parmetis-4.0.3-v5legva4mfqqce3sdgesl4th77brabgp" CACHE PATH "")
 
-set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/scotch-7.0.3-nebodz5k3zv7xdt3nqooanpyn3o4glwk" CACHE PATH "")
+set(SCOTCH_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/scotch-7.0.3-o4ndyzzae5dofc4ntxfnw3ujd2qluj2d" CACHE PATH "")
 
-set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-ippbrqdxoazamofylj5pmuwrh6inr7wj" CACHE PATH "")
+set(SUPERLU_DIST_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/superlu-dist-git.0f6efc377df2440c235452d13d28d2c717f832a1_6.3.0-git.8-ippbrqdxoazamofylj5pmuwrh6inr7wj" CACHE PATH "")
 
-set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/suite-sparse-5.10.1-webltrnxup4nbupu53no5257splerdr6" CACHE PATH "")
+set(SUITESPARSE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/suite-sparse-5.10.1-webltrnxup4nbupu53no5257splerdr6" CACHE PATH "")
 
-set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/trilinos-16.0.0-ysargtkfdb5xy5fzx6ulphazmjvezelh" CACHE PATH "")
+set(TRILINOS_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/trilinos-16.0.0-2msgbzjderuhenlm3y7zzgarxokidqh6" CACHE PATH "")
 
-set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-vsn53kpmhlyqhmuwxiwedwzceibebdtp" CACHE PATH "")
+set(HYPRE_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/hypre-git.c893886d15eb57e87dd36efec23693ece3ddc88e_2.32.0-git.4-vsn53kpmhlyqhmuwxiwedwzceibebdtp" CACHE PATH "")
 
 set(ENABLE_PETSC OFF CACHE BOOL "")
 
@@ -148,7 +148,7 @@ set(ENABLE_PYGEOSX ON CACHE BOOL "")
 
 set(SPHINX_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/python/quartz-gcc-python/python/bin/sphinx-build" CACHE PATH "")
 
-set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/doxygen-1.8.20-c4zarmc366msdoizvmau2bs7n76ob7vo/bin/doxygen" CACHE PATH "")
+set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/doxygen-1.8.20-c4zarmc366msdoizvmau2bs7n76ob7vo/bin/doxygen" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # Development tools
@@ -156,7 +156,7 @@ set(DOXYGEN_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12no
 
 set(ENABLE_UNCRUSTIFY ON CACHE BOOL "")
 
-set(UNCRUSTIFY_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-12/ruby-gcc-12noAVX_tpls/gcc-12noAVX/uncrustify-git.401a4098bce9dcc47e024987403f2d59d9ba7bd2_0.70.1-git.319-2mqopy2akzlsxtxeg27byz3abovta3nh/bin/uncrustify" CACHE PATH "")
+set(UNCRUSTIFY_EXECUTABLE "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/uncrustify-git.401a4098bce9dcc47e024987403f2d59d9ba7bd2_0.70.1-git.319-2mqopy2akzlsxtxeg27byz3abovta3nh/bin/uncrustify" CACHE PATH "")
 
 #--------------------------------------------------------------------------------
 # addr2line
@@ -170,9 +170,11 @@ set(ADDR2LINE_EXEC  "/usr/bin/addr2line" CACHE PATH "")
 # Other
 #--------------------------------------------------------------------------------
 
-set(ENABLE_MATHPRESSO OFF CACHE BOOL "")
+set(ENABLE_MATHPRESSO ON CACHE BOOL "")
 
-set(ENABLE_XML_UPDATES OFF CACHE BOOL "")
+set(MATHPRESSO_DIR "/usr/gapps/GEOSX/thirdPartyLibs/2025-02-28/ruby-gcc-12noAVX_tpls/gcc-12noAVX/mathpresso-geos-oxuork75cuchoi2oejgmbuucnru7llce" CACHE PATH "")
+
+set(ENABLE_XML_UPDATES ON CACHE BOOL "")
 
 set(ATS_ARGUMENTS "--machine slurm56" CACHE STRING "")
 


### PR DESCRIPTION
This PR:

- Creates a spack variant and recipe for mathpresso.
  - Allows correct compilation and generation of schema (bypasses https://github.com/GEOS-DEV/GEOS/issues/3407)
- Update spack-generated host-configs on LC to include mathpresso (only GEOS host-configs modified, LvArray dependencies unchanged) 

Relates to GEOS-DEV/thirdPartyLibs#298