### PR TITLE
fix: Unsafe access to std::vector without bounds check

### DIFF
--- a/src/coreComponents/common/format/table/TableFormatter.cpp
+++ b/src/coreComponents/common/format/table/TableFormatter.cpp
@@ -475,9 +475,8 @@ void TableTextFormatter::stretchColumnsByMergedCellsWidth( std::vector< size_t >
       {
         CellLayoutRow & row = tableGrid[rowId];
         TableLayout::CellLayout const & cell = row.cells[columnId];
-        TableLayout::CellLayout const & leftCell = row.cells[columnId - 1];
         bool const isToMergeWithRight = cell.m_cellType == CellType::MergeNext;
-        bool const isToMergeWithLeft = columnId > 0 && leftCell.m_cellType == CellType::MergeNext;
+        bool const isToMergeWithLeft = columnId > 0 && row.cells[columnId - 1].m_cellType == CellType::MergeNext;
         bool const isFirstToMerge = isToMergeWithRight && !isToMergeWithLeft;
         if( isFirstToMerge )
         { // we detected a set of cells to merge, let's compute its total width

--- a/src/coreComponents/common/format/table/TableFormatter.cpp
+++ b/src/coreComponents/common/format/table/TableFormatter.cpp
@@ -476,7 +476,7 @@ void TableTextFormatter::stretchColumnsByMergedCellsWidth( stdVector< size_t > &
         CellLayoutRow & row = tableGrid[rowId];
         TableLayout::CellLayout const & cell = row.cells[columnId];
         bool const isToMergeWithRight = cell.m_cellType == CellType::MergeNext;
-bool const isToMergeWithLeft = ( columnId > 0 ) ? ( row.cells[columnId - 1].m_cellType == CellType::MergeNext ) : false; 
+        bool const isToMergeWithLeft = ( columnId > 0 ) ? ( row.cells[columnId - 1].m_cellType == CellType::MergeNext ) : false; 
         bool const isFirstToMerge = isToMergeWithRight && !isToMergeWithLeft;
         if( isFirstToMerge )
         { // we detected a set of cells to merge, let's compute its total width

--- a/src/coreComponents/common/format/table/TableFormatter.cpp
+++ b/src/coreComponents/common/format/table/TableFormatter.cpp
@@ -476,7 +476,7 @@ void TableTextFormatter::stretchColumnsByMergedCellsWidth( stdVector< size_t > &
         CellLayoutRow & row = tableGrid[rowId];
         TableLayout::CellLayout const & cell = row.cells[columnId];
         bool const isToMergeWithRight = cell.m_cellType == CellType::MergeNext;
-        bool const isToMergeWithLeft = ( columnId > 0 ) ? ( row.cells[columnId - 1].m_cellType == CellType::MergeNext ) : false; 
+        bool const isToMergeWithLeft = ( columnId > 0 ) ? ( row.cells[columnId - 1].m_cellType == CellType::MergeNext ) : false;
         bool const isFirstToMerge = isToMergeWithRight && !isToMergeWithLeft;
         if( isFirstToMerge )
         { // we detected a set of cells to merge, let's compute its total width

--- a/src/coreComponents/common/format/table/TableFormatter.cpp
+++ b/src/coreComponents/common/format/table/TableFormatter.cpp
@@ -476,7 +476,7 @@ void TableTextFormatter::stretchColumnsByMergedCellsWidth( stdVector< size_t > &
         CellLayoutRow & row = tableGrid[rowId];
         TableLayout::CellLayout const & cell = row.cells[columnId];
         bool const isToMergeWithRight = cell.m_cellType == CellType::MergeNext;
-        bool const isToMergeWithLeft = columnId > 0 && row.cells[columnId - 1].m_cellType == CellType::MergeNext;
+bool const isToMergeWithLeft = ( columnId > 0 ) ? ( row.cells[columnId - 1].m_cellType == CellType::MergeNext ) : false; 
         bool const isFirstToMerge = isToMergeWithRight && !isToMergeWithLeft;
         if( isFirstToMerge )
         { // we detected a set of cells to merge, let's compute its total width

--- a/src/coreComponents/mesh/generators/VTKUtilities.cpp
+++ b/src/coreComponents/mesh/generators/VTKUtilities.cpp
@@ -1435,17 +1435,17 @@ std::vector< localIndex > getWedgeNodeOrderingFromPolyhedron( vtkCell * const ce
   {
     auto edgeNode0 = cell->GetEdge( iEdge )->GetPointId( 0 );
     auto edgeNode1 = cell->GetEdge( iEdge )->GetPointId( 1 );
-    auto it0 = std::find( &nodeTri0[0], &nodeTri0[3], edgeNode0 );
-    auto it1 = std::find( &nodeTri0[0], &nodeTri0[3], edgeNode1 );
+    auto it0 = std::find( nodeTri0.begin(), nodeTri0.end(), edgeNode0 );
+    auto it1 = std::find( nodeTri0.begin(), nodeTri0.end(), edgeNode1 );
 
-    if( it0 != &nodeTri0[3] && it1 == &nodeTri0[3] )
+    if( it0 != nodeTri0.end() && it1 == nodeTri0.end() )
     {
-      nodeTri1[std::distance( &nodeTri0[0], it0 )] = edgeNode1;
+      nodeTri1[std::distance( nodeTri0.begin(), it0 )] = edgeNode1;
     }
 
-    if( it0 == &nodeTri0[3] && it1 != &nodeTri0[3] )
+    if( it0 == nodeTri0.end() && it1 != nodeTri0.end() )
     {
-      nodeTri1[std::distance( &nodeTri0[0], it1 )] = edgeNode0;
+      nodeTri1[std::distance( nodeTri0.begin(), it1 )] = edgeNode0;
     }
   }
 

--- a/src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp
+++ b/src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp
@@ -1030,7 +1030,7 @@ bool CommunicationTools::asyncUnpack( MeshLevel & mesh,
   MpiWrapper::testSome( icomm.size(),
                         icomm.mpiRecvBufferRequest(),
                         &recvCount,
-                        &*neighborIndices.begin(),
+                        neighborIndices.data(),
                         icomm.mpiRecvBufferStatus() );
 
   for( int recvIdx = 0; recvIdx < recvCount; ++recvIdx )

--- a/src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp
+++ b/src/coreComponents/mesh/mpiCommunications/CommunicationTools.cpp
@@ -1030,7 +1030,7 @@ bool CommunicationTools::asyncUnpack( MeshLevel & mesh,
   MpiWrapper::testSome( icomm.size(),
                         icomm.mpiRecvBufferRequest(),
                         &recvCount,
-                        &neighborIndices[0],
+                        &*neighborIndices.begin(),
                         icomm.mpiRecvBufferStatus() );
 
   for( int recvIdx = 0; recvIdx < recvCount; ++recvIdx )


### PR DESCRIPTION

Ensure safe access in the [L478](https://github.com/GEOS-DEV/GEOS/blob/4aa2c9fd542b18cbbb493580a461f53cb33f2e42/src/coreComponents/common/format/table/TableFormatter.cpp#L478) of file src/coreComponents/common/format/table/TableFormatter.cpp.

fix issue #3627.