### PR TITLE
refactor: split functionality of addToFractureMesh

### DIFF
--- a/src/coreComponents/mesh/SurfaceElementRegion.cpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.cpp
@@ -89,11 +89,10 @@ void SurfaceElementRegion::initializePreSubGroups()
 
 localIndex SurfaceElementRegion::addToSurfaceMesh( FaceManager const * const faceManager,
                                                    ArrayOfArraysView< localIndex const >  const & originalFaceToEdgeMap,
-                                                   localIndex const faceIndices[2],
-                                                   SortedArray< localIndex > & connectedEdges )
+                                                   localIndex const faceIndices[2])
 {
   localIndex rval = -1;
-
+  SortedArray< localIndex > connectedEdges;
   arrayView2d< localIndex const > const faceToElementRegion = faceManager->elementRegionList();
   arrayView2d< localIndex const > const faceToElementSubRegion = faceManager->elementSubRegionList();
   arrayView2d< localIndex const > const faceToElementIndex = faceManager->elementList();
@@ -187,17 +186,19 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
                                                     ArrayOfArraysView< localIndex const >  const & originalFaceToEdgeMap,
                                                     localIndex const faceIndices[2] )
 {
-  SortedArray< localIndex > connectedEdges;
-  localIndex const kfe = this->addToSurfaceMesh( faceManager, originalFaceToEdgeMap, faceIndices, connectedEdges );
+  localIndex const kfe = this->addToSurfaceMesh( faceManager, originalFaceToEdgeMap, faceIndices);
 
   FaceElementSubRegion & subRegion = this->getUniqueSubRegion< FaceElementSubRegion >();
   arrayView1d< real64 > const ruptureTime = subRegion.getField< fields::ruptureTime >();
   ruptureTime( kfe ) = time_np1;
 
+  SurfaceElementSubRegion::EdgeMapType & edgeMap = subRegion.edgeList();
   // Fill the connectivity between FaceElement entries. This is essentially a copy of the
   // edgesToFaces map, but with differing offsets.
-  for( auto const & edge : connectedEdges )
+  for( localIndex a = 0; a < edgeMap.sizeOfArray(kfe); ++a )
   {
+    const localIndex edge = edgeMap[kfe][a];
+    
     // check to see if the edgesToFractureConnectors already have an entry
     if( subRegion.m_edgesTo2dFaces.count( edge )==0 )
     {

--- a/src/coreComponents/mesh/SurfaceElementRegion.cpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.cpp
@@ -89,7 +89,7 @@ void SurfaceElementRegion::initializePreSubGroups()
 
 localIndex SurfaceElementRegion::addToSurfaceMesh( FaceManager const * const faceManager,
                                                    ArrayOfArraysView< localIndex const >  const & originalFaceToEdgeMap,
-                                                   localIndex const faceIndices[2])
+                                                   localIndex const faceIndices[2] )
 {
   localIndex rval = -1;
   SortedArray< localIndex > connectedEdges;
@@ -186,7 +186,7 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
                                                     ArrayOfArraysView< localIndex const >  const & originalFaceToEdgeMap,
                                                     localIndex const faceIndices[2] )
 {
-  localIndex const kfe = this->addToSurfaceMesh( faceManager, originalFaceToEdgeMap, faceIndices);
+  localIndex const kfe = this->addToSurfaceMesh( faceManager, originalFaceToEdgeMap, faceIndices );
 
   FaceElementSubRegion & subRegion = this->getUniqueSubRegion< FaceElementSubRegion >();
   arrayView1d< real64 > const ruptureTime = subRegion.getField< fields::ruptureTime >();
@@ -195,10 +195,10 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
   SurfaceElementSubRegion::EdgeMapType & edgeMap = subRegion.edgeList();
   // Fill the connectivity between FaceElement entries. This is essentially a copy of the
   // edgesToFaces map, but with differing offsets.
-  for( localIndex a = 0; a < edgeMap.sizeOfArray(kfe); ++a )
+  for( localIndex a = 0; a < edgeMap.sizeOfArray( kfe ); ++a )
   {
     const localIndex edge = edgeMap[kfe][a];
-    
+
     // check to see if the edgesToFractureConnectors already have an entry
     if( subRegion.m_edgesTo2dFaces.count( edge )==0 )
     {

--- a/src/coreComponents/mesh/SurfaceElementRegion.cpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.cpp
@@ -87,10 +87,9 @@ void SurfaceElementRegion::initializePreSubGroups()
   } );
 }
 
-localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
-                                                    FaceManager const * const faceManager,
-                                                    ArrayOfArraysView< localIndex const >  const & originalFaceToEdgeMap,
-                                                    localIndex const faceIndices[2] )
+localIndex SurfaceElementRegion::addToSurfaceMesh( FaceManager const * const faceManager,
+                                                   ArrayOfArraysView< localIndex const >  const & originalFaceToEdgeMap,
+                                                   localIndex const faceIndices[2] )
 {
   localIndex rval = -1;
 
@@ -103,9 +102,6 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
   FaceElementSubRegion & subRegion = this->getUniqueSubRegion< FaceElementSubRegion >();
   subRegion.resize( subRegion.size() + 1 );
   rval = subRegion.size() - 1;
-
-
-  arrayView1d< real64 > const ruptureTime = subRegion.getField< fields::ruptureTime >();
 
   arrayView2d< real64 const > const faceCenter = faceManager->faceCenter();
   arrayView2d< real64 > const elemCenter = subRegion.getElementCenter();
@@ -121,7 +117,6 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
   ArrayOfArraysView< localIndex const > const faceToNodeMap = faceManager->nodeList().toViewConst();
 
   localIndex const kfe = subRegion.size() - 1;
-  ruptureTime( kfe ) = time_np1;
 
   LvArray::tensorOps::copy< 3 >( elemCenter[ kfe ], faceCenter[ faceIndices[ 0 ] ] );
 
@@ -185,36 +180,56 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
     }
   }
 
