### PR TITLE
fix: Fix compilation errors with gcc 13

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/kernels/CompositionalMultiphaseWellKernels.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/kernels/CompositionalMultiphaseWellKernels.cpp
@@ -632,6 +632,7 @@ PresTempCompFracInitializationKernel::
   RAJA::ReduceMax< parallelDeviceReduce, integer > foundNegativePres( 0 );
   RAJA::ReduceMax< parallelDeviceReduce, integer > foundInconsistentCompFrac( 0 );
 
+  auto const avgCompFracView = avgCompFrac.toViewConst();
 
   forAll< parallelDevicePolicy<> >( subRegionSize, [=] GEOS_HOST_DEVICE ( localIndex const iwelem )
   {
@@ -641,7 +642,7 @@ PresTempCompFracInitializationKernel::
     real64 sumCompFracForCheck = 0.0;
     for( integer ic = 0; ic < numComps; ++ic )
     {
-      wellElemCompFrac[iwelem][ic] = avgCompFrac[ic];
+      wellElemCompFrac[iwelem][ic] = avgCompFracView[ic];
       sumCompFracForCheck += wellElemCompFrac[iwelem][ic];
     }
 

--- a/src/coreComponents/unitTests/constitutiveTests/MultiFluidTest.hpp
+++ b/src/coreComponents/unitTests/constitutiveTests/MultiFluidTest.hpp
@@ -225,13 +225,13 @@ testNumericalDerivatives( constitutive::MultiFluidBase & fluid,
     GET_FLUID_DATA( fluid, fields::multifluid::dTotalDensity )
   };
 
-  auto phaseFracCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseFraction );
-  auto phaseDensCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseDensity );
-  auto phaseViscCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseViscosity );
-  auto phaseEnthCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseEnthalpy );
-  auto phaseEnergyCopy   = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseInternalEnergy );
-  auto phaseCompFracCopy = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseCompFraction );
-  auto totalDensCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::totalDensity );
+  auto const & phaseFracCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseFraction );
+  auto const & phaseDensCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseDensity );
+  auto const & phaseViscCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseViscosity );
+  auto const & phaseEnthCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseEnthalpy );
+  auto const & phaseEnergyCopy   = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseInternalEnergy );
+  auto const & phaseCompFracCopy = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseCompFraction );
+  real64 totalDensCopy = 0.0;
 
 #undef GET_FLUID_DATA
 
@@ -282,6 +282,8 @@ testNumericalDerivatives( constitutive::MultiFluidBase & fluid,
       resetFluid( fluidCopy );
       fluidWrapper.update( 0, 0, pressure + dP, temperature, composition );
 
+      totalDensCopy = fluidCopy.totalDensity()( 0, 0 );
+
       checkDerivative( phaseFracCopy.toSliceConst(), phaseFrac.value.toSliceConst(), dPhaseFrac[Deriv::dP].toSliceConst(),
                        dP, relTol, absTol, "phaseFrac", "Pres", phases );
       checkDerivative( phaseDensCopy.toSliceConst(), phaseDens.value.toSliceConst(), dPhaseDens[Deriv::dP].toSliceConst(),
@@ -308,6 +310,8 @@ testNumericalDerivatives( constitutive::MultiFluidBase & fluid,
       real64 const dT = perturbParameter * (temperature + perturbParameter);
       resetFluid( fluidCopy );
       fluidWrapper.update( 0, 0, pressure, temperature + dT, composition );
+
+      totalDensCopy = fluidCopy.totalDensity()( 0, 0 );
 
       checkDerivative( phaseFracCopy.toSliceConst(), phaseFrac.value.toSliceConst(), dPhaseFrac[Deriv::dT].toSliceConst(),
                        dT, relTol, absTol, "phaseFrac", "Temp", phases );
@@ -366,6 +370,8 @@ testNumericalDerivatives( constitutive::MultiFluidBase & fluid,
 
       resetFluid( fluidCopy );
       fluidWrapper.update( 0, 0, pressure, temperature, compNew[0] );
+
+      totalDensCopy = fluidCopy.totalDensity()( 0, 0 );
 
       string const var = "compFrac[" + components[jc] + "]";
       checkDerivative( phaseFracCopy.toSliceConst(), phaseFrac.value.toSliceConst(), dPhaseFrac[Deriv::dC+jc].toSliceConst(),

--- a/src/coreComponents/unitTests/constitutiveTests/MultiFluidTest.hpp
+++ b/src/coreComponents/unitTests/constitutiveTests/MultiFluidTest.hpp
@@ -225,13 +225,13 @@ testNumericalDerivatives( constitutive::MultiFluidBase & fluid,
     GET_FLUID_DATA( fluid, fields::multifluid::dTotalDensity )
   };
 
-  auto const phaseFracCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseFraction );
-  auto const phaseDensCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseDensity );
-  auto const phaseViscCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseViscosity );
-  auto const phaseEnthCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseEnthalpy );
-  auto const phaseEnergyCopy   = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseInternalEnergy );
-  auto const phaseCompFracCopy = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseCompFraction );
-  auto const totalDensCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::totalDensity );
+  auto phaseFracCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseFraction );
+  auto phaseDensCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseDensity );
+  auto phaseViscCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseViscosity );
+  auto phaseEnthCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseEnthalpy );
+  auto phaseEnergyCopy   = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseInternalEnergy );
+  auto phaseCompFracCopy = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseCompFraction );
+  auto totalDensCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::totalDensity );
 
 #undef GET_FLUID_DATA
 

--- a/src/coreComponents/unitTests/constitutiveTests/MultiFluidTest.hpp
+++ b/src/coreComponents/unitTests/constitutiveTests/MultiFluidTest.hpp
@@ -225,13 +225,13 @@ testNumericalDerivatives( constitutive::MultiFluidBase & fluid,
     GET_FLUID_DATA( fluid, fields::multifluid::dTotalDensity )
   };
 
-  auto const & phaseFracCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseFraction );
-  auto const & phaseDensCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseDensity );
-  auto const & phaseViscCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseViscosity );
-  auto const & phaseEnthCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseEnthalpy );
-  auto const & phaseEnergyCopy   = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseInternalEnergy );
-  auto const & phaseCompFracCopy = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseCompFraction );
-  auto const & totalDensCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::totalDensity );
+  auto const phaseFracCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseFraction );
+  auto const phaseDensCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseDensity );
+  auto const phaseViscCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseViscosity );
+  auto const phaseEnthCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseEnthalpy );
+  auto const phaseEnergyCopy   = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseInternalEnergy );
+  auto const phaseCompFracCopy = GET_FLUID_DATA( fluidCopy, fields::multifluid::phaseCompFraction );
+  auto const totalDensCopy     = GET_FLUID_DATA( fluidCopy, fields::multifluid::totalDensity );
 
 #undef GET_FLUID_DATA
 


### PR DESCRIPTION
Resolves #3585 
- Ensures that kernel launch captures `ArrayView` instead of `Array`
- Removes dangling references