### PR TITLE
feat: Add option for computing the imaging condition for RTM

### DIFF
--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/firstOrderEqn/isotropic/AcousticFirstOrderWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/firstOrderEqn/isotropic/AcousticFirstOrderWaveEquationSEM.cpp
@@ -396,7 +396,7 @@ real64 AcousticFirstOrderWaveEquationSEM::explicitStepForward( real64 const & ti
                                                                real64 const & dt,
                                                                integer cycleNumber,
                                                                DomainPartition & domain,
-                                                               bool GEOS_UNUSED_PARAM( computeGradient ) )
+                                                               integer GEOS_UNUSED_PARAM( computeGradient ) )
 {
   real64 dtOut = explicitStepInternal( time_n, dt, cycleNumber, domain );
   return dtOut;
@@ -408,7 +408,7 @@ real64 AcousticFirstOrderWaveEquationSEM::explicitStepBackward( real64 const & t
                                                                 real64 const & dt,
                                                                 integer cycleNumber,
                                                                 DomainPartition & domain,
-                                                                bool GEOS_UNUSED_PARAM( computeGradient ) )
+                                                                integer GEOS_UNUSED_PARAM( computeGradient ) )
 {
   GEOS_ERROR( getDataContext() << ": Backward propagation for the first-order wave propagator not yet implemented" );
   real64 dtOut = explicitStepInternal( time_n, dt, cycleNumber, domain );

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/firstOrderEqn/isotropic/AcousticFirstOrderWaveEquationSEM.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/firstOrderEqn/isotropic/AcousticFirstOrderWaveEquationSEM.hpp
@@ -61,13 +61,13 @@ public:
                                       real64 const & dt,
                                       integer const cycleNumber,
                                       DomainPartition & domain,
-                                      bool const computeGradient ) override;
+                                      integer const computeGradient ) override;
 
   virtual real64 explicitStepBackward( real64 const & time_n,
                                        real64 const & dt,
                                        integer const cycleNumber,
                                        DomainPartition & domain,
-                                       bool const computeGradient ) override;
+                                       integer const computeGradient ) override;
 
   /**
    * @brief Initialize Perfectly Matched Layer (PML) information

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/anisotropic/AcousticVTIWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/anisotropic/AcousticVTIWaveEquationSEM.cpp
@@ -482,7 +482,7 @@ real64 AcousticVTIWaveEquationSEM::explicitStepForward( real64 const & time_n,
                                                         real64 const & dt,
                                                         integer,
                                                         DomainPartition & domain,
-                                                        bool computeGradient )
+                                                        integer computeGradient )
 {
   real64 dtOut = explicitStepInternal( time_n, dt, domain );
 
@@ -501,7 +501,7 @@ real64 AcousticVTIWaveEquationSEM::explicitStepForward( real64 const & time_n,
     arrayView1d< real32 > const q_n = nodeManager.getField< acousticvtifields::Pressure_q_n >();
     arrayView1d< real32 > const q_np1 = nodeManager.getField< acousticvtifields::Pressure_q_np1 >();
 
-    if( computeGradient )
+    if( computeGradient  > 0 )
     {
       GEOS_ERROR( "This option is not supported yet" );
     }
@@ -537,7 +537,7 @@ real64 AcousticVTIWaveEquationSEM::explicitStepBackward( real64 const & GEOS_UNU
                                                          real64 const & GEOS_UNUSED_PARAM( dt ),
                                                          integer GEOS_UNUSED_PARAM( cycleNumber ),
                                                          DomainPartition & GEOS_UNUSED_PARAM( domain ),
-                                                         bool GEOS_UNUSED_PARAM( computeGradient ) )
+                                                         integer GEOS_UNUSED_PARAM( computeGradient ) )
 {
   GEOS_ERROR( "This option is not supported yet" );
   return -1;

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/anisotropic/AcousticVTIWaveEquationSEM.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/anisotropic/AcousticVTIWaveEquationSEM.hpp
@@ -60,14 +60,14 @@ public:
                                       real64 const & dt,
                                       integer const cycleNumber,
                                       DomainPartition & domain,
-                                      bool const computeGradient ) override;
+                                      integer const computeGradient ) override;
 
 
   virtual real64 explicitStepBackward( real64 const & GEOS_UNUSED_PARAM( time_n ),
                                        real64 const & GEOS_UNUSED_PARAM( dt ),
                                        integer const GEOS_UNUSED_PARAM( cycleNumber ),
                                        DomainPartition & GEOS_UNUSED_PARAM( domain ),
-                                       bool const GEOS_UNUSED_PARAM( computeGradient ) ) override;
+                                       integer const GEOS_UNUSED_PARAM( computeGradient ) ) override;
 
   /**@}*/
 

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/isotropic/AcousticWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/isotropic/AcousticWaveEquationSEM.cpp
@@ -918,7 +918,7 @@ real64 AcousticWaveEquationSEM::explicitStepForward( real64 const & time_n,
                                                      real64 const & dt,
                                                      integer cycleNumber,
                                                      DomainPartition & domain,
-                                                     bool computeGradient )
+                                                     integer computeGradient )
 {
   real64 dtCompute = explicitStepInternal( time_n, dt, cycleNumber, domain );
 
@@ -989,7 +989,7 @@ real64 AcousticWaveEquationSEM::explicitStepBackward( real64 const & time_n,
                                                       real64 const & dt,
                                                       integer cycleNumber,
                                                       DomainPartition & domain,
-                                                      bool computeGradient )
+                                                      integer computeGradient )
 {
   real64 dtCompute = explicitStepInternal( time_n, dt, cycleNumber, domain );
   forDiscretizationOnMeshTargets( domain.getMeshBodies(),
@@ -1015,7 +1015,7 @@ real64 AcousticWaveEquationSEM::explicitStepBackward( real64 const & time_n,
     real64 const & maxTime = event.getReference< real64 >( EventManager::viewKeyStruct::maxTimeString() );
     int const maxCycle = int(round( maxTime / dt ));
 
-    if( computeGradient && cycleNumber < maxCycle )
+    if( computeGradient > 0 && cycleNumber < maxCycle )
     {
       ElementRegionManager & elemManager = mesh.getElemManager();
 
@@ -1053,7 +1053,7 @@ real64 AcousticWaveEquationSEM::explicitStepBackward( real64 const & time_n,
         arrayView1d< integer const > const elemGhostRank = elementSubRegion.ghostRank();
         GEOS_MARK_SCOPE ( updatePartialGradient );
 
-        //COMPUTE GRADIENTS with respect to K=1/rho*c2 (grad) and b=1/rho (grad2)
+        //COMPUTE GRADIENTS or imaging condition with respect to K=1/rho*c2 (grad) and b=1/rho (grad2)
         finiteElement::FiniteElementBase const &
         fe = elementSubRegion.getReference< finiteElement::FiniteElementBase >( getDiscretizationName() );
 
@@ -1061,16 +1061,30 @@ real64 AcousticWaveEquationSEM::explicitStepBackward( real64 const & time_n,
         {
           using FE_TYPE = TYPEOFREF( finiteElement );
 
-          AcousticMatricesSEM::GradientKappaBuoyancy< FE_TYPE > kernelG( finiteElement );
-          kernelG.template computeGradient< EXEC_POLICY, ATOMIC_POLICY >( elementSubRegion.size(),
-                                                                          nodeCoords,
-                                                                          elemsToNodes,
-                                                                          elemGhostRank,
-                                                                          p_nm1,
-                                                                          p_n,
-                                                                          p_forward,
-                                                                          grad,
-                                                                          grad2 );
+          if( computeGradient == 1 )
+          {
+            AcousticMatricesSEM::GradientKappaBuoyancy< FE_TYPE > kernelG( finiteElement );
+            kernelG.template computeGradient< EXEC_POLICY, ATOMIC_POLICY >( elementSubRegion.size(),
+                                                                            nodeCoords,
+                                                                            elemsToNodes,
+                                                                            elemGhostRank,
+                                                                            p_nm1,
+                                                                            p_n,
+                                                                            p_forward,
+                                                                            grad,
+                                                                            grad2 );
+          }
+          else if( computeGradient == 2 )
+          {
+            AcousticMatricesSEM::ImagingCondition< FE_TYPE > kernelI( finiteElement );
+            kernelI.template computeImagingCondition< EXEC_POLICY, ATOMIC_POLICY >( elementSubRegion.size(),
+                                                                                    nodeCoords,
+                                                                                    elemsToNodes,
+                                                                                    elemGhostRank,
+                                                                                    p_n,
+                                                                                    p_forward,
+                                                                                    grad );
+          }
 
 
         } );

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/isotropic/AcousticWaveEquationSEM.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/isotropic/AcousticWaveEquationSEM.hpp
@@ -72,13 +72,13 @@ public:
                                       real64 const & dt,
                                       integer const cycleNumber,
                                       DomainPartition & domain,
-                                      bool const computeGradient ) override;
+                                      integer const computeGradient ) override;
 
   virtual real64 explicitStepBackward( real64 const & time_n,
                                        real64 const & dt,
                                        integer const cycleNumber,
                                        DomainPartition & domain,
-                                       bool const computeGradient ) override;
+                                       integer const computeGradient ) override;
 
   /**@}*/
 

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/shared/AcousticFields.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/shared/AcousticFields.hpp
@@ -97,7 +97,7 @@ DECLARE_FIELD( PartialGradient,
                0,
                NOPLOT,
                WRITE_AND_READ,
-               "Partiel gradient computed during backward propagation" );
+               "Partial gradient or imaging condition computed during backward propagation" );
 
 DECLARE_FIELD( PartialGradient2,
                "partialGradient2",

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/shared/AcousticMatricesSEMKernel.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/shared/AcousticMatricesSEMKernel.hpp
@@ -217,6 +217,63 @@ struct AcousticMatricesSEM
     FE_TYPE const & m_finiteElement;
   };
 
+  template< typename FE_TYPE >
+  struct ImagingCondition
+  {
+
+    ImagingCondition( FE_TYPE const & finiteElement )
+      : m_finiteElement( finiteElement )
+    {}
+
+    /**
+     * @brief Launch the computation of the imaging condition for RTM
+     * @tparam EXEC_POLICY the execution policy
+     * @tparam ATOMIC_POLICY the atomic policy
+     * @param[in] size the number of cells in the subRegion
+     * @param[in] nodeCoords coordinates of the nodes
+     * @param[in] elemsToNodes map from element to nodes
+     * @param[in] q_n current time step of backward
+     * @param[in] p_n current time step of forward
+     * @param[out] imag will contain the imaging condition value
+     */
+    template< typename EXEC_POLICY, typename ATOMIC_POLICY >
+    void
+    computeImagingCondition( localIndex const size,
+                             arrayView2d< WaveSolverBase::wsCoordType const, nodes::REFERENCE_POSITION_USD > const nodeCoords,
+                             arrayView2d< localIndex const, cells::NODE_MAP_USD > const elemsToNodes,
+                             arrayView1d< integer const > const elemGhostRank,
+                             arrayView1d< real32 const > const q_n,
+                             arrayView1d< real32 const > const p_n,
+                             arrayView1d< real32 > const imag )
+
+    {
+      forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const e )
+      {
+        if( elemGhostRank[e]<0 )
+        {
+          // only the eight corners of the mesh cell are needed to compute the Jacobian
+          real64 xLocal[ 8 ][ 3 ];
+          for( localIndex a = 0; a < 8; ++a )
+          {
+            localIndex const nodeIndex = elemsToNodes( e, FE_TYPE::meshIndexToLinearIndex3D( a ) );
+            for( localIndex i = 0; i < 3; ++i )
+            {
+              xLocal[a][i] = nodeCoords( nodeIndex, i );
+            }
+          }
+          constexpr localIndex numQuadraturePointsPerElem = FE_TYPE::numQuadraturePoints;
+          for( localIndex q = 0; q < numQuadraturePointsPerElem; ++q )
+          {
+            localIndex nodeIdx = elemsToNodes( e, q );
+            imag[e] += q_n[nodeIdx] * p_n[nodeIdx] * m_finiteElement.computeMassTerm( q, xLocal );
+          }
+        }
+      } ); // end loop over element
+    }
+    /// The finite element space/discretization object for the element type in the subRegion
+    FE_TYPE const & m_finiteElement;
+  };
+
 };
 
 } // namespace geos

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEM.cpp
@@ -463,7 +463,7 @@ real64 ElasticFirstOrderWaveEquationSEM::explicitStepForward( real64 const & tim
                                                               real64 const & dt,
                                                               integer cycleNumber,
                                                               DomainPartition & domain,
-                                                              bool GEOS_UNUSED_PARAM( computeGradient ) )
+                                                              integer GEOS_UNUSED_PARAM( computeGradient ) )
 {
   real64 dtOut = explicitStepInternal( time_n, dt, cycleNumber, domain );
   return dtOut;
@@ -475,7 +475,7 @@ real64 ElasticFirstOrderWaveEquationSEM::explicitStepBackward( real64 const & ti
                                                                real64 const & dt,
                                                                integer cycleNumber,
                                                                DomainPartition & domain,
-                                                               bool GEOS_UNUSED_PARAM( computeGradient ) )
+                                                               integer GEOS_UNUSED_PARAM( computeGradient ) )
 {
   GEOS_ERROR( getDataContext() << ": Backward propagation for the first order elastic wave propagator not yet implemented" );
   real64 dtOut = explicitStepInternal( time_n, dt, cycleNumber, domain );

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEM.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEM.hpp
@@ -62,13 +62,13 @@ public:
                                       real64 const & dt,
                                       integer const cycleNumber,
                                       DomainPartition & domain,
-                                      bool const computeGradient ) override;
+                                      integer const computeGradient ) override;
 
   virtual real64 explicitStepBackward( real64 const & time_n,
                                        real64 const & dt,
                                        integer const cycleNumber,
                                        DomainPartition & domain,
-                                       bool const computeGradient ) override;
+                                       integer const computeGradient ) override;
 
 
   /**

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/secondOrderEqn/isotropic/ElasticWaveEquationSEM.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/secondOrderEqn/isotropic/ElasticWaveEquationSEM.cpp
@@ -739,7 +739,7 @@ real64 ElasticWaveEquationSEM::explicitStepForward( real64 const & time_n,
                                                     real64 const & dt,
                                                     integer,
                                                     DomainPartition & domain,
-                                                    bool GEOS_UNUSED_PARAM( computeGradient ) )
+                                                    integer GEOS_UNUSED_PARAM( computeGradient ) )
 {
   real64 dtCompute = explicitStepInternal( time_n, dt, domain );
   return dtCompute;
@@ -751,7 +751,7 @@ real64 ElasticWaveEquationSEM::explicitStepBackward( real64 const & time_n,
                                                      real64 const & dt,
                                                      integer,
                                                      DomainPartition & domain,
-                                                     bool GEOS_UNUSED_PARAM( computeGradient ) )
+                                                     integer GEOS_UNUSED_PARAM( computeGradient ) )
 {
   GEOS_ERROR( getDataContext() << ": Backward propagation for the elastic wave propagator not yet implemented" );
   real64 dtOut = explicitStepInternal( time_n, dt, domain );

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/secondOrderEqn/isotropic/ElasticWaveEquationSEM.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/secondOrderEqn/isotropic/ElasticWaveEquationSEM.hpp
@@ -72,13 +72,13 @@ public:
                                       real64 const & dt,
                                       integer const cycleNumber,
                                       DomainPartition & domain,
-                                      bool const computeGradient ) override;
+                                      integer const computeGradient ) override;
 
   virtual real64 explicitStepBackward( real64 const & time_n,
                                        real64 const & dt,
                                        integer const cycleNumber,
                                        DomainPartition & domain,
-                                       bool const computeGradient ) override;
+                                       integer const computeGradient ) override;
   /**@}*/
 
   /**

--- a/src/coreComponents/physicsSolvers/wavePropagation/shared/WaveSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/shared/WaveSolverBase.cpp
@@ -100,7 +100,7 @@ WaveSolverBase::WaveSolverBase( const std::string & name,
   registerWrapper( viewKeyStruct::saveFieldsString(), &m_saveFields ).
     setInputFlag( InputFlags::OPTIONAL ).
     setApplyDefaultValue( 0 ).
-    setDescription( "Set to 1 to save fields during forward and restore them during backward" );
+    setDescription( "Set to 1 to save fields during forward and restore them during backward. If set to 1, the gradient is computed, and if set to 2, the imaging condition is computed." );
 
   registerWrapper( viewKeyStruct::shotIndexString(), &m_shotIndex ).
     setInputFlag( InputFlags::OPTIONAL ).

--- a/src/coreComponents/physicsSolvers/wavePropagation/shared/WaveSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/shared/WaveSolverBase.hpp
@@ -227,28 +227,28 @@ protected:
    * @param dt the perscribed timestep
    * @param cycleNumber the current cycle number
    * @param domain the domain object
-   * @param computeGradient Indicates if we want to compute gradient at this step
+   * @param computeGradient Indicates if we want to compute gradient or the imaging condition at this step
    * @return return the timestep that was achieved during the step.
    */
   virtual real64 explicitStepForward( real64 const & time_n,
                                       real64 const & dt,
                                       integer const cycleNumber,
                                       DomainPartition & domain,
-                                      bool const computeGradient ) = 0;
+                                      integer const computeGradient ) = 0;
   /**
    * @brief Perform backward explicit step
    * @param time_n time at the beginning of the step
    * @param dt the perscribed timestep
    * @param cycleNumber the current cycle number
    * @param domain the domain object
-   * @param computeGradient Indicates if we want to compute gradient at this step
+   * @param computeGradient Indicates if we want to compute gradient or the imaging condition at this step
    * @return return the timestep that was achieved during the step.
    */
   virtual real64 explicitStepBackward( real64 const & time_n,
                                        real64 const & dt,
                                        integer const cycleNumber,
                                        DomainPartition & domain,
-                                       bool const computeGradient ) = 0;
+                                       integer const computeGradient ) = 0;
 
 
   virtual void registerDataOnMesh( Group & meshBodies ) override;
