### PR TITLE
refactor: use old pore volume in volume balance equation

### DIFF
--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3746-12509-e98985d
+  baseline: integratedTests/baseline_integratedTests-pr3748-12577-95ae10a
 
 allow_fail:
   all: ''

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -6,6 +6,10 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
+PR #3748 (2025-08-06) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3556-12451-d672aab.tar.gz>
+=====================
+Use old pore volume in volume balance equation - minor diffs for compositional flow tests.
+
 PR #3746 (2025-08-01) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3556-12451-d672aab.tar.gz>
 =====================
 Fix initial composition for `2ph_cap_1d_ihu`.

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.cpp
@@ -49,7 +49,6 @@
 #include "physicsSolvers/fluidFlow/kernels/compositional/SolidInternalEnergyUpdateKernel.hpp"
 #include "physicsSolvers/fluidFlow/kernels/compositional/HydrostaticPressureKernel.hpp"
 #include "physicsSolvers/fluidFlow/kernels/compositional/StatisticsKernel.hpp"
-#include "physicsSolvers/fluidFlow/kernels/compositional/zFormulation/AccumulationZFormulationKernel.hpp"
 #include "physicsSolvers/fluidFlow/kernels/compositional/zFormulation/PhaseVolumeFractionZFormulationKernel.hpp"
 
 #if defined( __INTEL_COMPILER )
@@ -1441,62 +1440,7 @@ void CompositionalMultiphaseBase::assembleLocalTerms( DomainPartition & domain,
                                                 [&]( localIndex const,
                                                      ElementSubRegionBase const & subRegion )
     {
-      string const dofKey = dofManager.getKey( viewKeyStruct::elemDofFieldString() );
-      string const & fluidName = subRegion.getReference< string >( viewKeyStruct::fluidNamesString() );
-      string const & solidName = subRegion.getReference< string >( viewKeyStruct::solidNamesString() );
-
-      MultiFluidBase const & fluid = getConstitutiveModel< MultiFluidBase >( subRegion, fluidName );
-      CoupledSolidBase const & solid = getConstitutiveModel< CoupledSolidBase >( subRegion, solidName );
-
-      if( m_formulationType == CompositionalMultiphaseFormulationType::OverallComposition )
-      {
-        // isothermal for now
-        isothermalCompositionalMultiphaseBaseKernels::
-          AccumulationZFormulationKernelFactory::
-          createAndLaunch< parallelDevicePolicy<> >( m_numComponents,
-                                                     m_numPhases,
-                                                     dofManager.rankOffset(),
-                                                     kernelFlags,
-                                                     dofKey,
-                                                     subRegion,
-                                                     fluid,
-                                                     solid,
-                                                     localMatrix,
-                                                     localRhs );
-      }
-      else
-      {
-        if( m_isThermal )
-        {
-          thermalCompositionalMultiphaseBaseKernels::
-            AccumulationKernelFactory::
-            createAndLaunch< parallelDevicePolicy<> >( m_numComponents,
-                                                       m_numPhases,
-                                                       dofManager.rankOffset(),
-                                                       kernelFlags,
-                                                       dofKey,
-                                                       subRegion,
-                                                       fluid,
-                                                       solid,
-                                                       localMatrix,
-                                                       localRhs );
-        }
-        else
-        {
-          isothermalCompositionalMultiphaseBaseKernels::
-            AccumulationKernelFactory::
-            createAndLaunch< parallelDevicePolicy<> >( m_numComponents,
-                                                       m_numPhases,
-                                                       dofManager.rankOffset(),
-                                                       kernelFlags,
-                                                       dofKey,
-                                                       subRegion,
-                                                       fluid,
-                                                       solid,
-                                                       localMatrix,
-                                                       localRhs );
-        }
-      }
+      accumulationAssemblyLaunch( dofManager, subRegion, localMatrix, localRhs );
     } );
   } );
 }

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseBase.hpp
@@ -26,6 +26,7 @@
 #include "constitutive/solid/CoupledSolidBase.hpp"
 #include "physicsSolvers/fluidFlow/kernels/compositional/AccumulationKernel.hpp"
 #include "physicsSolvers/fluidFlow/kernels/compositional/ThermalAccumulationKernel.hpp"
+#include "physicsSolvers/fluidFlow/kernels/compositional/zFormulation/AccumulationZFormulationKernel.hpp"
 
 namespace geos
 {
@@ -131,7 +132,7 @@ public:
   void accumulationAssemblyLaunch( DofManager const & dofManager,
                                    SUBREGION_TYPE const & subRegion,
                                    CRSMatrixView< real64, globalIndex const > const & localMatrix,
-                                   arrayView1d< real64 > const & localRhs );
+                                   arrayView1d< real64 > const & localRhs ) const;
 
   virtual void
   resetStateToBeginningOfStep( DomainPartition & domain ) override;
