### PR TITLE
feat: Implement phase ordering for compositional fluid model

### DIFF
--- a/src/coreComponents/constitutive/CMakeLists.txt
+++ b/src/coreComponents/constitutive/CMakeLists.txt
@@ -115,6 +115,7 @@ set( constitutive_headers
      fluid/multifluid/compositional/parameters/EquationOfState.hpp
      fluid/multifluid/compositional/parameters/ImmiscibleWaterParameters.hpp
      fluid/multifluid/compositional/parameters/ModelParameters.hpp
+     fluid/multifluid/compositional/parameters/PhaseType.hpp
      fluid/multifluid/compositional/parameters/PressureTemperatureCoordinates.hpp
      fluid/multifluid/compositional/CompositionalMultiphaseFluid.hpp
      fluid/multifluid/compositional/CompositionalMultiphaseFluidUpdates.hpp
@@ -267,6 +268,7 @@ set( constitutive_sources
      fluid/multifluid/compositional/parameters/ComponentProperties.cpp
      fluid/multifluid/compositional/parameters/CriticalVolume.cpp
      fluid/multifluid/compositional/parameters/ImmiscibleWaterParameters.cpp
+     fluid/multifluid/compositional/parameters/PhaseType.cpp
      fluid/multifluid/compositional/parameters/PressureTemperatureCoordinates.cpp
      fluid/multifluid/compositional/CompositionalMultiphaseFluid.cpp
      fluid/multifluid/compositional/CompositionalMultiphaseFluidUpdates.cpp

--- a/src/coreComponents/constitutive/fluid/multifluid/MultiFluidBase.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/MultiFluidBase.cpp
@@ -187,6 +187,26 @@ void MultiFluidBase::postInputInitialization()
                           InputError );
   }
 
+  // Make sure that phase names and component names are not repeated
+  std::set< std::string > uniqueNames;
+  for( integer ip = 0; ip < numPhase; ++ip )
+  {
+    std::string const lowerCaseName = stringutilities::toLower( m_phaseNames[ip] );
+    GEOS_THROW_IF ( uniqueNames.find( lowerCaseName ) != uniqueNames.end(),
+                    GEOS_FMT( "{}: phase name {} is repeated. "
+                              "Phase names should be unique.", getFullName(), m_phaseNames[ip] ), InputError );
+    uniqueNames.insert( lowerCaseName );
+  }
+  uniqueNames.clear();
+  for( integer ic = 0; ic < numComp; ++ic )
+  {
+    std::string const lowerCaseName = stringutilities::toLower( m_componentNames[ic] );
+    GEOS_THROW_IF ( uniqueNames.find( lowerCaseName ) != uniqueNames.end(),
+                    GEOS_FMT( "{}: component name {} is repeated. "
+                              "Component names should be unique.", getFullName(), m_componentNames[ic] ), InputError );
+    uniqueNames.insert( lowerCaseName );
+  }
+
   // call to correctly set member array tertiary sizes on the 'main' material object
   resizeFields( 0, 0 );
 

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.cpp
@@ -21,6 +21,7 @@
 
 #include "constitutive/fluid/multifluid/CO2Brine/functions/PVTFunctionHelpers.hpp"
 #include "constitutive/fluid/multifluid/MultiFluidFields.hpp"
+#include "constitutive/fluid/multifluid/compositional/parameters/PhaseType.hpp"
 #include "codingUtilities/Utilities.hpp"
 #include "common/format/StringUtilities.hpp"
 
@@ -83,9 +84,6 @@ CompositionalMultiphaseFluid( string const & name, Group * const parent )
   m_parameters->registerParameters( this );
 
   // Register extra wrappers to enable auto-cloning
-  registerWrapper( "phaseOrder", &m_phaseOrder )
-    .setSizedFromParent( 0 )
-    .setRestartFlags( RestartFlags::NO_WRITE );
   registerWrapper( "componentType", &m_componentProperties->m_componentType )
     .setSizedFromParent( 0 )
     .setRestartFlags( RestartFlags::NO_WRITE );
@@ -94,8 +92,16 @@ CompositionalMultiphaseFluid( string const & name, Group * const parent )
 template< typename FLASH, typename PHASE1, typename PHASE2, typename PHASE3 >
 integer CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::getWaterPhaseIndex() const
 {
-  integer const aqueous = static_cast< integer >(PhaseType::AQUEOUS);
-  return m_phaseOrder.size() > aqueous ? m_phaseOrder[aqueous] : -1;
+  auto const phaseTypes = getPhaseTypes();
+  integer const aqueous = static_cast< integer >(compositional::PhaseType::AQUEOUS);
+  for( integer ip = 0; ip < numFluidPhases(); ++ip )
+  {
+    if( phaseTypes[ip] == aqueous )
+    {
+      return ip;
+    }
+  }
+  return -1;
 }
 
 template< typename FLASH, typename PHASE1, typename PHASE2, typename PHASE3 >
