### PR TITLE
fix: random error with DAS receivers (Invalid distribution of receivers)

### DIFF
--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/secondOrderEqn/isotropic/ElasticWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/secondOrderEqn/isotropic/ElasticWaveEquationSEM.cpp
@@ -280,7 +280,7 @@ void ElasticWaveEquationSEM::precomputeSourceAndReceiverTerm( MeshLevel & baseMe
 
       PreComputeSourcesAndReceivers::
         Compute3DSourceAndReceiverConstantsWithDAS
-      < EXEC_POLICY, FE_TYPE >
+      < EXEC_POLICY, ATOMIC_POLICY, FE_TYPE >
         ( elementSubRegion.size(),
         facesToNodes,
         nodeCoords,
@@ -467,8 +467,14 @@ void ElasticWaveEquationSEM::initializePostInitialConditionsPreSubGroups()
     m_timeStep=dtOut;
   }
 
-  WaveSolverUtils::initTrace( "seismoTraceReceiver", getName(), m_outputSeismoTrace, m_receiverConstants.size( 0 ), m_receiverIsLocal );
-  WaveSolverUtils::initTrace( "dasTraceReceiver", getName(), m_outputSeismoTrace, m_linearDASGeometry.size( 0 ), m_receiverIsLocal );
+  if( m_useDAS == WaveSolverUtils::DASType::none )
+  {
+    WaveSolverUtils::initTrace( "seismoTraceReceiver", getName(), m_outputSeismoTrace, m_receiverConstants.size( 0 ), m_receiverIsLocal );
+  }
+  else
+  {
+    WaveSolverUtils::initTrace( "dasTraceReceiver", getName(), m_outputSeismoTrace, m_linearDASGeometry.size( 0 ), m_receiverIsLocal );
+  }
 }
 
 real64 ElasticWaveEquationSEM::computeTimeStep( real64 & dtOut )

--- a/src/coreComponents/physicsSolvers/wavePropagation/shared/PrecomputeSourcesAndReceiversKernel.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/shared/PrecomputeSourcesAndReceiversKernel.hpp
@@ -389,7 +389,7 @@ struct PreComputeSourcesAndReceivers
    * @param[in] sourceForce force vector of the source
    * @param[in] sourceMoment moment (symmetric rank-2 tensor) of the source
    */
-  template< typename EXEC_POLICY, typename FE_TYPE >
+  template< typename EXEC_POLICY, typename ATOMIC_POLICY, typename FE_TYPE >
   static void
   Compute3DSourceAndReceiverConstantsWithDAS( localIndex const size,
                                               ArrayOfArraysView< localIndex const > const baseFacesToNodes,
@@ -602,7 +602,10 @@ struct PreComputeSourcesAndReceivers
                 receiverConstants[ircv][iSample * numNodesPerElem + a] += N[a] * sampleIntegrationConstants[ iSample ];
               }
             }
-            receiverIsLocal[ ircv ] = 2;
+            if( receiverIsLocal[ircv] != 1 )
+            {
+              RAJA::atomicCAS< ATOMIC_POLICY >( &receiverIsLocal[ ircv ], 0, 2 );
+            }
           }
         } // end loop over samples
         // determine if the current rank is the owner of this receiver
@@ -619,7 +622,7 @@ struct PreComputeSourcesAndReceivers
                                                                       coords );
         if( receiverFound && elemGhostRank[k] < 0 )
         {
-          receiverIsLocal[ ircv ] = 1;
+          RAJA::atomicExchange< ATOMIC_POLICY >( &receiverIsLocal[ ircv ], 1 );
         }
       } // end loop over receivers
     } );


### PR DESCRIPTION
This bug was caused by non-atomized modifications of `receiverIsLocal`, which sometimes set this flag from `1` (this rank is responsible for writing the receiver data) to `2` (this rank must compute receiver data but is not responsible for writing). 
This PR corrects the bug by introducing a condition on update and an appropriate, and by atomizing the update of the array in the case of DAS data.
Also, another bug is resolved by only initializing geophone if and only if DAS is inactive. Both were initialized, resulting in empty files being generated.