### PR TITLE
fix: Add box name to message

### DIFF
--- a/src/coreComponents/mesh/simpleGeometricObjects/Box.cpp
+++ b/src/coreComponents/mesh/simpleGeometricObjects/Box.cpp
@@ -72,7 +72,7 @@ void Box::postInputInitialization()
     if( m_max[i]<m_min[i] )
     {
       std::swap( m_max[i], m_min[i] );
-      GEOS_LOG_RANK_0( GEOS_FMT( "Reordering box definition for {} component as {} < {} ", i, m_max[i], m_min[i] ) );
+      GEOS_LOG_RANK_0( GEOS_FMT( "Reordering box definition {} for {} component as {} < {} ", getName(), i, m_max[i], m_min[i] ) );
     }
   }
 


### PR DESCRIPTION
Adds the box name to a warning message when the ordering of the components is reversed.

Current message is
```
Reordering box definition for 0 component as 7 < 6
```
This is changed to
```
Reordering box definition MyBox for 0 component as 7 < 6
```
which includes the name of the box.