### PR TITLE
fix: Prevent distutils conflicts in CI

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -147,14 +147,14 @@ jobs:
       fail-fast : false
       matrix:
         include:
-          - name: Ubuntu (20.04, gcc 9.4.0, open-mpi 4.0.3)
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc9
-            BUILD_SHARED_LIBS: ON
-            ENABLE_HYPRE: OFF
-            ENABLE_TRILINOS: ON
-            GEOS_ENABLE_BOUNDS_CHECK: ON
-            HOST_CONFIG: /spack-generated.cmake
+          # - name: Ubuntu (20.04, gcc 9.4.0, open-mpi 4.0.3)
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc9
+          #   BUILD_SHARED_LIBS: ON
+          #   ENABLE_HYPRE: OFF
+          #   ENABLE_TRILINOS: ON
+          #   GEOS_ENABLE_BOUNDS_CHECK: ON
+          #   HOST_CONFIG: /spack-generated.cmake
 
 #           - name: Ubuntu debug (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
 #             CMAKE_BUILD_TYPE: Debug
@@ -184,15 +184,15 @@ jobs:
 #             GCP_BUCKET: geosx/ubuntu22.04-gcc11
 #             HOST_CONFIG: /spack-generated.cmake
 
-#           - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2)
-#             CMAKE_BUILD_TYPE: Release
-#             DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
-#             GCP_BUCKET: geosx/ubuntu22.04-gcc12
-#             ENABLE_HYPRE: ON
-#             ENABLE_TRILINOS: OFF
-#             BUILD_SHARED_LIBS: ON
-#             GEOS_ENABLE_BOUNDS_CHECK: ON
-#             HOST_CONFIG: /spack-generated.cmake
+          - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2)
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
+            GCP_BUCKET: geosx/ubuntu22.04-gcc12
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            BUILD_SHARED_LIBS: ON
+            GEOS_ENABLE_BOUNDS_CHECK: ON
+            HOST_CONFIG: /spack-generated.cmake
 
 #           - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2) - NO BOUNDS CHECK
 #             CMAKE_BUILD_TYPE: Release
@@ -319,21 +319,21 @@ jobs:
       fail-fast : false
       matrix:
         include:
-          - name: Ubuntu CUDA debug (20.04, clang 10.0.0 + gcc 9.4.0, open-mpi 4.0.3, cuda-11.8.89)
-            BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
-            CMAKE_BUILD_TYPE: Debug
-            BUILD_GENERATOR: "--ninja"
-            DOCKER_REPOSITORY: geosx/ubuntu20.04-clang10.0.0-cuda11.8.89
-            ENABLE_HYPRE_DEVICE: CUDA
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            GEOS_ENABLE_BOUNDS_CHECK: OFF
-            RUNS_ON: streak2
-            NPROC: 8
-            DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
-            DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
-            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
-            HOST_CONFIG: /spack-generated.cmake
+          # - name: Ubuntu CUDA debug (20.04, clang 10.0.0 + gcc 9.4.0, open-mpi 4.0.3, cuda-11.8.89)
+          #   BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
+          #   CMAKE_BUILD_TYPE: Debug
+          #   BUILD_GENERATOR: "--ninja"
+          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-clang10.0.0-cuda11.8.89
+          #   ENABLE_HYPRE_DEVICE: CUDA
+          #   ENABLE_HYPRE: ON
+          #   ENABLE_TRILINOS: OFF
+          #   GEOS_ENABLE_BOUNDS_CHECK: OFF
+          #   RUNS_ON: streak2
+          #   NPROC: 8
+          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
+          #   DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
+          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
+          #   HOST_CONFIG: /spack-generated.cmake
       
           - name: Ubuntu CUDA (20.04, clang 10.0.0 + gcc 9.4.0, open-mpi 4.0.3, cuda-11.8.89)
             BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
@@ -351,71 +351,71 @@ jobs:
             DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
             HOST_CONFIG: /spack-generated.cmake
           
-          - name: Rockylinux CUDA (8, clang 17.0.6, cuda 12.5.1)
-            BUILD_AND_TEST_CLI_ARGS: "--no-install-schema"
-            CMAKE_BUILD_TYPE: Release
-            BUILD_GENERATOR: "--ninja"
-            ENABLE_HYPRE_DEVICE: CUDA
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            GEOS_ENABLE_BOUNDS_CHECK: OFF
-            DOCKER_REPOSITORY: geosx/rockylinux8-clang17-cuda12.5
-            RUNS_ON: streak
-            NPROC: 8
-            DOCKER_RUN_ARGS: "--cpus=8 --memory=256g --runtime=nvidia --gpus all -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
-            DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
-            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
-            HOST_CONFIG: /spack-generated.cmake
+          # - name: Rockylinux CUDA (8, clang 17.0.6, cuda 12.5.1)
+          #   BUILD_AND_TEST_CLI_ARGS: "--no-install-schema"
+          #   CMAKE_BUILD_TYPE: Release
+          #   BUILD_GENERATOR: "--ninja"
+          #   ENABLE_HYPRE_DEVICE: CUDA
+          #   ENABLE_HYPRE: ON
+          #   ENABLE_TRILINOS: OFF
+          #   GEOS_ENABLE_BOUNDS_CHECK: OFF
+          #   DOCKER_REPOSITORY: geosx/rockylinux8-clang17-cuda12.5
+          #   RUNS_ON: streak
+          #   NPROC: 8
+          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=256g --runtime=nvidia --gpus all -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
+          #   DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
+          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
+          #   HOST_CONFIG: /spack-generated.cmake
           
-          - name: Rockylinux CUDA (8, gcc 8.5, cuda 12.5.1)
-            BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
-            CMAKE_BUILD_TYPE: Release
-            BUILD_GENERATOR: "--ninja"
-            ENABLE_HYPRE_DEVICE: CUDA
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            GEOS_ENABLE_BOUNDS_CHECK: OFF
-            DOCKER_REPOSITORY: geosx/rockylinux8-gcc8-cuda12.5
-            RUNS_ON: streak2
-            NPROC: 8
-            DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
-            DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
-            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
-            HOST_CONFIG: /spack-generated.cmake
+          # - name: Rockylinux CUDA (8, gcc 8.5, cuda 12.5.1)
+          #   BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
+          #   CMAKE_BUILD_TYPE: Release
+          #   BUILD_GENERATOR: "--ninja"
+          #   ENABLE_HYPRE_DEVICE: CUDA
+          #   ENABLE_HYPRE: ON
+          #   ENABLE_TRILINOS: OFF
+          #   GEOS_ENABLE_BOUNDS_CHECK: OFF
+          #   DOCKER_REPOSITORY: geosx/rockylinux8-gcc8-cuda12.5
+          #   RUNS_ON: streak2
+          #   NPROC: 8
+          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
+          #   DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
+          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
+          #   HOST_CONFIG: /spack-generated.cmake
 