-  // Fill the connectivity between FaceElement entries. This is essentially a copy of the
-  // edgesToFaces map, but with differing offsets.
+  return rval;
+}
+
+localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
+                                                    FaceManager const * const faceManager,
+                                                    ArrayOfArraysView< localIndex const >  const & originalFaceToEdgeMap,
+                                                    localIndex const faceIndices[2] )
+{
+
+  localIndex const kfe = this->addToSurfaceMesh( faceManager, originalFaceToEdgeMap, faceIndices );
+
+  FaceElementSubRegion & subRegion = this->getUniqueSubRegion< FaceElementSubRegion >();
+  arrayView1d< real64 > const ruptureTime = subRegion.getField< fields::ruptureTime >();
+  ruptureTime( kfe ) = time_np1;
+
+  SurfaceElementSubRegion::EdgeMapType & edgeMap = subRegion.edgeList();
+  SortedArray< localIndex > connectedEdges;
+  for( localIndex a = 0; a < edgeMap.sizeOfArray( kfe ); ++a )
+  {
+    connectedEdges.insert( edgeMap[kfe][a] );
+  }
+
   for( auto const & edge : connectedEdges )
   {
-    // check to see if the edgesToFractureConnectors already have an entry
-    if( subRegion.m_edgesTo2dFaces.count( edge )==0 )
+    if( subRegion.m_edgesTo2dFaces.count( edge ) == 0 )
     {
-      // if not, then fill increase the size of the fractureConnectors to face elements map and
-      // fill the fractureConnectorsToEdges map with the current edge....and the inverse map too.
       subRegion.m_2dFaceTo2dElems.appendArray( 0 );
       subRegion.m_2dFaceToEdge.emplace_back( edge );
-      subRegion.m_edgesTo2dFaces[edge] = subRegion.m_2dFaceToEdge.size()-1;
+      subRegion.m_edgesTo2dFaces[edge] = subRegion.m_2dFaceToEdge.size() - 1;
     }
-    // now fill the fractureConnectorsToFaceElements map. This is analogous to the edge to face map
+
     localIndex const connectorIndex = subRegion.m_edgesTo2dFaces[edge];
     localIndex const numCells = subRegion.m_2dFaceTo2dElems.sizeOfArray( connectorIndex ) + 1;
     subRegion.m_2dFaceTo2dElems.resizeArray( connectorIndex, numCells );
-    subRegion.m_2dFaceTo2dElems[connectorIndex][ numCells-1 ] = kfe;
+    subRegion.m_2dFaceTo2dElems[connectorIndex][ numCells - 1 ] = kfe;
 
-    // And fill the list of connectors that will need stencil modifications
     subRegion.m_recalculateConnectionsFor2dFaces.insert( connectorIndex );
   }
 
   subRegion.calculateSingleElementGeometricQuantities( kfe, faceManager->faceArea() );
 
-  // update the sets
+  FaceElementSubRegion::FaceMapType & faceMap = subRegion.faceList();
   for( auto const & setIter : faceManager->sets().wrappers() )
   {
-    SortedArrayView< localIndex const > const & faceSet = faceManager->sets().getReference< SortedArray< localIndex > >( setIter.first );
-    SortedArray< localIndex > & faceElementSet = subRegion.sets().registerWrapper< SortedArray< localIndex > >( setIter.first ).reference();
+    SortedArrayView< localIndex const > const & faceSet =
+      faceManager->sets().getReference< SortedArray< localIndex > >( setIter.first );
+
+    SortedArray< localIndex > & faceElementSet =
+      subRegion.sets().registerWrapper< SortedArray< localIndex > >( setIter.first ).reference();
+
     for( localIndex a = 0; a < faceMap.size( 0 ); ++a )
     {
       if( faceSet.count( faceMap[a][0] ) )
@@ -224,7 +239,7 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
     }
   }
 
-  return rval;
+  return kfe;
 }
 
 