@@ -316,7 +316,7 @@ protected:
   localIndex m_forward;
 
   /// Indicate if we want to save fields to restore them during backward
-  localIndex m_saveFields;
+  integer m_saveFields;
 
   // Indicate the current shot computed for naming saved temporary data
   integer m_shotIndex;

--- a/src/coreComponents/unitTests/wavePropagationTests/testWavePropagation.cpp
+++ b/src/coreComponents/unitTests/wavePropagationTests/testWavePropagation.cpp
@@ -208,7 +208,7 @@ TEST_F( AcousticWaveEquationSEMTest, SeismoTrace )
   // run for 1s (10 steps)
   for( int i=0; i<10; i++ )
   {
-    propagator->explicitStepForward( time_n, dt, i, domain, false );
+    propagator->explicitStepForward( time_n, dt, i, domain, 0 );
     time_n += dt;
   }
   // cleanup (triggers calculation of the remaining seismograms data points)
@@ -244,7 +244,7 @@ TEST_F( AcousticWaveEquationSEMTest, SeismoTrace )
   // run adjoint solver
   for( int i = 0; i < 10; i++ )
   {
-    propagator->explicitStepBackward( time_n, dt, i, domain, false );
+    propagator->explicitStepBackward( time_n, dt, i, domain, 0 );
     time_n += dt;
   }
   // check again the seismo content.