-          - name: Pangea 3 CUDA (AlmaLinux 8.8, gcc 9.4.0, open-mpi 4.1.2, cuda 11.5.0, openblas 0.3.10)
-            BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
-            CMAKE_BUILD_TYPE: Release
-            BUILD_GENERATOR: "--makefile"
-            DOCKER_REPOSITORY: geosx/pangea3-almalinux8-gcc9.4-openmpi4.1.2-cuda11.5.0-openblas0.3.18
-            ENABLE_HYPRE_DEVICE: CUDA
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            GEOS_ENABLE_BOUNDS_CHECK: OFF
-            HOST_ARCH: ppc64le
-            RUNS_ON: streak2
-            NPROC: 8
-            DOCKER_RUN_ARGS: "--cpus=8 --memory=128g -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
-            DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
-            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
-            HOST_CONFIG: /spack-generated-wave-solver-only.cmake
+          # - name: Pangea 3 CUDA (AlmaLinux 8.8, gcc 9.4.0, open-mpi 4.1.2, cuda 11.5.0, openblas 0.3.10)
+          #   BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
+          #   CMAKE_BUILD_TYPE: Release
+          #   BUILD_GENERATOR: "--makefile"
+          #   DOCKER_REPOSITORY: geosx/pangea3-almalinux8-gcc9.4-openmpi4.1.2-cuda11.5.0-openblas0.3.18
+          #   ENABLE_HYPRE_DEVICE: CUDA
+          #   ENABLE_HYPRE: ON
+          #   ENABLE_TRILINOS: OFF
+          #   GEOS_ENABLE_BOUNDS_CHECK: OFF
+          #   HOST_ARCH: ppc64le
+          #   RUNS_ON: streak2
+          #   NPROC: 8
+          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=128g -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
+          #   DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
+          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
+          #   HOST_CONFIG: /spack-generated-wave-solver-only.cmake
 
-          - name: Sherlock GPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10, cuda 12.4.0,)
-            BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
-            BUILD_GENERATOR: "--ninja"
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-cuda12.4.0-openblas0.3.10-zlib1.2.11
-            ENABLE_HYPRE_DEVICE: CUDA
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            GEOS_ENABLE_BOUNDS_CHECK: OFF
-            GCP_BUCKET: geosx/Sherlock-GPU
-            RUNS_ON: streak2
-            NPROC: 8
-            DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
-            DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
-            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
-            HOST_CONFIG: /spack-generated.cmake
+          # - name: Sherlock GPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10, cuda 12.4.0,)
+          #   BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
+          #   BUILD_GENERATOR: "--ninja"
+          #   CMAKE_BUILD_TYPE: Release
+          #   DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-cuda12.4.0-openblas0.3.10-zlib1.2.11
+          #   ENABLE_HYPRE_DEVICE: CUDA
+          #   ENABLE_HYPRE: ON
+          #   ENABLE_TRILINOS: OFF
+          #   GEOS_ENABLE_BOUNDS_CHECK: OFF
+          #   GCP_BUCKET: geosx/Sherlock-GPU
+          #   RUNS_ON: streak2
+          #   NPROC: 8
+          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
+          #   DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
+          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
+          #   HOST_CONFIG: /spack-generated.cmake
 
           # Below this line, jobs that deploy to Google Cloud.
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -156,73 +156,73 @@ jobs:
             GEOS_ENABLE_BOUNDS_CHECK: ON
             HOST_CONFIG: /spack-generated.cmake
 
-          - name: Ubuntu debug (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
-            CMAKE_BUILD_TYPE: Debug
-            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
-            BUILD_SHARED_LIBS: ON
-            ENABLE_HYPRE: OFF
-            ENABLE_TRILINOS: ON
-            GEOS_ENABLE_BOUNDS_CHECK: ON
-            HOST_CONFIG: /spack-generated.cmake
+#           - name: Ubuntu debug (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
+#             CMAKE_BUILD_TYPE: Debug
+#             DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
+#             BUILD_SHARED_LIBS: ON
+#             ENABLE_HYPRE: OFF
+#             ENABLE_TRILINOS: ON
+#             GEOS_ENABLE_BOUNDS_CHECK: ON
+#             HOST_CONFIG: /spack-generated.cmake
 
-          - name: Ubuntu (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
-            BUILD_SHARED_LIBS: ON
-            ENABLE_HYPRE: OFF
-            ENABLE_TRILINOS: ON
-            GEOS_ENABLE_BOUNDS_CHECK: ON
-            HOST_CONFIG: /spack-generated.cmake
+#           - name: Ubuntu (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
+#             CMAKE_BUILD_TYPE: Release
+#             DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
+#             BUILD_SHARED_LIBS: ON
+#             ENABLE_HYPRE: OFF
+#             ENABLE_TRILINOS: ON
+#             GEOS_ENABLE_BOUNDS_CHECK: ON
+#             HOST_CONFIG: /spack-generated.cmake
 
-          - name: Ubuntu (22.04, gcc 11.4.0, open-mpi 4.1.2)
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc11
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            BUILD_SHARED_LIBS: ON
-            GEOS_ENABLE_BOUNDS_CHECK: OFF
-            GCP_BUCKET: geosx/ubuntu22.04-gcc11
-            HOST_CONFIG: /spack-generated.cmake
+#           - name: Ubuntu (22.04, gcc 11.4.0, open-mpi 4.1.2)
+#             CMAKE_BUILD_TYPE: Release
+#             DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc11
+#             ENABLE_HYPRE: ON
+#             ENABLE_TRILINOS: OFF
+#             BUILD_SHARED_LIBS: ON
+#             GEOS_ENABLE_BOUNDS_CHECK: OFF
+#             GCP_BUCKET: geosx/ubuntu22.04-gcc11
+#             HOST_CONFIG: /spack-generated.cmake
 
-          - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2)
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
-            GCP_BUCKET: geosx/ubuntu22.04-gcc12
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            BUILD_SHARED_LIBS: ON
-            GEOS_ENABLE_BOUNDS_CHECK: ON
-            HOST_CONFIG: /spack-generated.cmake
+#           - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2)
+#             CMAKE_BUILD_TYPE: Release
+#             DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
+#             GCP_BUCKET: geosx/ubuntu22.04-gcc12
+#             ENABLE_HYPRE: ON
+#             ENABLE_TRILINOS: OFF
+#             BUILD_SHARED_LIBS: ON
+#             GEOS_ENABLE_BOUNDS_CHECK: ON
+#             HOST_CONFIG: /spack-generated.cmake
 
-          - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2) - NO BOUNDS CHECK
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
-            GCP_BUCKET: geosx/ubuntu22.04-gcc12
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            BUILD_SHARED_LIBS: ON
-            GEOS_ENABLE_BOUNDS_CHECK: OFF
-            HOST_CONFIG: /spack-generated.cmake
+#           - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2) - NO BOUNDS CHECK
+#             CMAKE_BUILD_TYPE: Release
+#             DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
+#             GCP_BUCKET: geosx/ubuntu22.04-gcc12
+#             ENABLE_HYPRE: ON
+#             ENABLE_TRILINOS: OFF
+#             BUILD_SHARED_LIBS: ON
+#             GEOS_ENABLE_BOUNDS_CHECK: OFF
+#             HOST_CONFIG: /spack-generated.cmake
 