--- a/src/coreComponents/mesh/SurfaceElementRegion.cpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.cpp
@@ -89,11 +89,10 @@ void SurfaceElementRegion::initializePreSubGroups()
 
 localIndex SurfaceElementRegion::addToSurfaceMesh( FaceManager const * const faceManager,
                                                    ArrayOfArraysView< localIndex const >  const & originalFaceToEdgeMap,
-                                                   localIndex const faceIndices[2] )
+                                                   localIndex const faceIndices[2],
+                                                   SortedArray< localIndex > & connectedEdges )
 {
   localIndex rval = -1;
-
-  SortedArray< localIndex > connectedEdges;
 
   arrayView2d< localIndex const > const faceToElementRegion = faceManager->elementRegionList();
   arrayView2d< localIndex const > const faceToElementSubRegion = faceManager->elementSubRegionList();
@@ -188,48 +187,44 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
                                                     ArrayOfArraysView< localIndex const >  const & originalFaceToEdgeMap,
                                                     localIndex const faceIndices[2] )
 {
-
-  localIndex const kfe = this->addToSurfaceMesh( faceManager, originalFaceToEdgeMap, faceIndices );
+  SortedArray< localIndex > connectedEdges;
+  localIndex const kfe = this->addToSurfaceMesh( faceManager, originalFaceToEdgeMap, faceIndices, connectedEdges );
 
   FaceElementSubRegion & subRegion = this->getUniqueSubRegion< FaceElementSubRegion >();
   arrayView1d< real64 > const ruptureTime = subRegion.getField< fields::ruptureTime >();
   ruptureTime( kfe ) = time_np1;
 
-  SurfaceElementSubRegion::EdgeMapType & edgeMap = subRegion.edgeList();
-  SortedArray< localIndex > connectedEdges;
-  for( localIndex a = 0; a < edgeMap.sizeOfArray( kfe ); ++a )
-  {
-    connectedEdges.insert( edgeMap[kfe][a] );
-  }
-
+  // Fill the connectivity between FaceElement entries. This is essentially a copy of the
+  // edgesToFaces map, but with differing offsets.
   for( auto const & edge : connectedEdges )
   {
-    if( subRegion.m_edgesTo2dFaces.count( edge ) == 0 )
+    // check to see if the edgesToFractureConnectors already have an entry
+    if( subRegion.m_edgesTo2dFaces.count( edge )==0 )
     {
+      // if not, then fill increase the size of the fractureConnectors to face elements map and
+      // fill the fractureConnectorsToEdges map with the current edge....and the inverse map too.
       subRegion.m_2dFaceTo2dElems.appendArray( 0 );
       subRegion.m_2dFaceToEdge.emplace_back( edge );
-      subRegion.m_edgesTo2dFaces[edge] = subRegion.m_2dFaceToEdge.size() - 1;
+      subRegion.m_edgesTo2dFaces[edge] = subRegion.m_2dFaceToEdge.size()-1;
     }
-
+    // now fill the fractureConnectorsToFaceElements map. This is analogous to the edge to face map
     localIndex const connectorIndex = subRegion.m_edgesTo2dFaces[edge];
     localIndex const numCells = subRegion.m_2dFaceTo2dElems.sizeOfArray( connectorIndex ) + 1;
     subRegion.m_2dFaceTo2dElems.resizeArray( connectorIndex, numCells );
-    subRegion.m_2dFaceTo2dElems[connectorIndex][ numCells - 1 ] = kfe;
+    subRegion.m_2dFaceTo2dElems[connectorIndex][ numCells-1 ] = kfe;
 
+    // And fill the list of connectors that will need stencil modifications
     subRegion.m_recalculateConnectionsFor2dFaces.insert( connectorIndex );
   }
 
   subRegion.calculateSingleElementGeometricQuantities( kfe, faceManager->faceArea() );
 
-  FaceElementSubRegion::FaceMapType & faceMap = subRegion.faceList();
+  // update the sets
+  FaceElementSubRegion::FaceMapType const & faceMap = subRegion.faceList();
   for( auto const & setIter : faceManager->sets().wrappers() )
   {
-    SortedArrayView< localIndex const > const & faceSet =
-      faceManager->sets().getReference< SortedArray< localIndex > >( setIter.first );
-
-    SortedArray< localIndex > & faceElementSet =
-      subRegion.sets().registerWrapper< SortedArray< localIndex > >( setIter.first ).reference();
-
+    SortedArrayView< localIndex const > const & faceSet = faceManager->sets().getReference< SortedArray< localIndex > >( setIter.first );
+    SortedArray< localIndex > & faceElementSet = subRegion.sets().registerWrapper< SortedArray< localIndex > >( setIter.first ).reference();
     for( localIndex a = 0; a < faceMap.size( 0 ); ++a )
     {
       if( faceSet.count( faceMap[a][0] ) )

--- a/src/coreComponents/mesh/SurfaceElementRegion.cpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.cpp
@@ -195,9 +195,11 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
   SurfaceElementSubRegion::EdgeMapType & edgeMap = subRegion.edgeList();
   // Fill the connectivity between FaceElement entries. This is essentially a copy of the
   // edgesToFaces map, but with differing offsets.
-  for( localIndex a = 0; a < edgeMap.sizeOfArray( kfe ); ++a )
+  localIndex const faceIndex = faceIndices[0];
+  localIndex const numEdges = originalFaceToEdgeMap.sizeOfArray( faceIndex );
+  for( localIndex a = 0; a < numEdges; ++a )
   {
-    const localIndex edge = edgeMap[kfe][a];
+    const localIndex edge = originalFaceToEdgeMap( faceIndex, a );
 
     // check to see if the edgesToFractureConnectors already have an entry
     if( subRegion.m_edgesTo2dFaces.count( edge )==0 )

--- a/src/coreComponents/mesh/SurfaceElementRegion.cpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.cpp
@@ -172,7 +172,7 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
                                                     ArrayOfArraysView< localIndex const >  const & originalFaceToEdgeMap,
                                                     localIndex const faceIndices[2] )
 {
-  localIndex const kfe = this->addToSurfaceMesh( faceManager, originalFaceToEdgeMap, faceIndices );
+  localIndex const kfe = this->addToSurfaceMesh( faceManager, faceIndices );
 
   FaceElementSubRegion & subRegion = this->getUniqueSubRegion< FaceElementSubRegion >();
   arrayView1d< real64 > const ruptureTime = subRegion.getField< fields::ruptureTime >();

--- a/src/coreComponents/mesh/SurfaceElementRegion.cpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.cpp
@@ -192,7 +192,6 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
   arrayView1d< real64 > const ruptureTime = subRegion.getField< fields::ruptureTime >();
   ruptureTime( kfe ) = time_np1;
 
-  SurfaceElementSubRegion::EdgeMapType & edgeMap = subRegion.edgeList();
   // Fill the connectivity between FaceElement entries. This is essentially a copy of the
   // edgesToFaces map, but with differing offsets.
   localIndex const faceIndex = faceIndices[0];

--- a/src/coreComponents/mesh/SurfaceElementRegion.cpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.cpp
@@ -92,7 +92,6 @@ localIndex SurfaceElementRegion::addToSurfaceMesh( FaceManager const * const fac
                                                    localIndex const faceIndices[2] )
 {
   localIndex rval = -1;
-  SortedArray< localIndex > connectedEdges;
   arrayView2d< localIndex const > const faceToElementRegion = faceManager->elementRegionList();
   arrayView2d< localIndex const > const faceToElementSubRegion = faceManager->elementSubRegionList();
   arrayView2d< localIndex const > const faceToElementIndex = faceManager->elementList();
@@ -109,7 +108,6 @@ localIndex SurfaceElementRegion::addToSurfaceMesh( FaceManager const * const fac
   arrayView1d< integer const > const faceGhostRank = faceManager->ghostRank();
 
   SurfaceElementSubRegion::NodeMapType & nodeMap = subRegion.nodeList();
-  SurfaceElementSubRegion::EdgeMapType & edgeMap = subRegion.edgeList();
   FaceElementSubRegion::FaceMapType & faceMap = subRegion.faceList();
 
   ArrayOfArraysView< localIndex const > const faceToNodeMap = faceManager->nodeList().toViewConst();
@@ -149,17 +147,6 @@ localIndex SurfaceElementRegion::addToSurfaceMesh( FaceManager const * const fac
     nodeMap[ kfe ][ 7 ] = faceToNodeMap( faceIndices[ 1 ], 2 );
   }
 
-  // Add the edges that compose the faceElement to the edge map. This is essentially a copy of
-  // the facesToEdges entry.
-  localIndex const faceIndex = faceIndices[0];
-  localIndex const numEdges = originalFaceToEdgeMap.sizeOfArray( faceIndex );
-  edgeMap.resizeArray( kfe, numEdges );
-  for( localIndex a=0; a<numEdges; ++a )
-  {
-    edgeMap[kfe][a] = originalFaceToEdgeMap( faceIndex, a );
-    connectedEdges.insert( originalFaceToEdgeMap( faceIndex, a ) );
-  }
-
   // Add the cell region/subregion/index to the faceElementToCells map
   FixedToManyElementRelation & faceElementsToCells = subRegion.getToCellRelation();
 
@@ -192,14 +179,23 @@ localIndex SurfaceElementRegion::addToFractureMesh( real64 const time_np1,
   arrayView1d< real64 > const ruptureTime = subRegion.getField< fields::ruptureTime >();
   ruptureTime( kfe ) = time_np1;
 
-  // Fill the connectivity between FaceElement entries. This is essentially a copy of the
-  // edgesToFaces map, but with differing offsets.
+  // Add the edges that compose the faceElement to the edge map. This is essentially a copy of
+  // the facesToEdges entry.
+  SurfaceElementSubRegion::EdgeMapType & edgeMap = subRegion.edgeList();
+  SortedArray< localIndex > connectedEdges;
   localIndex const faceIndex = faceIndices[0];
   localIndex const numEdges = originalFaceToEdgeMap.sizeOfArray( faceIndex );
-  for( localIndex a = 0; a < numEdges; ++a )
+  edgeMap.resizeArray( kfe, numEdges );
+  for( localIndex a=0; a<numEdges; ++a )
   {
-    const localIndex edge = originalFaceToEdgeMap( faceIndex, a );
+    edgeMap[kfe][a] = originalFaceToEdgeMap( faceIndex, a );
+    connectedEdges.insert( originalFaceToEdgeMap( faceIndex, a ) );
+  }
 
+  // Fill the connectivity between FaceElement entries. This is essentially a copy of the
+  // edgesToFaces map, but with differing offsets.
+  for( auto const & edge : connectedEdges )
+  {
     // check to see if the edgesToFractureConnectors already have an entry
     if( subRegion.m_edgesTo2dFaces.count( edge )==0 )
     {

--- a/src/coreComponents/mesh/SurfaceElementRegion.cpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.cpp
@@ -88,7 +88,6 @@ void SurfaceElementRegion::initializePreSubGroups()
 }
 
 localIndex SurfaceElementRegion::addToSurfaceMesh( FaceManager const * const faceManager,
-                                                   ArrayOfArraysView< localIndex const >  const & originalFaceToEdgeMap,
                                                    localIndex const faceIndices[2] )
 {
   localIndex rval = -1;

--- a/src/coreComponents/mesh/SurfaceElementRegion.hpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.hpp
@@ -110,8 +110,7 @@ public:
    */
   localIndex addToSurfaceMesh( FaceManager const * const faceManager,
                                ArrayOfArraysView< localIndex const > const & originalFaceToEdges,
-                               localIndex const faceIndices[2],
-                               SortedArray< localIndex > & connectedEdges );
+                               localIndex const faceIndices[2]);
 
   /**
    * @brief This function generates and adds entries to the face/fracture mesh.

--- a/src/coreComponents/mesh/SurfaceElementRegion.hpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.hpp
@@ -110,7 +110,8 @@ public:
    */
   localIndex addToSurfaceMesh( FaceManager const * const faceManager,
                                ArrayOfArraysView< localIndex const > const & originalFaceToEdges,
-                               localIndex const faceIndices[2] );
+                               localIndex const faceIndices[2],
+                               SortedArray< localIndex > & connectedEdges );
 
   /**
    * @brief This function generates and adds entries to the face/fracture mesh.

--- a/src/coreComponents/mesh/SurfaceElementRegion.hpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.hpp
@@ -102,6 +102,17 @@ public:
   virtual void generateMesh( Group const & faceBlocks ) override;
 
   /**
+   * @brief This function generates and adds entries to the face/surface mesh.
+   * @param faceManager pointer to the FaceManager object.
+   * @param originalFaceToEdges face-to-edge map before the rupture.
+   * @param faceIndices the local indices of the new faces that define the face element.
+   * @return the local index of the new FaceElement entry.
+   */
+  localIndex addToSurfaceMesh( FaceManager const * const faceManager,
+                               ArrayOfArraysView< localIndex const > const & originalFaceToEdges,
+                               localIndex const faceIndices[2] );
+
+  /**
    * @brief This function generates and adds entries to the face/fracture mesh.
    * @param time_np1 rupture time
    * @param faceManager pointer to the FaceManager object.

--- a/src/coreComponents/mesh/SurfaceElementRegion.hpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.hpp
@@ -110,7 +110,7 @@ public:
    */
   localIndex addToSurfaceMesh( FaceManager const * const faceManager,
                                ArrayOfArraysView< localIndex const > const & originalFaceToEdges,
-                               localIndex const faceIndices[2]);
+                               localIndex const faceIndices[2] );
 
   /**
    * @brief This function generates and adds entries to the face/fracture mesh.

--- a/src/coreComponents/mesh/SurfaceElementRegion.hpp
+++ b/src/coreComponents/mesh/SurfaceElementRegion.hpp
@@ -104,12 +104,10 @@ public:
   /**
    * @brief This function generates and adds entries to the face/surface mesh.
    * @param faceManager pointer to the FaceManager object.
-   * @param originalFaceToEdges face-to-edge map before the rupture.
    * @param faceIndices the local indices of the new faces that define the face element.
    * @return the local index of the new FaceElement entry.
    */
   localIndex addToSurfaceMesh( FaceManager const * const faceManager,
-                               ArrayOfArraysView< localIndex const > const & originalFaceToEdges,
                                localIndex const faceIndices[2] );
 
   /**


### PR DESCRIPTION
To enable dedicated interface conditions in the physics solvers, it's important to separate the attributions of the `addToFractureMesh` function. The adopted solution is to introduce an auxiliary function, `addToSurfaceMesh`, which handles only the `faceElementsToCells` mappings.

To preserve the original functionality of addToFractureMesh, the following steps are taken:

1.  Call to addToSurfaceMesh to avoid duplicating code
2. Set the rupture time
3. Build fracture-specific edge-to-face connectivity
4. Compute geometry
5. Update set memberships