@@ -128,6 +134,19 @@ void CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::postInputIni
                         GEOS_FMT( "{}: invalid number of phases in '{}'. There should be {} phases",
                                   getFullName(), viewKeyStruct::phaseNamesString(), NUM_PHASES ),
                         InputError );
+
+  // Phase types should not be repeated
+  auto const phaseTypes = getPhaseTypes();
+  std::set< integer > uniquePhases;
+  for( integer ip = 0; ip < NP; ++ip )
+  {
+    string const type_name = EnumStrings< compositional::PhaseType >::toString( static_cast< compositional::PhaseType >(phaseTypes[ip]));
+    GEOS_THROW_IF ( uniquePhases.find( phaseTypes[ip] ) != uniquePhases.end(),
+                    GEOS_FMT( "{}: phase with name {} is of type {} which is repeated. "
+                              "Phase types should be unique.", getFullName(), m_phaseNames[ip],
+                              type_name ), InputError );
+    uniquePhases.insert( phaseTypes[ip] );
+  }
 
   auto const checkInputSize = [&]( auto const & array, integer const expected, string const & attribute )
   {
@@ -180,12 +199,6 @@ void CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::postInputIni
                             InputError );
     }
   }
-
-  // Determine the phase ordering
-  m_phaseOrder.resize( 3 );
-  m_phaseOrder[PhaseType::LIQUID] = findPhaseIndex( "oil,liq,liquid" );
-  m_phaseOrder[PhaseType::VAPOUR] = findPhaseIndex( "gas,vap,vapor,vapour" );
-  m_phaseOrder[PhaseType::AQUEOUS] = findPhaseIndex( "wat,water,aqueous" );
 
   m_parameters->postInputInitialization( this, *m_componentProperties );
 }
@@ -245,9 +258,16 @@ CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::createKernelWrapp
 template< typename FLASH, typename PHASE1, typename PHASE2, typename PHASE3 >
 void CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::createModels()
 {
+  m_phaseType = getPhaseTypes();
+
+  // Determine the phase ordering
+  m_phaseOrder.resize( m_phaseType.size() );
+  FlashModel::calculatePhaseOrdering( m_phaseType.toViewConst(), m_phaseOrder );
+
   m_flash = std::make_unique< FLASH >( getName() + '_' + FLASH::catalogName(),
                                        *m_componentProperties,
-                                       *m_parameters );
+                                       *m_parameters,
+                                       m_phaseType.toViewConst() );
 
   m_phase1 = std::make_unique< PHASE1 >( GEOS_FMT( "{}_PhaseModel1", getName() ),
                                          *m_componentProperties,
@@ -266,19 +286,15 @@ void CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::createModels
 }
 
 template< typename FLASH, typename PHASE1, typename PHASE2, typename PHASE3 >
-integer CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::findPhaseIndex( string names ) const
+array1d< integer > CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::getPhaseTypes() const
 {
-  auto const nameContainer = stringutilities::tokenize( names, ",", true, false );
-
-  for( integer ip = 0; ip < numFluidPhases(); ++ip )
+  integer const numPhases = numFluidPhases();
+  array1d< integer > phaseTypes( numPhases );
+  for( integer ip = 0; ip < numPhases; ++ip )
   {
-    std::string const phaseName = stringutilities::toLower( m_phaseNames[ip] );
-    if( std::find( nameContainer.begin(), nameContainer.end(), phaseName ) != nameContainer.end())
-    {
-      return ip;
-    }
+    phaseTypes[ip] = static_cast< integer >(compositional::getPhaseTypeFromName( m_phaseNames[ip] ));
   }
-  return -1;
+  return phaseTypes;
 }
 
 // Create the fluid models

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.hpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.hpp
@@ -115,18 +115,11 @@ protected:
 
   virtual void resizeFields( localIndex const size, localIndex const numPts ) override;
 
-  enum PhaseType : integer
-  {
-    LIQUID = 0,
-    VAPOUR = 1,
-    AQUEOUS = 2,
-  };
-
 private:
   // Create the fluid models
   void createModels();
 