-          - name: Ubuntu (22.04, clang 15.0.7, open-mpi 4.1.2)
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/ubuntu22.04-clang15
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            GEOS_ENABLE_BOUNDS_CHECK: ON
-            BUILD_SHARED_LIBS: ON
-            HOST_CONFIG: /spack-generated.cmake
+#           - name: Ubuntu (22.04, clang 15.0.7, open-mpi 4.1.2)
+#             CMAKE_BUILD_TYPE: Release
+#             DOCKER_REPOSITORY: geosx/ubuntu22.04-clang15
+#             ENABLE_HYPRE: ON
+#             ENABLE_TRILINOS: OFF
+#             GEOS_ENABLE_BOUNDS_CHECK: ON
+#             BUILD_SHARED_LIBS: ON
+#             HOST_CONFIG: /spack-generated.cmake
 
-          - name: Sherlock CPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10)
-            CMAKE_BUILD_TYPE: Release
-            DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-openblas0.3.10-zlib1.2.11
-            ENABLE_HYPRE: ON
-            ENABLE_TRILINOS: OFF
-            GEOS_ENABLE_BOUNDS_CHECK: OFF
-            GCP_BUCKET: geosx/Sherlock-CPU
-            HOST_CONFIG: /spack-generated.cmake
-#            HOST_CONFIG: host-configs/Stanford/sherlock-gcc10.cmake
-            BUILD_SHARED_LIBS: ON
+#           - name: Sherlock CPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10)
+#             CMAKE_BUILD_TYPE: Release
+#             DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-openblas0.3.10-zlib1.2.11
+#             ENABLE_HYPRE: ON
+#             ENABLE_TRILINOS: OFF
+#             GEOS_ENABLE_BOUNDS_CHECK: OFF
+#             GCP_BUCKET: geosx/Sherlock-CPU
+#             HOST_CONFIG: /spack-generated.cmake
+# #            HOST_CONFIG: host-configs/Stanford/sherlock-gcc10.cmake
+#             BUILD_SHARED_LIBS: ON
 
     uses: ./.github/workflows/build_and_test.yml
     with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -147,42 +147,42 @@ jobs:
       fail-fast : false
       matrix:
         include:
-          # - name: Ubuntu (20.04, gcc 9.4.0, open-mpi 4.0.3)
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc9
-          #   BUILD_SHARED_LIBS: ON
-          #   ENABLE_HYPRE: OFF
-          #   ENABLE_TRILINOS: ON
-          #   GEOS_ENABLE_BOUNDS_CHECK: ON
-          #   HOST_CONFIG: /spack-generated.cmake
+          - name: Ubuntu (20.04, gcc 9.4.0, open-mpi 4.0.3)
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc9
+            BUILD_SHARED_LIBS: ON
+            ENABLE_HYPRE: OFF
+            ENABLE_TRILINOS: ON
+            GEOS_ENABLE_BOUNDS_CHECK: ON
+            HOST_CONFIG: /spack-generated.cmake
 
