### PR TITLE
fix: Keep XML validation log in build directory

### DIFF
--- a/scripts/validateXMLFiles.bash
+++ b/scripts/validateXMLFiles.bash
@@ -7,7 +7,7 @@ if [ -z "$1" ]; then
 fi
 
 SCHEMA=$1; shift
-LOGFILE=xml_validation_results.log
+LOGFILE=$(pwd)/xml_validation_results.log
 
 # "-r" in GNU xargs omits the call if input is empty
 # OS X xargs does not support it, but does the same by default


### PR DESCRIPTION
The xml validation log ends up with the sources instead of being in the build directory.

Follow up to #3588 with the change at [validateXMLFiles.bash:49](https://github.com/GEOS-DEV/GEOS/blob/c9886616ac7772eb43fdfdf98b81565d5a6e7bc3/scripts/validateXMLFiles.bash#L49)