-  integer findPhaseIndex( string names ) const;
+  array1d< integer > getPhaseTypes() const;
 
   static std::unique_ptr< compositional::ModelParameters > createModelParameters();
 
@@ -134,7 +127,8 @@ private:
   std::unique_ptr< FLASH > m_flash{};
 
   // Phase ordering
-  array1d< integer > m_phaseOrder;
+  array1d< integer > m_phaseOrder{};
+  array1d< integer > m_phaseType{};
 
   // Phase models
   std::unique_ptr< PHASE1 > m_phase1{};

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/models/ImmiscibleWaterFlashModel.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/models/ImmiscibleWaterFlashModel.cpp
@@ -22,6 +22,7 @@
 #include "constitutive/fluid/multifluid/compositional/parameters/EquationOfState.hpp"
 #include "constitutive/fluid/multifluid/compositional/parameters/CriticalVolume.hpp"
 #include "constitutive/fluid/multifluid/compositional/parameters/BrineSalinity.hpp"
+#include "constitutive/fluid/multifluid/compositional/parameters/PhaseType.hpp"
 
 namespace geos
 {
@@ -40,9 +41,11 @@ string ImmiscibleWaterFlashModel::catalogName()
 
 ImmiscibleWaterFlashModel::ImmiscibleWaterFlashModel( string const & name,
                                                       ComponentProperties const & componentProperties,
-                                                      ModelParameters const & modelParameters ):
+                                                      ModelParameters const & modelParameters,
+                                                      arrayView1d< integer const > const phaseTypes ):
   FunctionBase( name, componentProperties ),
-  m_parameters( modelParameters )
+  m_parameters( modelParameters ),
+  m_phaseTypes( phaseTypes )
 {
   m_waterComponentIndex = ImmiscibleWaterParameters::getWaterComponentIndex( componentProperties );
 }
@@ -50,9 +53,12 @@ ImmiscibleWaterFlashModel::ImmiscibleWaterFlashModel( string const & name,
 ImmiscibleWaterFlashModel::KernelWrapper
 ImmiscibleWaterFlashModel::createKernelWrapper() const
 {
-  constexpr integer liquidIndex = 0;
-  constexpr integer vapourIndex = 1;
-  constexpr integer aqueousIndex = 2;
+  array1d< integer > phaseOrder( KernelWrapper::getNumberOfPhases());
+  calculatePhaseOrdering( m_phaseTypes, phaseOrder );
+  integer const liquidIndex = phaseOrder[0];
+  integer const vapourIndex = phaseOrder[1];
+  integer const aqueousIndex = phaseOrder[2];
+
   EquationOfState const * equationOfState = m_parameters.get< EquationOfState >();
   EquationOfStateType const liquidEos =  EnumStrings< EquationOfStateType >::fromString( equationOfState->m_equationsOfStateNames[liquidIndex] );
   EquationOfStateType const vapourEos =  EnumStrings< EquationOfStateType >::fromString( equationOfState->m_equationsOfStateNames[vapourIndex] );
@@ -103,6 +109,34 @@ ImmiscibleWaterFlashModel::createParameters( std::unique_ptr< ModelParameters > 
   auto params = NegativeTwoPhaseFlashModel::createParameters( std::move( parameters ) );
   params = ImmiscibleWaterParameters::create( std::move( params ) );
   return params;
+}
+
+void ImmiscibleWaterFlashModel::calculatePhaseOrdering( arrayView1d< integer const > const & phaseTypes,
+                                                        arrayView1d< integer > const & phaseOrder )
+{
+  integer liquidIndex = -1;
+  integer vapourIndex = -1;
+  integer aqueousIndex = -1;
+
+  for( integer ip = 0; ip < KernelWrapper::getNumberOfPhases(); ++ip )
+  {
+    if( isPhaseType( phaseTypes[ip], PhaseType::LIQUID ))
+    {
+      liquidIndex = ip;
+    }
+    if( isPhaseType( phaseTypes[ip], PhaseType::VAPOUR ))
+    {
+      vapourIndex = ip;
+    }
+    if( isPhaseType( phaseTypes[ip], PhaseType::AQUEOUS ))
+    {
+      aqueousIndex = ip;
+    }
+  }
+
+  phaseOrder[0] = liquidIndex;
+  phaseOrder[1] = vapourIndex;
+  phaseOrder[2] = aqueousIndex;
 }
 
 } // end namespace compositional

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/models/ImmiscibleWaterFlashModel.hpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/models/ImmiscibleWaterFlashModel.hpp
@@ -106,7 +106,8 @@ class ImmiscibleWaterFlashModel : public FunctionBase
 public:
   ImmiscibleWaterFlashModel( string const & name,
                              ComponentProperties const & componentProperties,
-                             ModelParameters const & modelParameters );
+                             ModelParameters const & modelParameters,
+                             arrayView1d< integer const > const phaseTypes );
 
   static string catalogName();
 