-#           - name: Ubuntu debug (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
-#             CMAKE_BUILD_TYPE: Debug
-#             DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
-#             BUILD_SHARED_LIBS: ON
-#             ENABLE_HYPRE: OFF
-#             ENABLE_TRILINOS: ON
-#             GEOS_ENABLE_BOUNDS_CHECK: ON
-#             HOST_CONFIG: /spack-generated.cmake
+          - name: Ubuntu debug (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
+            CMAKE_BUILD_TYPE: Debug
+            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
+            BUILD_SHARED_LIBS: ON
+            ENABLE_HYPRE: OFF
+            ENABLE_TRILINOS: ON
+            GEOS_ENABLE_BOUNDS_CHECK: ON
+            HOST_CONFIG: /spack-generated.cmake
 
-#           - name: Ubuntu (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
-#             CMAKE_BUILD_TYPE: Release
-#             DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
-#             BUILD_SHARED_LIBS: ON
-#             ENABLE_HYPRE: OFF
-#             ENABLE_TRILINOS: ON
-#             GEOS_ENABLE_BOUNDS_CHECK: ON
-#             HOST_CONFIG: /spack-generated.cmake
+          - name: Ubuntu (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/ubuntu20.04-gcc10
+            BUILD_SHARED_LIBS: ON
+            ENABLE_HYPRE: OFF
+            ENABLE_TRILINOS: ON
+            GEOS_ENABLE_BOUNDS_CHECK: ON
+            HOST_CONFIG: /spack-generated.cmake
 
-#           - name: Ubuntu (22.04, gcc 11.4.0, open-mpi 4.1.2)
-#             CMAKE_BUILD_TYPE: Release
-#             DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc11
-#             ENABLE_HYPRE: ON
-#             ENABLE_TRILINOS: OFF
-#             BUILD_SHARED_LIBS: ON
-#             GEOS_ENABLE_BOUNDS_CHECK: OFF
-#             GCP_BUCKET: geosx/ubuntu22.04-gcc11
-#             HOST_CONFIG: /spack-generated.cmake
+          - name: Ubuntu (22.04, gcc 11.4.0, open-mpi 4.1.2)
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc11
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            BUILD_SHARED_LIBS: ON
+            GEOS_ENABLE_BOUNDS_CHECK: OFF
+            GCP_BUCKET: geosx/ubuntu22.04-gcc11
+            HOST_CONFIG: /spack-generated.cmake
 
           - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2)
             CMAKE_BUILD_TYPE: Release
@@ -194,35 +194,35 @@ jobs:
             GEOS_ENABLE_BOUNDS_CHECK: ON
             HOST_CONFIG: /spack-generated.cmake
 
-#           - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2) - NO BOUNDS CHECK
-#             CMAKE_BUILD_TYPE: Release
-#             DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
-#             GCP_BUCKET: geosx/ubuntu22.04-gcc12
-#             ENABLE_HYPRE: ON
-#             ENABLE_TRILINOS: OFF
-#             BUILD_SHARED_LIBS: ON
-#             GEOS_ENABLE_BOUNDS_CHECK: OFF
-#             HOST_CONFIG: /spack-generated.cmake
+          - name: Ubuntu (22.04, gcc 12.3.0, open-mpi 4.1.2) - NO BOUNDS CHECK
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/ubuntu22.04-gcc12
+            GCP_BUCKET: geosx/ubuntu22.04-gcc12
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            BUILD_SHARED_LIBS: ON
+            GEOS_ENABLE_BOUNDS_CHECK: OFF
+            HOST_CONFIG: /spack-generated.cmake
 
-#           - name: Ubuntu (22.04, clang 15.0.7, open-mpi 4.1.2)
-#             CMAKE_BUILD_TYPE: Release
-#             DOCKER_REPOSITORY: geosx/ubuntu22.04-clang15
-#             ENABLE_HYPRE: ON
-#             ENABLE_TRILINOS: OFF
-#             GEOS_ENABLE_BOUNDS_CHECK: ON
-#             BUILD_SHARED_LIBS: ON
-#             HOST_CONFIG: /spack-generated.cmake
+          - name: Ubuntu (22.04, clang 15.0.7, open-mpi 4.1.2)
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/ubuntu22.04-clang15
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            GEOS_ENABLE_BOUNDS_CHECK: ON
+            BUILD_SHARED_LIBS: ON
+            HOST_CONFIG: /spack-generated.cmake
 
-#           - name: Sherlock CPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10)
-#             CMAKE_BUILD_TYPE: Release
-#             DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-openblas0.3.10-zlib1.2.11
-#             ENABLE_HYPRE: ON
-#             ENABLE_TRILINOS: OFF
-#             GEOS_ENABLE_BOUNDS_CHECK: OFF
-#             GCP_BUCKET: geosx/Sherlock-CPU
-#             HOST_CONFIG: /spack-generated.cmake
-# #            HOST_CONFIG: host-configs/Stanford/sherlock-gcc10.cmake
-#             BUILD_SHARED_LIBS: ON
+          - name: Sherlock CPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10)
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-openblas0.3.10-zlib1.2.11
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            GEOS_ENABLE_BOUNDS_CHECK: OFF
+            GCP_BUCKET: geosx/Sherlock-CPU
+            HOST_CONFIG: /spack-generated.cmake
+#            HOST_CONFIG: host-configs/Stanford/sherlock-gcc10.cmake
+            BUILD_SHARED_LIBS: ON
 
     uses: ./.github/workflows/build_and_test.yml
     with:
@@ -319,21 +319,21 @@ jobs:
       fail-fast : false
       matrix:
         include:
-          # - name: Ubuntu CUDA debug (20.04, clang 10.0.0 + gcc 9.4.0, open-mpi 4.0.3, cuda-11.8.89)
-          #   BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
-          #   CMAKE_BUILD_TYPE: Debug
-          #   BUILD_GENERATOR: "--ninja"
-          #   DOCKER_REPOSITORY: geosx/ubuntu20.04-clang10.0.0-cuda11.8.89
-          #   ENABLE_HYPRE_DEVICE: CUDA
-          #   ENABLE_HYPRE: ON
-          #   ENABLE_TRILINOS: OFF
-          #   GEOS_ENABLE_BOUNDS_CHECK: OFF
-          #   RUNS_ON: streak2
-          #   NPROC: 8
-          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
-          #   DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
-          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
-          #   HOST_CONFIG: /spack-generated.cmake
+          - name: Ubuntu CUDA debug (20.04, clang 10.0.0 + gcc 9.4.0, open-mpi 4.0.3, cuda-11.8.89)
+            BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
+            CMAKE_BUILD_TYPE: Debug
+            BUILD_GENERATOR: "--ninja"
+            DOCKER_REPOSITORY: geosx/ubuntu20.04-clang10.0.0-cuda11.8.89
+            ENABLE_HYPRE_DEVICE: CUDA
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            GEOS_ENABLE_BOUNDS_CHECK: OFF
+            RUNS_ON: streak2
+            NPROC: 8
+            DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
+            DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
+            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
+            HOST_CONFIG: /spack-generated.cmake
       
           - name: Ubuntu CUDA (20.04, clang 10.0.0 + gcc 9.4.0, open-mpi 4.0.3, cuda-11.8.89)
             BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
@@ -351,71 +351,71 @@ jobs:
             DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
             HOST_CONFIG: /spack-generated.cmake
           
-          # - name: Rockylinux CUDA (8, clang 17.0.6, cuda 12.5.1)
-          #   BUILD_AND_TEST_CLI_ARGS: "--no-install-schema"
-          #   CMAKE_BUILD_TYPE: Release
-          #   BUILD_GENERATOR: "--ninja"
-          #   ENABLE_HYPRE_DEVICE: CUDA
-          #   ENABLE_HYPRE: ON
-          #   ENABLE_TRILINOS: OFF
-          #   GEOS_ENABLE_BOUNDS_CHECK: OFF
-          #   DOCKER_REPOSITORY: geosx/rockylinux8-clang17-cuda12.5
-          #   RUNS_ON: streak
-          #   NPROC: 8
-          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=256g --runtime=nvidia --gpus all -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
-          #   DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
-          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
-          #   HOST_CONFIG: /spack-generated.cmake
+          - name: Rockylinux CUDA (8, clang 17.0.6, cuda 12.5.1)
+            BUILD_AND_TEST_CLI_ARGS: "--no-install-schema"
+            CMAKE_BUILD_TYPE: Release
+            BUILD_GENERATOR: "--ninja"
+            ENABLE_HYPRE_DEVICE: CUDA
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            GEOS_ENABLE_BOUNDS_CHECK: OFF
+            DOCKER_REPOSITORY: geosx/rockylinux8-clang17-cuda12.5
+            RUNS_ON: streak
+            NPROC: 8
+            DOCKER_RUN_ARGS: "--cpus=8 --memory=256g --runtime=nvidia --gpus all -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
+            DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
+            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
+            HOST_CONFIG: /spack-generated.cmake
           
