### PR TITLE
refactor:  const access to stencil connector indices

### DIFF
--- a/src/coreComponents/finiteVolume/StencilBase.hpp
+++ b/src/coreComponents/finiteVolume/StencilBase.hpp
@@ -240,7 +240,7 @@ public:
 
   /**
    * @brief  Const access to stencil connector indices.
-   * @return A unordered_map of stencil connector indices
+   * @return An unordered_map of stencil connector indices
    */
   unordered_map< localIndex, localIndex > const &
   getConnectorIndices() const { return m_connectorIndices; }

--- a/src/coreComponents/finiteVolume/StencilBase.hpp
+++ b/src/coreComponents/finiteVolume/StencilBase.hpp
@@ -237,7 +237,7 @@ public:
    */
   typename TRAITS::WeightContainerViewConstType
   getWeights() const { return m_weights.toViewConst(); }
-  
+
   /**
    * @brief  Const access to stencil connector indices.
    * @return A geos::unordered_map of stencil connector indices

--- a/src/coreComponents/finiteVolume/StencilBase.hpp
+++ b/src/coreComponents/finiteVolume/StencilBase.hpp
@@ -237,6 +237,13 @@ public:
    */
   typename TRAITS::WeightContainerViewConstType
   getWeights() const { return m_weights.toViewConst(); }
+  
+  /**
+   * @brief  Const access to stencil connector indices.
+   * @return A geos::unordered_map of stencil connector indices
+   */
+  geos::unordered_map< localIndex, localIndex > const &
+  getConnectorIndices() const { return m_connectorIndices; }
 
 protected:
 

--- a/src/coreComponents/finiteVolume/StencilBase.hpp
+++ b/src/coreComponents/finiteVolume/StencilBase.hpp
@@ -240,9 +240,9 @@ public:
 
   /**
    * @brief  Const access to stencil connector indices.
-   * @return A geos::unordered_map of stencil connector indices
+   * @return A unordered_map of stencil connector indices
    */
-  geos::unordered_map< localIndex, localIndex > const &
+  unordered_map< localIndex, localIndex > const &
   getConnectorIndices() const { return m_connectorIndices; }
 
 protected:


### PR DESCRIPTION
Adds const access to stencil connector indices in [StencilBase.hpp](https://github.com/GEOS-DEV/GEOS/compare/feature/oduran/access_connector_idxs?expand=1#diff-642b101704a3df9d537e05181f58198363aa9337eaa1839c1d5830260dbc3a36).