@@ -127,8 +128,13 @@ public:
   // Create parameters unique to this model
   static std::unique_ptr< ModelParameters > createParameters( std::unique_ptr< ModelParameters > parameters );
 
+  // Determine phase ordering
+  static void calculatePhaseOrdering( arrayView1d< integer const > const & phaseTypes,
+                                      arrayView1d< integer > const & phaseOrder );
+
 private:
   ModelParameters const & m_parameters;
+  arrayView1d< integer const > const m_phaseTypes;
   integer m_waterComponentIndex{-1};
 };
 

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/models/NegativeTwoPhaseFlashModel.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/models/NegativeTwoPhaseFlashModel.cpp
@@ -20,6 +20,7 @@
 #include "NegativeTwoPhaseFlashModel.hpp"
 #include "constitutive/fluid/multifluid/compositional/parameters/CriticalVolume.hpp"
 #include "constitutive/fluid/multifluid/compositional/parameters/BrineSalinity.hpp"
+#include "constitutive/fluid/multifluid/compositional/parameters/PhaseType.hpp"
 
 namespace geos
 {
@@ -38,16 +39,21 @@ string NegativeTwoPhaseFlashModel::catalogName()
 
 NegativeTwoPhaseFlashModel::NegativeTwoPhaseFlashModel( string const & name,
                                                         ComponentProperties const & componentProperties,
-                                                        ModelParameters const & modelParameters ):
+                                                        ModelParameters const & modelParameters,
+                                                        arrayView1d< integer const > const phaseTypes ):
   FunctionBase( name, componentProperties ),
-  m_parameters( modelParameters )
+  m_parameters( modelParameters ),
+  m_phaseTypes( phaseTypes )
 {}
 
 NegativeTwoPhaseFlashModel::KernelWrapper
 NegativeTwoPhaseFlashModel::createKernelWrapper() const
 {
-  constexpr integer liquidIndex = 0;
-  constexpr integer vapourIndex = 1;
+  array1d< integer > phaseOrder( KernelWrapper::getNumberOfPhases());
+  calculatePhaseOrdering( m_phaseTypes, phaseOrder );
+  integer const liquidIndex = phaseOrder[0];
+  integer const vapourIndex = phaseOrder[1];
+
   EquationOfState const * equationOfState = m_parameters.get< EquationOfState >();
   EquationOfStateType const liquidEos =  EnumStrings< EquationOfStateType >::fromString( equationOfState->m_equationsOfStateNames[liquidIndex] );
   EquationOfStateType const vapourEos =  EnumStrings< EquationOfStateType >::fromString( equationOfState->m_equationsOfStateNames[vapourIndex] );
@@ -90,6 +96,53 @@ NegativeTwoPhaseFlashModel::createParameters( std::unique_ptr< ModelParameters >
   std::unique_ptr< ModelParameters > params = EquationOfState::create( std::move( parameters ) );
   params = CriticalVolume::create( std::move( params ) );
   return params;
+}
+
+void NegativeTwoPhaseFlashModel::calculatePhaseOrdering( arrayView1d< integer const > const & phaseTypes,
+                                                         arrayView1d< integer > const & phaseOrder )
+{
+  integer li = -1;
+  integer vi = -1;
+  integer ai = -1;
+  for( integer ip = 0; ip < KernelWrapper::getNumberOfPhases(); ++ip )
+  {
+    if( isPhaseType( phaseTypes[ip], PhaseType::LIQUID ))
+    {
+      li = ip;
+    }
+    if( isPhaseType( phaseTypes[ip], PhaseType::VAPOUR ))
+    {
+      vi = ip;
+    }
+    if( isPhaseType( phaseTypes[ip], PhaseType::AQUEOUS ))
+    {
+      ai = ip;
+    }
+  }
+
+  integer liquidIndex = -1;
+  integer vapourIndex = -1;
+  if( vi < 0 )
+  {
+    // If there's no gas then there is oil and water: oil is the wetting phase
+    vapourIndex = li;
+    liquidIndex = ai;
+  }
+  else if( 0 <= li )
+  {
+    // Oil and gas both present: gas is the wetting phase
+    vapourIndex = vi;
+    liquidIndex = li;
+  }
+  else
+  {
+    // Gas and water: gas is the wetting phase
+    vapourIndex = vi;
+    liquidIndex = ai;
+  }
+
+  phaseOrder[0] = liquidIndex;
+  phaseOrder[1] = vapourIndex;
 }
 
 } // end namespace compositional

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/models/NegativeTwoPhaseFlashModel.hpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/models/NegativeTwoPhaseFlashModel.hpp
@@ -187,7 +187,8 @@ class NegativeTwoPhaseFlashModel : public FunctionBase
 public:
   NegativeTwoPhaseFlashModel( string const & name,
                               ComponentProperties const & componentProperties,
-                              ModelParameters const & modelParameters );
+                              ModelParameters const & modelParameters,
+                              arrayView1d< integer const > const phaseTypes );
 
   static string catalogName();
 