-          # - name: Rockylinux CUDA (8, gcc 8.5, cuda 12.5.1)
-          #   BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
-          #   CMAKE_BUILD_TYPE: Release
-          #   BUILD_GENERATOR: "--ninja"
-          #   ENABLE_HYPRE_DEVICE: CUDA
-          #   ENABLE_HYPRE: ON
-          #   ENABLE_TRILINOS: OFF
-          #   GEOS_ENABLE_BOUNDS_CHECK: OFF
-          #   DOCKER_REPOSITORY: geosx/rockylinux8-gcc8-cuda12.5
-          #   RUNS_ON: streak2
-          #   NPROC: 8
-          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
-          #   DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
-          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
-          #   HOST_CONFIG: /spack-generated.cmake
+          - name: Rockylinux CUDA (8, gcc 8.5, cuda 12.5.1)
+            BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
+            CMAKE_BUILD_TYPE: Release
+            BUILD_GENERATOR: "--ninja"
+            ENABLE_HYPRE_DEVICE: CUDA
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            GEOS_ENABLE_BOUNDS_CHECK: OFF
+            DOCKER_REPOSITORY: geosx/rockylinux8-gcc8-cuda12.5
+            RUNS_ON: streak2
+            NPROC: 8
+            DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
+            DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
+            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
+            HOST_CONFIG: /spack-generated.cmake
 
-          # - name: Pangea 3 CUDA (AlmaLinux 8.8, gcc 9.4.0, open-mpi 4.1.2, cuda 11.5.0, openblas 0.3.10)
-          #   BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
-          #   CMAKE_BUILD_TYPE: Release
-          #   BUILD_GENERATOR: "--makefile"
-          #   DOCKER_REPOSITORY: geosx/pangea3-almalinux8-gcc9.4-openmpi4.1.2-cuda11.5.0-openblas0.3.18
-          #   ENABLE_HYPRE_DEVICE: CUDA
-          #   ENABLE_HYPRE: ON
-          #   ENABLE_TRILINOS: OFF
-          #   GEOS_ENABLE_BOUNDS_CHECK: OFF
-          #   HOST_ARCH: ppc64le
-          #   RUNS_ON: streak2
-          #   NPROC: 8
-          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=128g -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
-          #   DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
-          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
-          #   HOST_CONFIG: /spack-generated-wave-solver-only.cmake
+          - name: Pangea 3 CUDA (AlmaLinux 8.8, gcc 9.4.0, open-mpi 4.1.2, cuda 11.5.0, openblas 0.3.10)
+            BUILD_AND_TEST_CLI_ARGS: "--build-exe-only --no-install-schema"
+            CMAKE_BUILD_TYPE: Release
+            BUILD_GENERATOR: "--makefile"
+            DOCKER_REPOSITORY: geosx/pangea3-almalinux8-gcc9.4-openmpi4.1.2-cuda11.5.0-openblas0.3.18
+            ENABLE_HYPRE_DEVICE: CUDA
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            GEOS_ENABLE_BOUNDS_CHECK: OFF
+            HOST_ARCH: ppc64le
+            RUNS_ON: streak2
+            NPROC: 8
+            DOCKER_RUN_ARGS: "--cpus=8 --memory=128g -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
+            DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
+            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
+            HOST_CONFIG: /spack-generated-wave-solver-only.cmake
 
-          # - name: Sherlock GPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10, cuda 12.4.0,)
-          #   BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
-          #   BUILD_GENERATOR: "--ninja"
-          #   CMAKE_BUILD_TYPE: Release
-          #   DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-cuda12.4.0-openblas0.3.10-zlib1.2.11
-          #   ENABLE_HYPRE_DEVICE: CUDA
-          #   ENABLE_HYPRE: ON
-          #   ENABLE_TRILINOS: OFF
-          #   GEOS_ENABLE_BOUNDS_CHECK: OFF
-          #   GCP_BUCKET: geosx/Sherlock-GPU
-          #   RUNS_ON: streak2
-          #   NPROC: 8
-          #   DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
-          #   DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
-          #   DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
-          #   HOST_CONFIG: /spack-generated.cmake
+          - name: Sherlock GPU (centos 7.9.2009, gcc 10.1.0, open-mpi 4.1.2, openblas 0.3.10, cuda 12.4.0,)
+            BUILD_AND_TEST_CLI_ARGS: "--no-run-unit-tests --no-install-schema"
+            BUILD_GENERATOR: "--ninja"
+            CMAKE_BUILD_TYPE: Release
+            DOCKER_REPOSITORY: geosx/sherlock-gcc10.1.0-openmpi4.1.2-cuda12.4.0-openblas0.3.10-zlib1.2.11
+            ENABLE_HYPRE_DEVICE: CUDA
+            ENABLE_HYPRE: ON
+            ENABLE_TRILINOS: OFF
+            GEOS_ENABLE_BOUNDS_CHECK: OFF
+            GCP_BUCKET: geosx/Sherlock-GPU
+            RUNS_ON: streak2
+            NPROC: 8
+            DOCKER_RUN_ARGS: "--cpus=8 --memory=128g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/etc/pki/ca-trust/source/anchors/llnl:ro"
+            DOCKER_CERTS_DIR: "/etc/pki/ca-trust/source/anchors"
+            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-trust"
+            HOST_CONFIG: /spack-generated.cmake
 
           # Below this line, jobs that deploy to Google Cloud.
 

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -208,17 +208,35 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   echo "Running the integrated tests has been requested."
   # We install the python environment required by ATS to run the integrated tests.
   or_die apt-get update
-  or_die apt-get install -y virtualenv python3-dev python-is-python3
+  or_die apt-get install -y python3.10-venv python3-pip python3-setuptools python3-wheel python-is-python3
+
   ATS_PYTHON_HOME=/tmp/run_integrated_tests_virtualenv
-  or_die virtualenv ${ATS_PYTHON_HOME}
+  or_die python3 -m venv ${ATS_PYTHON_HOME}
+  source ${ATS_PYTHON_HOME}/bin/activate
 
-  # Force setuptools to use its own bundled distutils instead of the system's.
-  # This is a direct fix for the AssertionError related to /usr/lib/python3.10/distutils/core.py
-  export SETUPTOOLS_USE_DISTUTILS=local
 