--- a/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAdjoint1.cpp
+++ b/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAdjoint1.cpp
@@ -216,7 +216,7 @@ TEST_F( AcousticWaveEquationSEMTest, SeismoTrace )
   for( int i=0; i<50; i++ )
   {
     rhsForward[i][0]=WaveSolverUtils::evaluateRicker( time_n, *ptrTimeSourceFrequency, *ptrTimeSourceDelay, *ptrRickerOrder );
-    propagator->explicitStepForward( time_n, dt, i, domain, false );
+    propagator->explicitStepForward( time_n, dt, i, domain, 0 );
     time_n += dt;
   }
   // cleanup (triggers calculation of the remaining seismograms data points)
@@ -315,7 +315,7 @@ TEST_F( AcousticWaveEquationSEMTest, SeismoTrace )
   for( int i = 50; i > 0; i-- )
   {
     rhsBackward[i][0]=WaveSolverUtils::evaluateRicker( time_n, *ptrTimeSourceFrequency, *ptrTimeSourceDelay, *ptrRickerOrder );
-    propagator->explicitStepBackward( time_n, dt, i, domain, false );
+    propagator->explicitStepBackward( time_n, dt, i, domain, 0 );
     time_n -= dt;
     //check source node in backward loop
     arrayView2d< localIndex > const sNodeIds_loop = propagator->getReference< array2d< localIndex > >( AcousticWaveEquationSEM::viewKeyStruct::sourceNodeIdsString() ).toView();

--- a/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAdjoint1.cpp
+++ b/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAdjoint1.cpp
@@ -170,7 +170,7 @@ char const * xmlInput =
   </Problem>
   )xml";
 