@@ -208,8 +209,13 @@ public:
   // Create parameters unique to this model
   static std::unique_ptr< ModelParameters > createParameters( std::unique_ptr< ModelParameters > parameters );
 
+  // Determine phase ordering
+  static void calculatePhaseOrdering( arrayView1d< integer const > const & phaseTypes,
+                                      arrayView1d< integer > const & phaseOrder );
+
 private:
   ModelParameters const & m_parameters;
+  arrayView1d< integer const > const m_phaseTypes;
 };
 
 } // end namespace compositional

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/parameters/PhaseType.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/parameters/PhaseType.cpp
@@ -1,0 +1,59 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2016-2024 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2024 TotalEnergies
+ * Copyright (c) 2018-2024 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2023-2024 Chevron
+ * Copyright (c) 2019-     GEOS/GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file PhaseType.cpp
+ */
+
+#include "PhaseType.hpp"
+#include "common/format/StringUtilities.hpp"
+
+namespace geos
+{
+
+namespace constitutive
+{
+
+namespace compositional
+{
+
+static std::unordered_map< PhaseType, std::string > const phase_aliases{
+  {PhaseType::LIQUID, "liquid,liq,oil"},
+  {PhaseType::VAPOUR, "gas,vap,vapor,vapour"},
+  {PhaseType::AQUEOUS, "wat,water,aqueous"}
+};
+
+PhaseType getPhaseTypeFromName( string const & name )
+{
+  std::string const lowerCaseName = stringutilities::toLower( name );
+  for( auto const & it : phase_aliases )
+  {
+    auto const nameContainer = stringutilities::tokenize( it.second, ",", true, false );
+    if( std::find( nameContainer.begin(), nameContainer.end(), lowerCaseName ) != nameContainer.end())
+    {
+      return it.first;
+    }
+  }
+  // If the name has not been found, throw
+  GEOS_THROW( GEOS_FMT( "Phase name {} is not valid for compositional fluid model. "
+                        "Allowed values are liquid, vapor and water.", name ), InputError );
+  return PhaseType::LIQUID;
+}
+
+} // namespace compositional
+
+} // namespace constitutive
+
+} // namespace geos

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/parameters/PhaseType.hpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/parameters/PhaseType.hpp
@@ -1,0 +1,76 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2016-2024 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2024 TotalEnergies
+ * Copyright (c) 2018-2024 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2023-2024 Chevron
+ * Copyright (c) 2019-     GEOS/GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file PhaseType.hpp
+ */
+
+#ifndef GEOS_CONSTITUTIVE_FLUID_MULTIFLUID_COMPOSITIONAL_PARAMETERS_PHASETYPE_HPP_
+#define GEOS_CONSTITUTIVE_FLUID_MULTIFLUID_COMPOSITIONAL_PARAMETERS_PHASETYPE_HPP_
+
+#include "common/DataTypes.hpp"
+#include "common/format/EnumStrings.hpp"
+
+namespace geos
+{
+
+namespace constitutive
+{
+
+namespace compositional
+{
+
+/**
+ * @brief A list of fluid phase types
+ */
+enum class PhaseType : integer
+{
+  LIQUID = 0,
+  VAPOUR = 1,
+  AQUEOUS = 2
+};
+
+ENUM_STRINGS( PhaseType,
+              "Liquid",
+              "Vapour",
+              "Aqueous" );
+
+/**
+ * @brief Get the phase type from the name of the phase
+ * @param[in] name The name of the phase
+ * @return returns The phase type. Throws if the phase is not known
+ */
+PhaseType getPhaseTypeFromName( string const & name );
+
+/**
+ * @brief Check if a phase is a specific type
+ * @param[in] type The type of the phase
+ * @param[in] targetType The target type to check
+ * @return returns true if the type matches the target type
+ */
+GEOS_HOST_DEVICE
+GEOS_FORCE_INLINE
+static bool isPhaseType( integer const type, PhaseType const targetType )
+{
+  return (type == static_cast< int >(targetType));
+}
+
+} // namespace compositional
+
+} // namespace constitutive
+
+} // namespace geos
+
+#endif //GEOS_CONSTITUTIVE_FLUID_MULTIFLUID_COMPOSITIONAL_PARAMETERS_PHASETYPE_HPP_