-  or_die ${ATS_PYTHON_HOME}/bin/python3 -m pip install --upgrade pip setuptools
+  # 🔍 Debug the Python environment
+  echo "Python binary:"
+  which python
+  echo "Python version:"
+  python --version
+  echo "Ensurepip version:"
+  python -m ensurepip --version || echo "ensurepip not available"
+  echo "Distutils location before upgrade:"
+  python -c "import distutils; print(distutils.__file__)" || echo "distutils not found"
+  echo "Setuptools location before upgrade:"
+  python -c "import setuptools; print(setuptools.__file__)" || echo "setuptools not found"
 
-  ${ATS_PYTHON_HOME}/bin/python3 -m pip cache purge
+  # Upgrade pip and setuptools inside the venv
+  pip install --upgrade pip setuptools wheel
+
+  echo "Distutils location after upgrade:"
+  python -c "import distutils; print(distutils.__file__)" || echo "distutils not found"
+  echo "Setuptools location after upgrade:"
+  python -c "import setuptools; print(setuptools.__file__)" || echo "setuptools not found"
+
+  # Clear pip cache
+  pip cache purge
 
   # Setup a temporary directory to hold tests
   tempdir=$(mktemp -d)

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -318,7 +318,7 @@ fi
 
 if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   # fix the setuptools/distutils conflict
-  # export SETUPTOOLS_USE_DISTUTILS=stdlib
+  export SETUPTOOLS_USE_DISTUTILS=stdlib
 
   # We split the process in two steps. First installing the environment, then running the tests.
   or_die cmake --build . --target ats_environment

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -218,24 +218,20 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   or_die python3 -m venv ${ATS_PYTHON_HOME}
   source ${ATS_PYTHON_HOME}/bin/activate
 
+  # STEP 1: Upgrade pip and setuptools WHILE the system distutils still exists.
+  # The old version of pip needs it to run, but the new versions will be self-contained.
+  echo "--- Upgrading Python tooling to be self-sufficient ---"
+  pip install --upgrade pip setuptools wheel
+  echo "--- Tooling upgrade complete. The environment is now self-contained. ---"
+
+  # STEP 2: NOW that the tools are modern, remove the conflicting system directory.
+  # The new pip and setuptools we just installed no longer need it.
   CONFLICT_DIR="/usr/lib/python3.10/distutils"
-
-  echo "--- Checking for conflicting system distutils at: ${CONFLICT_DIR} ---"
+  echo "--- Removing now-unnecessary system distutils directory ---"
   if [ -d "${CONFLICT_DIR}" ]; then
-      echo "[CONFLICT CONFIRMED] Directory found. Attempting forceful removal..."
       rm -rf "${CONFLICT_DIR}"
-
-      # Verify that the directory is now gone.
-      if [ -d "${CONFLICT_DIR}" ]; then
-          echo "[FATAL ERROR] The directory ${CONFLICT_DIR} STILL EXISTS after 'rm -rf'."
-          echo "This indicates a fundamental issue with the Docker environment's filesystem."
-          exit 1
-      else
-          echo "[SUCCESS] The conflict directory has been confirmed as removed."
-      fi
+      echo "[SUCCESS] System distutils removed."
   else
-      echo "[INFO] No conflict directory was found to remove."
-  fi
 
   # Debug the Python environment
   echo "Python binary:"

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -208,7 +208,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   echo "Running the integrated tests has been requested."
   # We install the python environment required by ATS to run the integrated tests.
   or_die apt-get update
-  or_die apt-get install -y virtualenv python3-dev python-is-python3
+  or_die apt-get install -y python3.10-venv python3-dev python-is-python3
   ATS_PYTHON_HOME=/tmp/run_integrated_tests_virtualenv
   
   # Python 3.10+ deprecates distutils, and virtualenv may still rely on it, switch to using the built-in venv module

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -318,8 +318,8 @@ fi
 
 if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   # fix the setuptools/distutils conflict
-  export SETUPTOOLS_USE_DISTUTILS=stdlib
-  
+  # export SETUPTOOLS_USE_DISTUTILS=stdlib
+
   # We split the process in two steps. First installing the environment, then running the tests.
   or_die cmake --build . --target ats_environment
 

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -232,6 +232,8 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
       rm -rf "${CONFLICT_DIR}"
       echo "[SUCCESS] System distutils removed."
   else
+      echo "[INFO] System distutils was not present to be removed."
+  fi
 
   # Debug the Python environment
   echo "Python binary:"

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -208,14 +208,17 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   echo "Running the integrated tests has been requested."
   # We install the python environment required by ATS to run the integrated tests.
   or_die apt-get update
-  or_die apt-get install -y python3.10-venv python3-pip python3-setuptools python3-wheel python-is-python3
+
+  # We only install the bare minimum needed to create a virtual environment.
+  # 'pip', 'setuptools', and 'wheel' will be installed *inside* the venv.
+  # --no-install-recommends is CRITICAL to prevent apt from installing the conflicting system `python3-distutils`.
+  or_die apt-get install -y --no-install-recommends python3.10-venv python-is-python3
 
   ATS_PYTHON_HOME=/tmp/run_integrated_tests_virtualenv
   or_die python3 -m venv ${ATS_PYTHON_HOME}
   source ${ATS_PYTHON_HOME}/bin/activate
 
-
-  # 🔍 Debug the Python environment
+  # Debug the Python environment
   echo "Python binary:"
   which python
   echo "Python version:"
@@ -227,7 +230,7 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   echo "Setuptools location before upgrade:"
   python -c "import setuptools; print(setuptools.__file__)" || echo "setuptools not found"
 
-  # Upgrade pip and setuptools inside the venv
+  # Upgrade pip and setuptools inside the venv. This will install modern, self-contained versions.
   pip install --upgrade pip setuptools wheel
 
   echo "Distutils location after upgrade:"

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -208,55 +208,11 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   echo "Running the integrated tests has been requested."
   # We install the python environment required by ATS to run the integrated tests.
   or_die apt-get update
-
-  # We only install the bare minimum needed to create a virtual environment.
-  # 'pip', 'setuptools', and 'wheel' will be installed *inside* the venv.
-  # --no-install-recommends is CRITICAL to prevent apt from installing the conflicting system `python3-distutils`.
-  or_die apt-get install -y --no-install-recommends python3.10-venv python-is-python3
-
+  or_die apt-get install -y virtualenv python3-dev python-is-python3
   ATS_PYTHON_HOME=/tmp/run_integrated_tests_virtualenv
-  or_die python3 -m venv ${ATS_PYTHON_HOME}
-  source ${ATS_PYTHON_HOME}/bin/activate
+  or_die virtualenv ${ATS_PYTHON_HOME}
 