-class AcousticWaveEquationSEMTest : public ::testing::Test
+class AcousticWaveEquationSEMTest : public ::testing::TestWithParam< int >
 {
 public:
 
@@ -197,8 +197,10 @@ real64 constexpr AcousticWaveEquationSEMTest::time;
 real64 constexpr AcousticWaveEquationSEMTest::dt;
 real64 constexpr AcousticWaveEquationSEMTest::eps;
 
-TEST_F( AcousticWaveEquationSEMTest, SeismoTrace )
+TEST_P( AcousticWaveEquationSEMTest, SeismoTrace )
 {
+
+  int gradient = GetParam();
 
   DomainPartition & domain = state.getProblemManager().getDomainPartition();
   propagator = &state.getProblemManager().getPhysicsSolverManager().getGroup< AcousticWaveEquationSEM >( "acousticSolver" );
@@ -216,7 +218,7 @@ TEST_F( AcousticWaveEquationSEMTest, SeismoTrace )
   for( int i=0; i<50; i++ )
   {
     rhsForward[i][0]=WaveSolverUtils::evaluateRicker( time_n, *ptrTimeSourceFrequency, *ptrTimeSourceDelay, *ptrRickerOrder );
-    propagator->explicitStepForward( time_n, dt, i, domain, 0 );
+    propagator->explicitStepForward( time_n, dt, i, domain, gradient );
     time_n += dt;
   }
   // cleanup (triggers calculation of the remaining seismograms data points)
@@ -315,7 +317,7 @@ TEST_F( AcousticWaveEquationSEMTest, SeismoTrace )
   for( int i = 50; i > 0; i-- )
   {
     rhsBackward[i][0]=WaveSolverUtils::evaluateRicker( time_n, *ptrTimeSourceFrequency, *ptrTimeSourceDelay, *ptrRickerOrder );
-    propagator->explicitStepBackward( time_n, dt, i, domain, 0 );
+    propagator->explicitStepBackward( time_n, dt, i, domain, gradient );
     time_n -= dt;
     //check source node in backward loop
     arrayView2d< localIndex > const sNodeIds_loop = propagator->getReference< array2d< localIndex > >( AcousticWaveEquationSEM::viewKeyStruct::sourceNodeIdsString() ).toView();
@@ -393,6 +395,13 @@ TEST_F( AcousticWaveEquationSEMTest, SeismoTrace )
   std::cout << " Diff to compare with 9e-3: " << diffToCheck << std::endl;
   ASSERT_TRUE( diffToCheck < 9e-3 );
 }
+
+INSTANTIATE_TEST_CASE_P(
+        AcousticWaveEquationSEMTests,
+        AcousticWaveEquationSEMTest,
+        ::testing::Values(
+                0,1,2
+        ));
 
 int main( int argc, char * * argv )
 {

--- a/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAdjoint1.cpp
+++ b/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAdjoint1.cpp
@@ -397,11 +397,11 @@ TEST_P( AcousticWaveEquationSEMTest, SeismoTrace )
 }
 
 INSTANTIATE_TEST_CASE_P(
-        AcousticWaveEquationSEMTests,
-        AcousticWaveEquationSEMTest,
-        ::testing::Values(
-                0,1,2
-        ));
+  AcousticWaveEquationSEMTests,
+  AcousticWaveEquationSEMTest,
+  ::testing::Values(
+    0, 1, 2
+    ));
 
 int main( int argc, char * * argv )
 {

--- a/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAdjoint1.cpp
+++ b/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAdjoint1.cpp
@@ -396,7 +396,7 @@ TEST_P( AcousticWaveEquationSEMTest, SeismoTrace )
   ASSERT_TRUE( diffToCheck < 9e-3 );
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
   AcousticWaveEquationSEMTests,
   AcousticWaveEquationSEMTest,
   ::testing::Values(

--- a/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAttenuation.cpp
+++ b/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationAttenuation.cpp
@@ -196,7 +196,7 @@ TEST_F( ElasticWaveEquationSEMTest, SeismoTrace )
   // run for 1s (10 steps)
   for( int i=0; i<10; i++ )
   {
-    propagator->explicitStepForward( time_n, dt, i, domain, false );
+    propagator->explicitStepForward( time_n, dt, i, domain, 0 );
     time_n += dt;
   }
   // cleanup (triggers calculation of the remaining seismograms data points)

--- a/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationDAS.cpp
+++ b/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationDAS.cpp
@@ -180,7 +180,7 @@ TEST_F( ElasticWaveEquationSEMTest, SeismoTrace )
   // run for 1s (10 steps)
   for( int i=0; i<10; i++ )
   {
-    propagator->explicitStepForward( time_n, dt, i, domain, false );
+    propagator->explicitStepForward( time_n, dt, i, domain, 0 );
     time_n += dt;
   }
   // cleanup (triggers calculation of the remaining seismograms data points)

--- a/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationElasticVTI.cpp
+++ b/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationElasticVTI.cpp
@@ -204,7 +204,7 @@ TEST_F( ElasticWaveEquationSEMTest, SeismoTrace )
   // run for 1s (10 steps)
   for( int i=0; i<10; i++ )
   {
-    propagator->explicitStepForward( time_n, dt, i, domain, false );
+    propagator->explicitStepForward( time_n, dt, i, domain, 0 );
     time_n += dt;
   }
   // cleanup (triggers calculation of the remaining seismograms data points)

--- a/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationQ2.cpp
+++ b/src/coreComponents/unitTests/wavePropagationTests/testWavePropagationQ2.cpp
@@ -175,7 +175,7 @@ TEST_F( AcousticWaveEquationSEMTest, SeismoTrace )
   // run for 1s (10 steps)
   for( int i=0; i<10; i++ )
   {
-    propagator->explicitStepForward( time_n, dt, i, domain, false );
+    propagator->explicitStepForward( time_n, dt, i, domain, 0 );
     time_n += dt;
   }
   // cleanup (triggers calculation of the remaining seismograms data points)
@@ -213,7 +213,7 @@ TEST_F( AcousticWaveEquationSEMTest, SeismoTrace )
   // run adjoint solver
   for( int i = 0; i < 10; i++ )
   {
-    propagator->explicitStepBackward( time_n, dt, i, domain, false );
+    propagator->explicitStepBackward( time_n, dt, i, domain, 0 );
     time_n += dt;
   }
   // check again the seismo content.


### PR DESCRIPTION
This PR adds the possibility of computing the classic imaging condition for RTM seismic imaging. This reuses the machinery for the FWI gradient, changing the integral for the imaging condition.