--- a/src/coreComponents/constitutive/unitTests/testImmiscibleWaterFlashModel.cpp
+++ b/src/coreComponents/constitutive/unitTests/testImmiscibleWaterFlashModel.cpp
@@ -103,12 +103,11 @@ public:
     equationOfState->m_equationsOfStateNames.emplace_back( eosName );
     equationOfState->m_equationsOfStateNames.emplace_back( eosName );
 
-    array1d< integer > phaseTypes;
-    phaseTypes.emplace_back( static_cast< integer >(PhaseType::LIQUID));
-    phaseTypes.emplace_back( static_cast< integer >(PhaseType::VAPOUR));
-    phaseTypes.emplace_back( static_cast< integer >(PhaseType::AQUEOUS));
+    m_phaseTypes.emplace_back( static_cast< integer >(PhaseType::LIQUID));
+    m_phaseTypes.emplace_back( static_cast< integer >(PhaseType::VAPOUR));
+    m_phaseTypes.emplace_back( static_cast< integer >(PhaseType::AQUEOUS));
 
-    m_flash = std::make_unique< ImmiscibleWaterFlashModel >( "FlashModel", componentProperties, *m_parameters, phaseTypes );
+    m_flash = std::make_unique< ImmiscibleWaterFlashModel >( "FlashModel", componentProperties, *m_parameters, m_phaseTypes );
   }
 
   ~ImmiscibleWaterFlashModelTestFixture() = default;
@@ -288,6 +287,7 @@ protected:
   std::unique_ptr< TestFluid< NC > > m_fluid{};
   std::unique_ptr< ImmiscibleWaterFlashModel > m_flash{};
   std::unique_ptr< ModelParameters > m_parameters{};
+  array1d< integer > m_phaseTypes{};
 };
 
 using ImmiscibleWaterFlashModel3 = ImmiscibleWaterFlashModelTestFixture< 3 >;

--- a/src/coreComponents/constitutive/unitTests/testImmiscibleWaterFlashModel.cpp
+++ b/src/coreComponents/constitutive/unitTests/testImmiscibleWaterFlashModel.cpp
@@ -17,6 +17,7 @@
 #include "codingUtilities/UnitTestUtilities.hpp"
 #include "constitutive/fluid/multifluid/MultiFluidUtils.hpp"
 #include "constitutive/fluid/multifluid/compositional/parameters/EquationOfState.hpp"
+#include "constitutive/fluid/multifluid/compositional/parameters/PhaseType.hpp"
 #include "constitutive/fluid/multifluid/compositional/models/ImmiscibleWaterFlashModel.hpp"
 #include "TestFluid.hpp"
 #include "TestFluidUtilities.hpp"
@@ -102,7 +103,12 @@ public:
     equationOfState->m_equationsOfStateNames.emplace_back( eosName );
     equationOfState->m_equationsOfStateNames.emplace_back( eosName );
 
-    m_flash = std::make_unique< ImmiscibleWaterFlashModel >( "FlashModel", componentProperties, *m_parameters );
+    array1d< integer > phaseTypes;
+    phaseTypes.emplace_back( static_cast< integer >(PhaseType::LIQUID));
+    phaseTypes.emplace_back( static_cast< integer >(PhaseType::VAPOUR));
+    phaseTypes.emplace_back( static_cast< integer >(PhaseType::AQUEOUS));
+
+    m_flash = std::make_unique< ImmiscibleWaterFlashModel >( "FlashModel", componentProperties, *m_parameters, phaseTypes );
   }
 
   ~ImmiscibleWaterFlashModelTestFixture() = default;


### PR DESCRIPTION
This PR implements a phase ordering for compositional fluid models. The flash models have a specific ordering of the phases (liquid, vapour and water). This might not match the user specified order in the xml. This PR ensures that the mapping from the xml order matches what is expected by the flash.

It also allows the SW model to be used for the "water" phase.