-  # STEP 1: Upgrade pip and setuptools WHILE the system distutils still exists.
-  # The old version of pip needs it to run, but the new versions will be self-contained.
-  echo "--- Upgrading Python tooling to be self-sufficient ---"
-  pip install --upgrade pip setuptools wheel
-  echo "--- Tooling upgrade complete. The environment is now self-contained. ---"
-
-  # STEP 2: NOW that the tools are modern, remove the conflicting system directory.
-  # The new pip and setuptools we just installed no longer need it.
-  CONFLICT_DIR="/usr/lib/python3.10/distutils"
-  echo "--- Removing now-unnecessary system distutils directory ---"
-  if [ -d "${CONFLICT_DIR}" ]; then
-      rm -rf "${CONFLICT_DIR}"
-      echo "[SUCCESS] System distutils removed."
-  else
-      echo "[INFO] System distutils was not present to be removed."
-  fi
-
-  # Debug the Python environment
-  echo "Python binary:"
-  which python
-  echo "Python version:"
-  python --version
-  echo "Ensurepip version:"
-  python -m ensurepip --version || echo "ensurepip not available"
-  echo "Distutils location before upgrade:"
-  python -c "import distutils; print(distutils.__file__)" || echo "distutils not found"
-  echo "Setuptools location before upgrade:"
-  python -c "import setuptools; print(setuptools.__file__)" || echo "setuptools not found"
-
-  # Upgrade pip and setuptools inside the venv. This will install modern, self-contained versions.
-  pip install --upgrade pip setuptools wheel
-
-  echo "Distutils location after upgrade:"
-  python -c "import distutils; print(distutils.__file__)" || echo "distutils not found"
-  echo "Setuptools location after upgrade:"
-  python -c "import setuptools; print(setuptools.__file__)" || echo "setuptools not found"
-
-  # Clear pip cache
-  pip cache purge
+  python3 -m pip cache purge
 
   # Setup a temporary directory to hold tests
   tempdir=$(mktemp -d)
@@ -361,6 +317,9 @@ if [[ "${RUN_UNIT_TESTS}" = true ]]; then
 fi
 
 if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
+  # fix the setuptools/distutils conflict
+  export SETUPTOOLS_USE_DISTUTILS=stdlib
+  
   # We split the process in two steps. First installing the environment, then running the tests.
   or_die cmake --build . --target ats_environment
 

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -210,12 +210,12 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   or_die apt-get update
   or_die apt-get install -y virtualenv python3-dev python-is-python3
   ATS_PYTHON_HOME=/tmp/run_integrated_tests_virtualenv
-  or_die virtualenv ${ATS_PYTHON_HOME}
-
-  # Upgrade pip and setuptools inside the virtualenv to prevent distutils conflicts.
-  # We use the full path to the venv's python to ensure we're modifying the correct environment.
-  echo "Upgrading Python packaging tools in the virtual environment..."
-  or_die ${ATS_PYTHON_HOME}/bin/python3 -m pip install --upgrade pip setuptools
+  
+  # Python 3.10+ deprecates distutils, and virtualenv may still rely on it, switch to using the built-in venv module
+  or_die python3 -m venv ${ATS_PYTHON_HOME}
+  # Force Install setuptools and wheel After Environment Creation
+  source ${ATS_PYTHON_HOME}/bin/activate
+  pip install --upgrade pip setuptools wheel
 
   python3 -m pip cache purge
 

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -212,6 +212,11 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   ATS_PYTHON_HOME=/tmp/run_integrated_tests_virtualenv
   or_die virtualenv ${ATS_PYTHON_HOME}
 
+  # Upgrade pip and setuptools inside the virtualenv to prevent distutils conflicts.
+  # We use the full path to the venv's python to ensure we're modifying the correct environment.
+  echo "Upgrading Python packaging tools in the virtual environment..."
+  or_die ${ATS_PYTHON_HOME}/bin/python3 -m pip install --upgrade pip setuptools
+
   python3 -m pip cache purge
 
   # Setup a temporary directory to hold tests

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -218,6 +218,20 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   or_die python3 -m venv ${ATS_PYTHON_HOME}
   source ${ATS_PYTHON_HOME}/bin/activate
 
+  SYSTEM_DISTUTILS_PATH="/usr/lib/python3.10/distutils"
+
+  echo "Checking for conflicting system distutils at: ${SYSTEM_DISTUTILS_PATH}"
+  if [ -d "${SYSTEM_DISTUTILS_PATH}" ]; then
+      echo "CONFLICT CONFIRMED: System distutils found. Forcibly removing it..."
+      # This command removes the problematic directory from the system.
+      # The 'sudo' might be needed if the script doesn't run as the root user.
+      # If this line fails, try removing 'sudo'.
+      sudo rm -rf "${SYSTEM_DISTUTILS_PATH}"
+      echo "System distutils removed."
+  else
+      echo "System distutils not found. The environment should be clean."
+  fi
+
   # Debug the Python environment
   echo "Python binary:"
   which python

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -208,16 +208,17 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   echo "Running the integrated tests has been requested."
   # We install the python environment required by ATS to run the integrated tests.
   or_die apt-get update
-  or_die apt-get install -y python3.10-venv python3-dev python-is-python3
+  or_die apt-get install -y virtualenv python3-dev python-is-python3
   ATS_PYTHON_HOME=/tmp/run_integrated_tests_virtualenv
-  
-  # Python 3.10+ deprecates distutils, and virtualenv may still rely on it, switch to using the built-in venv module
-  or_die python3 -m venv ${ATS_PYTHON_HOME}
-  # Force Install setuptools and wheel After Environment Creation
-  source ${ATS_PYTHON_HOME}/bin/activate
-  pip install --upgrade pip setuptools wheel
+  or_die virtualenv ${ATS_PYTHON_HOME}
 
-  python3 -m pip cache purge
+  # Force setuptools to use its own bundled distutils instead of the system's.
+  # This is a direct fix for the AssertionError related to /usr/lib/python3.10/distutils/core.py
+  export SETUPTOOLS_USE_DISTUTILS=local
+
+  or_die ${ATS_PYTHON_HOME}/bin/python3 -m pip install --upgrade pip setuptools
+
+  ${ATS_PYTHON_HOME}/bin/python3 -m pip cache purge
 
   # Setup a temporary directory to hold tests
   tempdir=$(mktemp -d)

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -218,18 +218,23 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   or_die python3 -m venv ${ATS_PYTHON_HOME}
   source ${ATS_PYTHON_HOME}/bin/activate
 