@@ -598,7 +599,7 @@ template< typename SUBREGION_TYPE >
 void CompositionalMultiphaseBase::accumulationAssemblyLaunch( DofManager const & dofManager,
                                                               SUBREGION_TYPE const & subRegion,
                                                               CRSMatrixView< real64, globalIndex const > const & localMatrix,
-                                                              arrayView1d< real64 > const & localRhs )
+                                                              arrayView1d< real64 > const & localRhs ) const
 {
   constitutive::MultiFluidBase const & fluid =
     getConstitutiveModel< constitutive::MultiFluidBase >( subRegion, subRegion.template getReference< string >( viewKeyStruct::fluidNamesString() ) );
@@ -615,10 +616,11 @@ void CompositionalMultiphaseBase::accumulationAssemblyLaunch( DofManager const &
   if( m_useSimpleAccumulation )
     kernelFlags.set( KernelFlags::SimpleAccumulation );
 
-  if( m_isThermal )
+  if( m_formulationType == CompositionalMultiphaseFormulationType::OverallComposition )
   {
-    thermalCompositionalMultiphaseBaseKernels::
-      AccumulationKernelFactory::
+    // isothermal for now
+    isothermalCompositionalMultiphaseBaseKernels::
+      AccumulationZFormulationKernelFactory::
       createAndLaunch< parallelDevicePolicy<> >( m_numComponents,
                                                  m_numPhases,
                                                  dofManager.rankOffset(),
@@ -632,18 +634,36 @@ void CompositionalMultiphaseBase::accumulationAssemblyLaunch( DofManager const &
   }
   else
   {
-    isothermalCompositionalMultiphaseBaseKernels::
-      AccumulationKernelFactory::
-      createAndLaunch< parallelDevicePolicy<> >( m_numComponents,
-                                                 m_numPhases,
-                                                 dofManager.rankOffset(),
-                                                 kernelFlags,
-                                                 dofKey,
-                                                 subRegion,
-                                                 fluid,
-                                                 solid,
-                                                 localMatrix,
-                                                 localRhs );
+    if( m_isThermal )
+    {
+      thermalCompositionalMultiphaseBaseKernels::
+        AccumulationKernelFactory::
+        createAndLaunch< parallelDevicePolicy<> >( m_numComponents,
+                                                   m_numPhases,
+                                                   dofManager.rankOffset(),
+                                                   kernelFlags,
+                                                   dofKey,
+                                                   subRegion,
+                                                   fluid,
+                                                   solid,
+                                                   localMatrix,
+                                                   localRhs );
+    }
+    else
+    {
+      isothermalCompositionalMultiphaseBaseKernels::
+        AccumulationKernelFactory::
+        createAndLaunch< parallelDevicePolicy<> >( m_numComponents,
+                                                   m_numPhases,
+                                                   dofManager.rankOffset(),
+                                                   kernelFlags,
+                                                   dofKey,
+                                                   subRegion,
+                                                   fluid,
+                                                   solid,
+                                                   localMatrix,
+                                                   localRhs );
+    }
   }
 }
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/kernels/compositional/AccumulationKernel.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/kernels/compositional/AccumulationKernel.hpp
@@ -101,6 +101,7 @@ public:
     m_elemGhostRank( subRegion.ghostRank() ),
     m_volume( subRegion.getElementVolume() ),
     m_porosity( solid.getPorosity() ),
+    m_porosity_n( solid.getPorosity_n() ),
     m_dPoro_dPres( solid.getDporosity_dPressure() ),
     m_dCompFrac_dCompDens( subRegion.getField< fields::flow::dGlobalCompFraction_dGlobalCompDensity >() ),
     m_phaseVolFrac( subRegion.getField< fields::flow::phaseVolumeFraction >() ),
@@ -326,13 +327,13 @@ public:
     // possible use: assemble the derivatives wrt temperature, and use oneMinusPhaseVolFracSum if poreVolume depends on temperature
     phaseVolFractionSumKernelOp( oneMinusPhaseVolFracSum );
 
-    // scale saturation-based volume balance by pore volume (for better scaling w.r.t. other equations)
-    stack.localResidual[numComp] = stack.poreVolume * oneMinusPhaseVolFracSum;
+    // scale saturation-based volume balance by old pore volume (for better scaling w.r.t. other equations)
+    real64 const oldPV = m_volume[ei] * m_porosity_n[ei][0];
+    stack.localResidual[numComp] = oldPV * oneMinusPhaseVolFracSum;
     for( integer idof = 0; idof < numDof; ++idof )
     {
-      stack.localJacobian[numComp][idof] *= stack.poreVolume;
+      stack.localJacobian[numComp][idof] *= oldPV;
     }
-    stack.localJacobian[numComp][0] += stack.dPoreVolume_dPres * oneMinusPhaseVolFracSum;
   }
 
   /**
@@ -418,6 +419,7 @@ protected:
 
   /// Views on the porosity
   arrayView2d< real64 const > const m_porosity;
+  arrayView2d< real64 const > const m_porosity_n;
   arrayView2d< real64 const > const m_dPoro_dPres;
 
   /// Views on the derivatives of comp fractions wrt component density


### PR DESCRIPTION
for flow assembly kernel, for poromechanics it is already doing old pore volume

bonus: re-use `accumulationAssemblyLaunch` to avoid code duplication