### PR TITLE
fix: CI style and docs checks

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -132,6 +132,7 @@ jobs:
       BUILD_AND_TEST_CLI_ARGS: ${{ matrix.BUILD_AND_TEST_ARGS }}
       CMAKE_BUILD_TYPE: Release
       DOCKER_IMAGE_TAG: ${{ needs.is_not_draft_pull_request.outputs.DOCKER_IMAGE_TAG }}
+      HOST_CONFIG: /spack-generated.cmake
       DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc9
       RUNS_ON: ubuntu-22.04
       USE_SCCACHE: false

--- a/scripts/config-build.py
+++ b/scripts/config-build.py
@@ -230,12 +230,14 @@ def main(calling_script, args, unknown_args):
     os.chdir(build_path)
     with open(cmake_cmd, "r") as cmd_file:
         logging.info("Executing cmake line: '%s'" % cmd_file.read().rstrip(os.linesep))
-    subprocess.call(cmake_cmd, shell=True)
+    main_return_code = subprocess.call(cmake_cmd, shell=True)
 
     if args.graphviz:
-        subprocess.call(dot_line, shell=True)
+        main_return_code |= subprocess.call(dot_line, shell=True)
 
+    return main_return_code
 
 if __name__ == '__main__':
     logging.basicConfig(format='[%(filename)s]:[%(levelname)s]: %(message)s', level=logging.INFO)
-    main(sys.argv[0], *parse_args(sys.argv[1:]))
+    return_code = main(sys.argv[0], *parse_args(sys.argv[1:]))
+    sys.exit(return_code)

--- a/src/coreComponents/codingUtilities/Utilities.hpp
+++ b/src/coreComponents/codingUtilities/Utilities.hpp
@@ -63,7 +63,7 @@ template< typename ARRAY_TYPE >
 GEOS_FORCE_INLINE GEOS_HOST_DEVICE
 bool hasNonZero( ARRAY_TYPE const & array )
 {
-  for( auto it = array.begin(); it != array.end() ; ++it )
+  for( auto it = array.begin(); it != array.end(); ++it )
   {
     if( !isZero( *it ) )
     {

--- a/src/coreComponents/common/format/StringUtilities.hpp
+++ b/src/coreComponents/common/format/StringUtilities.hpp
@@ -213,7 +213,7 @@ string_view trim( string_view str,
 
 /**
  * @brief Trim the left string
- * @param[in] str the string to trim
+ * @param[in] s the string to trim
  * @return the trimmed string
  */
 string_view ltrimSpaces( string_view s );

--- a/src/coreComponents/finiteElement/elementFormulations/FiniteElementBase.hpp
+++ b/src/coreComponents/finiteElement/elementFormulations/FiniteElementBase.hpp
@@ -108,8 +108,7 @@ public:
    */
   template< typename SUBREGION_TYPE >
   struct MeshData
-  {
-  };
+  {};
 
 
   /**

--- a/src/coreComponents/physicsSolvers/PhysicsSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/PhysicsSolverBase.hpp
@@ -893,6 +893,10 @@ public:
   virtual PyTypeObject * getPythonType() const override;
 #endif
 
+  /**
+   * @brief accessor for m_meshTargets
+   * @return reference to m_meshTargets
+   */
   map< std::pair< string, string >, string_array > const & getMeshTargets() const
   {
     return m_meshTargets;


### PR DESCRIPTION
This PR:
- Get the style and documentation jobs actually running again.
  - These jobs were missing the `HOST_CONFIG` environment variable in Github Actions, so the CMake build could not find its dependencies.
- Fixes doxygen and uncrustify errors. 

- [x] Determine why these jobs were passing, but actually failing ([example](https://github.com/GEOS-DEV/GEOS/actions/runs/13702972819/job/38321240062))
  - Reason: `config-build.py` will always return an exit code of 0 on executing the CMake configuration line, regardless of if configuration is successful or not:  https://github.com/GEOS-DEV/GEOS/blob/5fe125be64c9d2978fdd2b6bdc471050fd85acf5/scripts/config-build.py#L233
  - Solution is to capture the return code and pass it up to `sys.exit(code)`.