-  SYSTEM_DISTUTILS_PATH="/usr/lib/python3.10/distutils"
+  CONFLICT_DIR="/usr/lib/python3.10/distutils"
 
-  echo "Checking for conflicting system distutils at: ${SYSTEM_DISTUTILS_PATH}"
-  if [ -d "${SYSTEM_DISTUTILS_PATH}" ]; then
-      echo "CONFLICT CONFIRMED: System distutils found. Forcibly removing it..."
-      # This command removes the problematic directory from the system.
-      # The 'sudo' might be needed if the script doesn't run as the root user.
-      # If this line fails, try removing 'sudo'.
-      sudo rm -rf "${SYSTEM_DISTUTILS_PATH}"
-      echo "System distutils removed."
+  echo "--- Checking for conflicting system distutils at: ${CONFLICT_DIR} ---"
+  if [ -d "${CONFLICT_DIR}" ]; then
+      echo "[CONFLICT CONFIRMED] Directory found. Attempting forceful removal..."
+      rm -rf "${CONFLICT_DIR}"
+
+      # Verify that the directory is now gone.
+      if [ -d "${CONFLICT_DIR}" ]; then
+          echo "[FATAL ERROR] The directory ${CONFLICT_DIR} STILL EXISTS after 'rm -rf'."
+          echo "This indicates a fundamental issue with the Docker environment's filesystem."
+          exit 1
+      else
+          echo "[SUCCESS] The conflict directory has been confirmed as removed."
+      fi
   else
-      echo "System distutils not found. The environment should be clean."
+      echo "[INFO] No conflict directory was found to remove."
   fi
 
   # Debug the Python environment

--- a/scripts/setupPythonEnvironment.bash
+++ b/scripts/setupPythonEnvironment.bash
@@ -121,7 +121,16 @@ fi
 
 # Updating pip
 echo "Updating pip"
-$PYTHON_TARGET -m pip install --upgrade pip
+echo "Before upgrade: $PYTHON_TARGET"
+$PYTHON_TARGET --version
+$PYTHON_TARGET -c "import distutils; print(distutils.__file__)"
+
+$PYTHON_TARGET -m pip install --upgrade pip setuptools
+
+echo "After upgrade: $PYTHON_TARGET"
+$PYTHON_TARGET --version
+$PYTHON_TARGET -c "import distutils; print(distutils.__file__)"
+
 
 # Install packages
 echo "Installing python packages..."

--- a/scripts/setupPythonEnvironment.bash
+++ b/scripts/setupPythonEnvironment.bash
@@ -11,11 +11,10 @@ PIP_CMD="pip --disable-pip-version-check"
 PACKAGE_BRANCH=main
 
 
-declare -a TARGET_PACKAGES=("geos-mesh"
+declare -a TARGET_PACKAGES=("geos-utils"
+                            "geos-mesh"
                             "geos-xml-tools"
                             "hdf5-wrapper"
-                            "geos-utils"
-                            "geos-mesh"
                             "pygeos-tools"
                             "geos-ats")
 declare -a LINK_SCRIPTS=("preprocess_xml"
@@ -121,16 +120,7 @@ fi
 
 # Updating pip
 echo "Updating pip"
-echo "Before upgrade: $PYTHON_TARGET"
-$PYTHON_TARGET --version
-$PYTHON_TARGET -c "import distutils; print(distutils.__file__)"
-
-$PYTHON_TARGET -m pip install --upgrade pip setuptools
-
-echo "After upgrade: $PYTHON_TARGET"
-$PYTHON_TARGET --version
-$PYTHON_TARGET -c "import distutils; print(distutils.__file__)"
-
+$PYTHON_TARGET -m pip install --upgrade pip
 
 # Install packages
 echo "Installing python packages..."
@@ -142,10 +132,10 @@ do
 
         # Try installing the package
         if $VERBOSE
-            INSTALL_MSG=$($PYTHON_TARGET -m $PIP_CMD install --upgrade --force-reinstall $PACKAGE_DIR/$p)
+            INSTALL_MSG=$($PYTHON_TARGET -m $PIP_CMD install --upgrade $PACKAGE_DIR/$p)
             INSTALL_RC=$?
         then
-            INSTALL_MSG=$($PYTHON_TARGET -m $PIP_CMD install --upgrade --force-reinstall $PACKAGE_DIR/$p 2>&1)
+            INSTALL_MSG=$($PYTHON_TARGET -m $PIP_CMD install --upgrade $PACKAGE_DIR/$p 2>&1)
             INSTALL_RC=$?
         fi
 

--- a/scripts/setupPythonEnvironment.bash
+++ b/scripts/setupPythonEnvironment.bash
@@ -142,10 +142,10 @@ do
 
         # Try installing the package
         if $VERBOSE
-            INSTALL_MSG=$($PYTHON_TARGET -m $PIP_CMD install --upgrade $PACKAGE_DIR/$p)
+            INSTALL_MSG=$($PYTHON_TARGET -m $PIP_CMD install --upgrade --force-reinstall $PACKAGE_DIR/$p)
             INSTALL_RC=$?
         then
-            INSTALL_MSG=$($PYTHON_TARGET -m $PIP_CMD install --upgrade $PACKAGE_DIR/$p 2>&1)
+            INSTALL_MSG=$($PYTHON_TARGET -m $PIP_CMD install --upgrade --force-reinstall $PACKAGE_DIR/$p 2>&1)
             INSTALL_RC=$?
         fi
 


### PR DESCRIPTION
This PR fixes a build failure occurring in the `run_integrated_tests` job.

**Problem**
The CI fails when installing Python dependencies for the integrated tests. The root cause is an `AssertionError` that may be triggered by a conflict between the system's `distutils` library (installed as part of `python3-dev`) and a patching mechanism (`_distutils_hack`) in modern versions of `setuptools`.

**Proposed Solution**
This PR introduces a potential solution by setting the environment variable `SETUPTOOLS_USE_DISTUTILS=stdlib` in the `ci_build_and_test_in_container.sh` script.

The intent is to instruct `setuptools` to use the version of `distutils` provided by the standard library (`stdlib`), which may prevent the conflict that leads to the build error. Another alternative could have been to pin `setuptools` to an older version but this is more restrictive.

**Other Changes**
As a minor cleanup, this PR also removes a duplicate entry for `"geos-mesh"` in the `TARGET_PACKAGES` array within the `setupPythonEnvironment.bash` script.