### PR TITLE
fix: time step logic for sequential

### DIFF
--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3537-10973-fe0f2c7
+  baseline: integratedTests/baseline_integratedTests-pr3624-11053-ae011c7
 
 allow_fail:
   all: ''

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -6,6 +6,10 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
+PR #3624 (2025-04-15)
+=====================
+Bugfix for time step cut in sequential, minor time step logic change when a cut occurs.
+
 PR #3537 (2025-04-02)
 =====================
 Added two attributes to TableFunction: writeCSV and logLevel.

--- a/src/coreComponents/physicsSolvers/NonlinearSolverParameters.cpp
+++ b/src/coreComponents/physicsSolvers/NonlinearSolverParameters.cpp
@@ -128,7 +128,7 @@ NonlinearSolverParameters::NonlinearSolverParameters( string const & name,
     setDescription( "Factor by which the time-step is increased when the number of Newton iterations is small." );
 
   registerWrapper( viewKeysStruct::minTimeStepIncreaseIntervalString(), &m_minTimeStepIncreaseInterval ).
-    setApplyDefaultValue( 3 ).
+    setApplyDefaultValue( 10 ).
     setInputFlag( InputFlags::OPTIONAL ).
     setDescription( "Minimum number of steps since the last time-step cut for increasing the time-step again." );
 

--- a/src/coreComponents/physicsSolvers/NonlinearSolverParameters.cpp
+++ b/src/coreComponents/physicsSolvers/NonlinearSolverParameters.cpp
@@ -128,9 +128,9 @@ NonlinearSolverParameters::NonlinearSolverParameters( string const & name,
     setDescription( "Factor by which the time-step is increased when the number of Newton iterations is small." );
 
   registerWrapper( viewKeysStruct::minTimeStepIncreaseIntervalString(), &m_minTimeStepIncreaseInterval ).
-    setApplyDefaultValue( 10 ).
+    setApplyDefaultValue( 3 ).
     setInputFlag( InputFlags::OPTIONAL ).
-    setDescription( "Minimum number of cycles since the last time-step cut for increasing the time-step again." );
+    setDescription( "Minimum number of steps since the last time-step cut for increasing the time-step again." );
 
   registerWrapper( viewKeysStruct::timeStepCutFactorString(), &m_timeStepCutFactor ).
     setApplyDefaultValue( 0.5 ).

--- a/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
@@ -356,26 +356,6 @@ real64 PhysicsSolverBase::setNextDt( real64 const & GEOS_UNUSED_PARAM( currentTi
                                      real64 const & currentDt,
                                      DomainPartition & domain )
 {
-  if( m_numTimestepsSinceLastDtCut >= 0 )
-  {
-    // Increase counter to indicate how many cycles since the last timestep cut
-    m_numTimestepsSinceLastDtCut++;
-
-    integer const minTimeStepIncreaseInterval = m_nonlinearSolverParameters.minTimeStepIncreaseInterval();
-    if( m_numTimestepsSinceLastDtCut < minTimeStepIncreaseInterval )
-    {
-      GEOS_LOG_LEVEL_RANK_0( logInfo::TimeStep,
-                             GEOS_FMT( "{}: time-step size will be kept the same since it's been {} cycles since last cut.",
-                                       getName(), m_numTimestepsSinceLastDtCut ) );
-      return currentDt;
-    }
-    else
-    {
-      // Reset the counter
-      m_numTimestepsSinceLastDtCut = -1;
-    }
-  }
-
   real64 const nextDtIter  = setNextDtBasedOnIterNumber( currentDt );
   GEOS_LOG_LEVEL_RANK_0_ON_GROUP( logInfo::TimeStep,
                                   GEOS_FMT( "{}: next time step based on number of iterations = {}", getName(), nextDtIter ),
@@ -427,7 +407,29 @@ real64 PhysicsSolverBase::setNextDt( real64 const & GEOS_UNUSED_PARAM( currentTi
     }
   }
 
-  return std::min( nextDtIter, nextDtStateChange );
+  real64 nextDt = LvArray::math::min( nextDtIter, nextDtStateChange );
+
+  if( m_numTimestepsSinceLastDtCut >= 0 )
+  {
+    // Increase counter to indicate how many steps since the last timestep cut
+    m_numTimestepsSinceLastDtCut++;
+
+    integer const minTimeStepIncreaseInterval = m_nonlinearSolverParameters.minTimeStepIncreaseInterval();
+    if( m_numTimestepsSinceLastDtCut < minTimeStepIncreaseInterval )
+    {
+      GEOS_LOG_LEVEL_RANK_0( logInfo::TimeStep,
+                             GEOS_FMT( "{}: time-step size will capped at {} s since it's been {} steps since last cut.",
+                                       getName(), currentDt, m_numTimestepsSinceLastDtCut ) );
+      nextDt = LvArray::math::min( nextDt, currentDt );
+    }
+    else
+    {
+      // Reset the counter
+      m_numTimestepsSinceLastDtCut = -1;
+    }
+  }
+
+  return nextDt;
 }
 
 real64 PhysicsSolverBase::setNextDtBasedOnStateChange( real64 const & currentDt,

--- a/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
@@ -260,15 +260,6 @@ bool PhysicsSolverBase::execute( real64 const time_n,
 {
   GEOS_MARK_FUNCTION;
 
-  /*
-   * Reset counter indicating the number of cycles since the last timestep cut
-   * when the new timestep. "-1" means that no time-step cut has ocurred.
-   * */
-  if( dt < m_nextDt )
-  {
-    m_numTimestepsSinceLastDtCut = -1;
-  }
-
   real64 dtRemaining = dt;
   real64 nextDt = dt;
 
@@ -338,12 +329,6 @@ bool PhysicsSolverBase::execute( real64 const time_n,
   // Decide what to do with the next Dt for the event running the solver.
   m_nextDt = setNextDt( time_n + dt, nextDt, domain );
 
-  // Increase counter to indicate how many cycles since the last timestep cut
-  if( m_numTimestepsSinceLastDtCut >= 0 )
-  {
-    m_numTimestepsSinceLastDtCut++;
-  }
-
   logEndOfCycleInformation( cycleNumber, numOfSubSteps, subStepDt );
 
   return false;
@@ -371,7 +356,26 @@ real64 PhysicsSolverBase::setNextDt( real64 const & GEOS_UNUSED_PARAM( currentTi
                                      real64 const & currentDt,
                                      DomainPartition & domain )
 {
-  integer const minTimeStepIncreaseInterval = m_nonlinearSolverParameters.minTimeStepIncreaseInterval();
+  if( m_numTimestepsSinceLastDtCut >= 0 )
+  {
+    // Increase counter to indicate how many cycles since the last timestep cut
+    m_numTimestepsSinceLastDtCut++;
+
+    integer const minTimeStepIncreaseInterval = m_nonlinearSolverParameters.minTimeStepIncreaseInterval();
+    if( m_numTimestepsSinceLastDtCut < minTimeStepIncreaseInterval )
+    {
+      GEOS_LOG_LEVEL_RANK_0( logInfo::TimeStep,
+                             GEOS_FMT( "{}: time-step size will be kept the same since it's been {} cycles since last cut.",
+                                       getName(), m_numTimestepsSinceLastDtCut ) );
+      return currentDt;
+    }
+    else
+    {
+      // Reset the counter
+      m_numTimestepsSinceLastDtCut = -1;
+    }
+  }
+
   real64 const nextDtIter  = setNextDtBasedOnIterNumber( currentDt );
   GEOS_LOG_LEVEL_RANK_0_ON_GROUP( logInfo::TimeStep,
                                   GEOS_FMT( "{}: next time step based on number of iterations = {}", getName(), nextDtIter ),
@@ -379,14 +383,6 @@ real64 PhysicsSolverBase::setNextDt( real64 const & GEOS_UNUSED_PARAM( currentTi
   real64 const nextDtStateChange = setNextDtBasedOnStateChange( currentDt, domain );
   GEOS_LOG_LEVEL_RANK_0( logInfo::TimeStep,
                          GEOS_FMT( "{}: next time step based on state change = {}", getName(), nextDtStateChange ));
-
-  if( ( m_numTimestepsSinceLastDtCut >= 0 ) && ( m_numTimestepsSinceLastDtCut < minTimeStepIncreaseInterval ) )
-  {
-    GEOS_LOG_LEVEL_RANK_0( logInfo::TimeStep,
-                           GEOS_FMT( "{}: time-step size will be kept the same since it's been {} cycles since last cut.",
-                                     getName(), m_numTimestepsSinceLastDtCut ) );
-    return currentDt;
-  }
 
   if( nextDtIter < nextDtStateChange )      // time step size decided based on convergence
   {

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
@@ -535,6 +535,7 @@ protected:
       {
         // cut timestep, go back to beginning of step and restart the Newton loop
         stepDt *= dtCutFactor;
+        m_numTimestepsSinceLastDtCut = 0;
         GEOS_LOG_LEVEL_RANK_0( logInfo::TimeStep, GEOS_FMT( "New dt = {}", stepDt ) );
 
         // notify the solver statistics counter that this is a time step cut

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
@@ -498,6 +498,7 @@ protected:
           {
             iter = 0; // restart outer loop
             stepDt = solverDt; // sync time step
+            m_numTimestepsSinceLastDtCut = 0;
           }
         } );
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
@@ -1007,8 +1007,6 @@ void SolidMechanicsLagrangianFEM::setupSystem( DomainPartition & domain,
                                                ParallelVector & solution,
                                                bool const setSparsity )
 {
-  GEOS_LOG( "SolidMechanicsLagrangianFEM::setupSystem" );
-
   GEOS_MARK_FUNCTION;
   PhysicsSolverBase::setupSystem( domain, dofManager, localMatrix, rhs, solution, setSparsity );
 


### PR DESCRIPTION
fix time step logic for sequential
some parts of the logic introduced in https://github.com/GEOS-DEV/GEOS/pull/3338 happen in `PhysicsSolverBase::execute` which is not executed for subsolvers of a coupled solver, while time step cut actually happens in a specific subsolver
this PR tries to centralize the logic within `PhysicsSolverBase::setNextDt` that should fix the issue when solver can not increase time step after a cut