### PR TITLE
feat: Add scatter data history

### DIFF
--- a/src/coreComponents/fileIO/CMakeLists.txt
+++ b/src/coreComponents/fileIO/CMakeLists.txt
@@ -37,7 +37,9 @@ set( fileIO_headers
      timeHistory/BufferedHistoryIO.hpp
      timeHistory/PackCollection.hpp
      timeHistory/HDFHistoryIO.hpp
-     timeHistory/HistoryCollection.hpp )
+     timeHistory/HistoryCollection.hpp 
+     timeHistory/ScatterDataProvider.hpp
+     timeHistory/ScatterDataHistoryCollection.hpp )
 
 #
 # Specify all sources
@@ -54,7 +56,8 @@ set( fileIO_sources
      timeHistory/HDFFile.cpp
      timeHistory/HistoryCollectionBase.cpp
      timeHistory/PackCollection.cpp
-     timeHistory/HDFHistoryIO.cpp )
+     timeHistory/HDFHistoryIO.cpp 
+     timeHistory/ScatterDataHistoryCollection.cpp )
 
 set( dependencyList ${parallelDeps} events mesh HDF5::HDF5 )
 if( ENABLE_PYGEOSX )

--- a/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.cpp
+++ b/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.cpp
@@ -1,0 +1,235 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2016-2024 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2024 TotalEnergies
+ * Copyright (c) 2018-2024 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2023-2024 Chevron
+ * Copyright (c) 2019-     GEOS/GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file ScatterDataHistoryCollection.cpp
+ */
+
+#include "ScatterDataHistoryCollection.hpp"
+
+#include "mesh/DomainPartition.hpp"
+#include "physicsSolvers/PhysicsSolverManager.hpp"
+#include "common/MpiWrapper.hpp"
+#include <cstring>
+
+namespace geos
+{
+
+using namespace dataRepository;
+
+ScatterDataHistoryCollection::ScatterDataHistoryCollection( string const & name, Group * const parent )
+  : HistoryCollectionBase( name, parent ),
+  m_scatterDataProvider( nullptr )
+{
+  registerWrapper( viewKeyStruct::solverNameString(), &m_solverName )
+    .setInputFlag( InputFlags::REQUIRED )
+    .setDescription( "Name of the physics solver that provides scatter data" );
+
+  registerWrapper( viewKeyStruct::includeCoordinatesString(), &m_includeCoordinates )
+    .setInputFlag( InputFlags::OPTIONAL )
+    .setApplyDefaultValue( 1 )
+    .setDescription( "Flag to include coordinates in output (1=yes, 0=no)" );
+
+  registerWrapper( viewKeyStruct::includeMetadataString(), &m_includeMetadata )
+    .setInputFlag( InputFlags::OPTIONAL )
+    .setApplyDefaultValue( 0 )
+    .setDescription( "Flag to include metadata in output (1=yes, 0=no)" );
+}
+
+void ScatterDataHistoryCollection::initializePostInitialConditionsPreSubGroups()
+{
+  HistoryCollectionBase::initializePostInitialConditionsPreSubGroups();
+
+  // Find the domain partition to locate the physics solver
+  findScatterDataProvider();
+
+  // Set up the collection count
+  m_collectionCount = 1; // Main scatter data
+
+  if( m_includeCoordinates && m_scatterDataProvider != nullptr )
+  {
+    array2d< real64 > const & coordinates = m_scatterDataProvider->getScatterCoordinates();
+    if( coordinates.size( 0 ) > 0 && coordinates.size( 1 ) > 0 )
+    {
+      m_collectionCount += coordinates.size( 1 ); // Add X, Y, Z coordinates
+    }
+  }
+}
+
+void ScatterDataHistoryCollection::findScatterDataProvider()
+{
+  // Get the problem manager from the hierarchy
+  Group const & problemManager = this->getGroupByPath( "/Problem" );
+
+  // Get the physics solver manager
+  Group const & physicsSolverManager = problemManager.getGroup( "Solvers" );
+
+  // Try to find the solver by name
+  Group const * solver = physicsSolverManager.getGroupPointer( m_solverName );
+  GEOS_THROW_IF( solver == nullptr,
+                 GEOS_FMT( "Could not find physics solver named '{}'", m_solverName ),
+                 InputError );
+
+  // Cast to ScatterDataProvider
+  m_scatterDataProvider = dynamic_cast< ScatterDataProvider const * >( solver );
+  GEOS_THROW_IF( m_scatterDataProvider == nullptr,
+                 GEOS_FMT( "Physics solver '{}' does not implement ScatterDataProvider interface", m_solverName ),
+                 InputError );
+
+  GEOS_LOG_RANK_0( GEOS_FMT( "Found scatter data provider '{}' with {} points", m_solverName, m_scatterDataProvider->getNumScatterPoints()) );
+}
+
+void ScatterDataHistoryCollection::collect( DomainPartition const & domain )
+{
+  GEOS_UNUSED_VAR( domain );
+
+  if( m_scatterDataProvider == nullptr )
+  {
+    GEOS_THROW( "Scatter data provider not initialized", std::runtime_error );
+  }
+
+  // Get the current scatter data values
+  array1d< real64 > const & scatterData = m_scatterDataProvider->getScatterData();
+  localIndex const numPoints = m_scatterDataProvider->getNumScatterPoints();
+
+  GEOS_THROW_IF( scatterData.size() != numPoints,
+                 GEOS_FMT( "Scatter data size ({}) does not match number of points ({})", scatterData.size(), numPoints ),
+                 std::runtime_error );
+}
+
+void ScatterDataHistoryCollection::collect( DomainPartition const & domain,
+                                            localIndex const collectionIdx,
+                                            buffer_unit_type * & buffer )
+{
+  GEOS_UNUSED_VAR( domain );
+  GEOS_MARK_FUNCTION;
+
+  if( m_scatterDataProvider == nullptr )
+  {
+    return;
+  }
+
+  localIndex const numPoints = m_scatterDataProvider->getNumScatterPoints();
+
+  // Collection index 0 is the main scatter data
+  if( collectionIdx == 0 )
+  {
+    array1d< real64 > const & scatterData = m_scatterDataProvider->getScatterData();
+
+    // Copy data to buffer
+    std::memcpy( buffer, scatterData.data(), numPoints * sizeof( real64 ) );
+    buffer += numPoints * sizeof( real64 );
+  }
+  // Subsequent indices are coordinates if requested
+  else if( m_includeCoordinates )
+  {
+    array2d< real64 > const & coordinates = m_scatterDataProvider->getScatterCoordinates();
+    localIndex const numDim = coordinates.size( 1 );
+    localIndex const coordIdx = collectionIdx - 1;
+
+    if( coordIdx < numDim && coordinates.size( 0 ) == numPoints )
+    {
+      // Extract the specific coordinate component
+      real64 * coordData = reinterpret_cast< real64 * >( buffer );
+      for( localIndex i = 0; i < numPoints; ++i )
+      {
+        coordData[i] = coordinates[i][coordIdx];
+      }
+      buffer += numPoints * sizeof( real64 );
+    }
+  }
+}
+
+localIndex ScatterDataHistoryCollection::numCollectors() const
+{
+  localIndex count = 1; // Main scatter data
+
+  if( m_includeCoordinates && m_scatterDataProvider != nullptr )
+  {
+    array2d< real64 > const & coordinates = m_scatterDataProvider->getScatterCoordinates();
+    if( coordinates.size( 0 ) > 0 && coordinates.size( 1 ) > 0 )
+    {
+      count += coordinates.size( 1 ); // Add X, Y, Z coordinates
+    }
+  }
+
+  return count;
+}
+
+const string & ScatterDataHistoryCollection::getTargetName() const
+{
+  return m_solverName;
+}
+
+HistoryMetadata ScatterDataHistoryCollection::getMetaData( DomainPartition const & domain, localIndex collectionIdx ) const
+{
+  GEOS_UNUSED_VAR( domain );
+
+  if( m_scatterDataProvider == nullptr )
+  {
+    return HistoryMetadata();
+  }
+
+  localIndex const numPoints = m_scatterDataProvider->getNumScatterPoints();
+
+  // Collection index 0 is always the main scatter data
+  if( collectionIdx == 0 )
+  {
+    return HistoryMetadata( "scatterData", numPoints, std::type_index( typeid( real64 ) ) );
+  }
+
+  // Subsequent indices are coordinates if requested
+  if( m_includeCoordinates )
+  {
+    array2d< real64 > const & coordinates = m_scatterDataProvider->getScatterCoordinates();
+    localIndex const numDim = coordinates.size( 1 );
+
+    if( collectionIdx <= numDim )
+    {
+      string coordName;
+      switch( collectionIdx - 1 )
+      {
+        case 0: coordName = "coordinateX"; break;
+        case 1: coordName = "coordinateY"; break;
+        case 2: coordName = "coordinateZ"; break;
+        default: coordName = "coordinate" + std::to_string( collectionIdx - 1 ); break;
+      }
+      return HistoryMetadata( coordName, numPoints, std::type_index( typeid( real64 ) ) );
+    }
+  }
+
+  return HistoryMetadata();
+}
+
+void ScatterDataHistoryCollection::updateSetsIndices( DomainPartition const & domain )
+{
+  GEOS_UNUSED_VAR( domain );
+}
+
+localIndex ScatterDataHistoryCollection::numMetaDataCollectors() const
+{
+  return 0;
+}
+
+HistoryCollection & ScatterDataHistoryCollection::getMetaDataCollector( localIndex metaIdx )
+{
+  GEOS_UNUSED_VAR( metaIdx );
+  GEOS_THROW( "Scatter data collections do not have metadata collectors",
+              std::runtime_error );
+}
+
+REGISTER_CATALOG_ENTRY( TaskBase, ScatterDataHistoryCollection, string const &, Group * const )
+
+} // namespace geos

--- a/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.cpp
+++ b/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.cpp
@@ -100,13 +100,15 @@ void ScatterDataHistoryCollection::collect( DomainPartition const & domain )
     GEOS_THROW( "Scatter data provider not initialized", std::runtime_error );
   }
 
-  // Get the current scatter data values
-  array1d< real64 > const & scatterData = m_scatterDataProvider->getScatterData();
-  localIndex const numPoints = m_scatterDataProvider->getNumScatterPoints();
-
-  GEOS_THROW_IF( scatterData.size() != numPoints,
-                 GEOS_FMT( "Scatter data size ({}) does not match number of points ({})", scatterData.size(), numPoints ),
-                 std::runtime_error );
+  // For each collection, populate the output buffer using the provider
+  for( localIndex collectionIdx = 0; collectionIdx < m_collectionCount; ++collectionIdx )
+  {
+    // Get the metadata to determine the buffer size needed
+    HistoryMetadata hmd = this->getMetaData( domain, collectionIdx );
+    // Get the output buffer for this collection using the buffer provider callback
+    buffer_unit_type * buffer = m_bufferProviders[collectionIdx]( hmd.size( 0 ));
+    collect( domain, collectionIdx, buffer );
+  }
 }
 
 void ScatterDataHistoryCollection::collect( DomainPartition const & domain,
@@ -127,10 +129,8 @@ void ScatterDataHistoryCollection::collect( DomainPartition const & domain,
   if( collectionIdx == 0 )
   {
     array1d< real64 > const & scatterData = m_scatterDataProvider->getScatterData();
-
     // Copy data to buffer
     std::memcpy( buffer, scatterData.data(), numPoints * sizeof( real64 ) );
-    buffer += numPoints * sizeof( real64 );
   }
   // Subsequent indices are coordinates if requested
   else if( m_includeCoordinates )
@@ -147,7 +147,6 @@ void ScatterDataHistoryCollection::collect( DomainPartition const & domain,
       {
         coordData[i] = coordinates[i][coordIdx];
       }
-      buffer += numPoints * sizeof( real64 );
     }
   }
 }

--- a/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.hpp
+++ b/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.hpp
@@ -1,0 +1,154 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2016-2024 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2024 TotalEnergies
+ * Copyright (c) 2018-2024 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2023-2024 Chevron
+ * Copyright (c) 2019-     GEOS/GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file ScatterDataHistoryCollection.hpp
+ */
+
+#ifndef GEOS_FILEIO_TIMEHISTORY_SCATTERDATAHISTORYCOLLECTION_HPP_
+#define GEOS_FILEIO_TIMEHISTORY_SCATTERDATAHISTORYCOLLECTION_HPP_
+
+#include "HistoryCollectionBase.hpp"
+#include "ScatterDataProvider.hpp"
+#include "common/DataTypes.hpp"
+
+namespace geos
+{
+class DomainPartition;
+
+
+/**
+ * @brief Collects time history data from scattered points
+ *
+ * This class collects time history data from solvers that implement the
+ * ScatterDataProvider interface.
+ */
+class ScatterDataHistoryCollection : public HistoryCollectionBase
+{
+public:
+
+  /// Constructor
+  ScatterDataHistoryCollection( string const & name, Group * const parent );
+
+  /// Destructor
+  virtual ~ScatterDataHistoryCollection() = default;
+
+  /// Non-copyable
+  ScatterDataHistoryCollection( ScatterDataHistoryCollection const & ) = delete;
+  ScatterDataHistoryCollection & operator=( ScatterDataHistoryCollection const & ) = delete;
+
+  /// Movable: default move constructor, deleted move assignment operator
+  ScatterDataHistoryCollection( ScatterDataHistoryCollection && ) = default;
+  ScatterDataHistoryCollection & operator=( ScatterDataHistoryCollection && ) = delete;
+
+
+  /**
+   * @brief Get the catalog name for factory registration
+   * @return The catalog name
+   */
+  static string catalogName() { return "ScatterDataHistoryCollection"; }
+
+  /**
+   * @brief Initialize the collection
+   */
+  virtual void initializePostInitialConditionsPreSubGroups() override;
+
+  /**
+   * @brief Get the metadata for a specific collection index
+   * @param domain The domain partition
+   * @param collectionIdx The collection index
+   * @return HistoryMetadata describing the data to be collected
+   */
+  virtual HistoryMetadata getMetaData( DomainPartition const & domain, localIndex collectionIdx ) const override;
+
+  /**
+   * @brief Get the number of discrete collection operations
+   * @return Number of collection operations
+   */
+  virtual localIndex numCollectors() const override;
+
+  /**
+   * @brief Get the name of the target being collected
+   * @return The target name (solver name)
+   */
+  virtual const string & getTargetName() const override;
+
+  /**
+   * @brief Get the number of metadata collectors
+   * @return Number of metadata collectors (always 0 for scatter data)
+   */
+  virtual localIndex numMetaDataCollectors() const override;
+
+  /**
+   * @brief Get a metadata collector (not applicable for scatter data)
+   * @param metaIdx The metadata collector index
+   * @return Reference to metadata collector
+   */
+  virtual HistoryCollection & getMetaDataCollector( localIndex metaIdx ) override;
+
+protected:
+
+  /**
+   * @brief Update set indices (required by base class, no-op for scatter data)
+   * @param domain The domain partition
+   */
+  virtual void updateSetsIndices( DomainPartition const & domain ) override;
+
+  /**
+   * @brief Collect data from the scatter data provider
+   * @param domain The domain partition containing the data
+   */
+  virtual void collect( DomainPartition const & domain );
+
+  /**
+   * @brief Collect data from a specific collection index into a buffer
+   * @param domain The domain partition containing the data
+   * @param collectionIdx The index of the collection operation
+   * @param buffer The buffer to write data into
+   */
+  virtual void collect( DomainPartition const & domain,
+                        localIndex const collectionIdx,
+                        buffer_unit_type * & buffer ) override;
+
+private:
+
+  /// Pointer to the scatter data provider (physics solver)
+  ScatterDataProvider const * m_scatterDataProvider;
+
+  /// Name of the physics solver that provides scatter data
+  string m_solverName;
+
+  /// Flag to include coordinates in output (default: true)
+  integer m_includeCoordinates;
+
+  /// Flag to include metadata in output (default: false)
+  integer m_includeMetadata;
+
+  /**
+   * @brief Find and validate the scatter data provider
+   */
+  void findScatterDataProvider();
+
+  struct viewKeyStruct
+  {
+    static constexpr char const * solverNameString() { return "solverName"; }
+    static constexpr char const * includeCoordinatesString() { return "includeCoordinates"; }
+    static constexpr char const * includeMetadataString() { return "includeMetadata"; }
+  };
+};
+
+} // namespace geos
+
+#endif /* GEOS_FILEIO_TIMEHISTORY_SCATTERDATAHISTORYCOLLECTION_HPP_ */

--- a/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.hpp
+++ b/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.hpp
@@ -49,9 +49,6 @@ public:
   ScatterDataHistoryCollection( ScatterDataHistoryCollection const & ) = delete;
   ScatterDataHistoryCollection & operator=( ScatterDataHistoryCollection const & ) = delete;
 
-  /// Movable: default move constructor, deleted move assignment operator
-  ScatterDataHistoryCollection( ScatterDataHistoryCollection && ) = default;
-  ScatterDataHistoryCollection & operator=( ScatterDataHistoryCollection && ) = delete;
 
   /**
    * @brief Collect data from the scatter data provider

--- a/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.hpp
+++ b/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.hpp
@@ -39,7 +39,11 @@ class ScatterDataHistoryCollection : public HistoryCollectionBase
 {
 public:
 
-  /// Constructor
+  /**
+   * @brief Constructor for ScatterDataHistoryCollection
+   * @param name The name of the collection
+   * @param parent The parent group in the data repository
+   */
   ScatterDataHistoryCollection( string const & name, Group * const parent );
 
   /// Destructor

--- a/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.hpp
+++ b/src/coreComponents/fileIO/timeHistory/ScatterDataHistoryCollection.hpp
@@ -53,6 +53,11 @@ public:
   ScatterDataHistoryCollection( ScatterDataHistoryCollection && ) = default;
   ScatterDataHistoryCollection & operator=( ScatterDataHistoryCollection && ) = delete;
 
+  /**
+   * @brief Collect data from the scatter data provider
+   * @param domain The domain partition containing the data
+   */
+  virtual void collect( DomainPartition const & domain );
 
   /**
    * @brief Get the catalog name for factory registration
@@ -106,11 +111,6 @@ protected:
    */
   virtual void updateSetsIndices( DomainPartition const & domain ) override;
 
-  /**
-   * @brief Collect data from the scatter data provider
-   * @param domain The domain partition containing the data
-   */
-  virtual void collect( DomainPartition const & domain );
 
   /**
    * @brief Collect data from a specific collection index into a buffer

--- a/src/coreComponents/fileIO/timeHistory/ScatterDataProvider.hpp
+++ b/src/coreComponents/fileIO/timeHistory/ScatterDataProvider.hpp
@@ -1,0 +1,86 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2016-2024 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2024 TotalEnergies
+ * Copyright (c) 2018-2024 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2023-2024 Chevron
+ * Copyright (c) 2019-     GEOS/GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file ScatterDataProvider.hpp
+ */
+
+#ifndef GEOS_FILEIO_TIMEHISTORY_SCATTERDATAPROVIDER_HPP_
+#define GEOS_FILEIO_TIMEHISTORY_SCATTERDATAPROVIDER_HPP_
+
+#include "common/DataTypes.hpp"
+
+namespace geos
+{
+
+/**
+ * @brief Interface for classes that provide scattered data (coordinates and values)
+ */
+class ScatterDataProvider
+{
+public:
+
+  /// Virtual destructor
+  virtual ~ScatterDataProvider() = default;
+
+  /**
+   * @brief Get the number of scatter points
+   * @return Number of points where scattered data is computed
+   */
+  virtual localIndex getNumScatterPoints() const = 0;
+
+  /**
+   * @brief Get the scattered data values
+   * @return Array of data values at scatter points
+   */
+  virtual array1d< real64 > const & getScatterData() const = 0;
+
+  /**
+   * @brief Get the coordinates of scatter points
+   * @return 2D array of coordinates [nPoints x nDim]
+   */
+  virtual array2d< real64 > const & getScatterCoordinates() const
+  {
+    static array2d< real64 > empty;
+    return empty;
+  }
+
+  /**
+   * @brief Get optional metadata for scatter points
+   * @return String array with metadata for each point (e.g., station names)
+   */
+  virtual string_array const & getScatterMetadata() const
+  {
+    static string_array empty;
+    return empty;
+  }
+
+protected:
+
+  /// Protected constructor
+  ScatterDataProvider() = default;
+
+  /// Non-copyable
+  ScatterDataProvider( ScatterDataProvider const & ) = delete;
+  ScatterDataProvider & operator=( ScatterDataProvider const & ) = delete;
+
+  /// Non-movable
+  ScatterDataProvider( ScatterDataProvider && ) = delete;
+  ScatterDataProvider & operator=( ScatterDataProvider && ) = delete;
+};
+
+} // namespace geos
+
+#endif /* GEOS_FILEIO_TIMEHISTORY_SCATTERDATAPROVIDER_HPP_ */

--- a/src/coreComponents/unitTests/fileIOTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/fileIOTests/CMakeLists.txt
@@ -2,6 +2,7 @@
 set( geosx_fileio_tests
      testHDFFile.cpp
      testMemoryStats.cpp
+     testScatterDataProvider.cpp
      testScatterDataHistoryCollection.cpp )
 
 set( tplDependencyList ${parallelDeps} gtest )

--- a/src/coreComponents/unitTests/fileIOTests/CMakeLists.txt
+++ b/src/coreComponents/unitTests/fileIOTests/CMakeLists.txt
@@ -1,7 +1,8 @@
 # Specify list of tests
 set( geosx_fileio_tests
      testHDFFile.cpp
-     testMemoryStats.cpp )
+     testMemoryStats.cpp
+     testScatterDataHistoryCollection.cpp )
 
 set( tplDependencyList ${parallelDeps} gtest )
 

--- a/src/coreComponents/unitTests/fileIOTests/testScatterDataHistoryCollection.cpp
+++ b/src/coreComponents/unitTests/fileIOTests/testScatterDataHistoryCollection.cpp
@@ -1,0 +1,220 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2016-2024 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2024 TotalEnergies
+ * Copyright (c) 2018-2024 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2023-2024 Chevron
+ * Copyright (c) 2019-     GEOS/GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+#include "fileIO/timeHistory/ScatterDataHistoryCollection.hpp"
+#include "fileIO/Outputs/TimeHistoryOutput.hpp"
+#include "physicsSolvers/PhysicsSolverManager.hpp"
+#include "mesh/DomainPartition.hpp"
+#include "mainInterface/initialization.hpp"
+#include <gtest/gtest.h>
+#include <conduit.hpp>
+#include <hdf5.h>
+#include <filesystem>
+
+using namespace geos;
+
+// Minimal mock ScatterDataProvider
+class MockScatterDataProvider : public ScatterDataProvider, public dataRepository::Group
+{
+public:
+  MockScatterDataProvider( string const & name, dataRepository::Group *parent ): dataRepository::Group( name, parent )
+  {
+    m_scatterData.resize( 3 );
+    m_scatterData[0] = 10; m_scatterData[1] = 20; m_scatterData[2] = 30;
+    m_coordinates.resize( 3, 3 );
+    m_coordinates( 0, 0 ) = 1000.0; m_coordinates( 0, 1 ) = 2000.0; m_coordinates( 0, 2 ) = 100.0;
+    m_coordinates( 1, 0 ) = 1500.0; m_coordinates( 1, 1 ) = 2500.0; m_coordinates( 1, 2 ) = 200.0;
+    m_coordinates( 2, 0 ) = 2000.0; m_coordinates( 2, 1 ) = 3000.0; m_coordinates( 2, 2 ) = 300.0;
+    m_metadata.resize( 3 );
+    m_metadata[0] = "Station_A"; m_metadata[1] = "Station_B"; m_metadata[2] = "Station_C";
+  }
+  localIndex getNumScatterPoints() const override { return 3; }
+  array1d< real64 > const & getScatterData() const override { return m_scatterData; }
+  array2d< real64 > const & getScatterCoordinates() const override { return m_coordinates; }
+  string_array const & getScatterMetadata() const override { return m_metadata; }
+  static string catalogName() { return "MockScatterDataProvider"; }
+private:
+  array1d< real64 > m_scatterData;
+  array2d< real64 > m_coordinates;
+  string_array m_metadata;
+};
+
+REGISTER_CATALOG_ENTRY( dataRepository::Group, MockScatterDataProvider, string const &, dataRepository::Group * const )
+
+
+class ScatterDataHistoryIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    m_conduitNode = std::make_unique< conduit::Node >();
+    m_rootGroup = std::make_unique< dataRepository::Group >( "Problem", *m_conduitNode );
+    auto & solvers = m_rootGroup->registerGroup< PhysicsSolverManager >( "Solvers" );
+    m_domain = &m_rootGroup->registerGroup< DomainPartition >( "domain" );
+    solvers.registerGroup< MockScatterDataProvider >( "gravitySolver" );
+    m_collection = &m_rootGroup->registerGroup< ScatterDataHistoryCollection >( "gravityHistory" );
+    m_collection->getReference< string >( "solverName" ) = "gravitySolver";
+    m_collection->getReference< integer >( "includeCoordinates" ) = 1;
+    m_collection->getReference< integer >( "includeMetadata" ) = 0;
+  }
+  std::unique_ptr< conduit::Node > m_conduitNode;
+  std::unique_ptr< dataRepository::Group > m_rootGroup;
+  DomainPartition *m_domain;
+  ScatterDataHistoryCollection *m_collection;
+};
+
+TEST_F( ScatterDataHistoryIntegrationTest, CompleteWorkflow )
+{
+  // Test initialization
+  m_collection->initializePostInitialConditionsPreSubGroups();
+  EXPECT_EQ( m_collection->numCollectors(), 4 ); // data + 3 coordinates
+  EXPECT_EQ( m_collection->getTargetName(), "gravitySolver" );
+  EXPECT_EQ( m_collection->catalogName(), "ScatterDataHistoryCollection" );
+  EXPECT_EQ( m_collection->numMetaDataCollectors(), 0 );
+  EXPECT_THROW( m_collection->getMetaDataCollector( 0 ), std::runtime_error );
+
+  // Test metadata for all collectors
+  for( localIndex idx = 0; idx < 4; ++idx )
+  {
+    auto metadata = m_collection->getMetaData( *m_domain, idx );
+    EXPECT_EQ( metadata.size(), 3 );
+    EXPECT_EQ( metadata.getType(), std::type_index( typeid(real64)));
+    if( idx == 0 )
+      EXPECT_EQ( metadata.getName(), "scatterData" );
+    else
+      EXPECT_TRUE( metadata.getName().find( "coordinate" ) != string::npos );
+  }
+}
+
+TEST_F( ScatterDataHistoryIntegrationTest, ErrorHandling )
+{
+  m_collection->getReference< string >( "solverName" ) = "invalidSolver";
+  EXPECT_THROW( m_collection->initializePostInitialConditionsPreSubGroups(), InputError );
+}
+
+// HDF5 test
+class ScatterDataHistoryHDF5Test : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    m_conduitNode = std::make_unique< conduit::Node >();
+    m_rootGroup = std::make_unique< dataRepository::Group >( "Problem", *m_conduitNode );
+    auto & solvers = m_rootGroup->registerGroup< PhysicsSolverManager >( "Solvers" );
+    m_provider = &solvers.registerGroup< MockScatterDataProvider >( "gravitySolver" );
+    m_domain = &m_rootGroup->registerGroup< DomainPartition >( "domain" );
+    auto & outputs = m_rootGroup->registerGroup< dataRepository::Group >( "Outputs" );
+    m_timeHistoryOutput = &outputs.registerGroup< TimeHistoryOutput >( "timeHistory" );
+    m_timeHistoryOutput->getReference< string >( "filename" ) = "testOutput";  // No path, just filename
+    m_timeHistoryOutput->getReference< string >( "format" ) = "hdf5";
+    m_collection = &m_timeHistoryOutput->registerGroup< ScatterDataHistoryCollection >( "gravityHistory" );
+    m_collection->getReference< string >( "solverName" ) = "gravitySolver";
+    m_collection->getReference< integer >( "includeCoordinates" ) = 1;
+    // Register the collection as a source for TimeHistoryOutput using string_array
+    m_timeHistoryOutput->getReference< string_array >( "sources" ).resize( 1 );
+    m_timeHistoryOutput->getReference< string_array >( "sources" )[0] = "gravityHistory";
+  }
+  void TearDown() override
+  {
+    std::filesystem::remove( "testOutput.hdf5" );
+  }
+  std::unique_ptr< conduit::Node > m_conduitNode;
+  std::unique_ptr< dataRepository::Group > m_rootGroup;
+  DomainPartition *m_domain;
+  TimeHistoryOutput *m_timeHistoryOutput;
+  ScatterDataHistoryCollection *m_collection;
+  MockScatterDataProvider *m_provider;
+};
+
+TEST_F( ScatterDataHistoryHDF5Test, HDF5FileOutput )
+{
+  // Set up output directory for TimeHistoryOutput
+  OutputBase::setOutputDirectory( "." );
+
+  // Initialize collection first
+  m_collection->initializePostInitialConditionsPreSubGroups();
+
+  // Debug: Check the sources array is properly set
+  auto & sources = m_timeHistoryOutput->getReference< string_array >( "sources" );
+  EXPECT_EQ( sources.size(), 1 );
+  EXPECT_EQ( sources[0], "gravityHistory" );
+
+  // Initialize TimeHistoryOutput - this should now work without directory errors
+  EXPECT_NO_THROW( m_timeHistoryOutput->initializePostInitialConditionsPostSubGroups() );
+
+  // Verify the collection is configured correctly
+  EXPECT_EQ( m_collection->numCollectors(), 4 ); // data + 3 coordinates
+  EXPECT_EQ( m_collection->getTargetName(), "gravitySolver" );
+
+  // Verify that we can get metadata for all collectors
+  for( localIndex idx = 0; idx < 4; ++idx )
+  {
+    auto metadata = m_collection->getMetaData( *m_domain, idx );
+    EXPECT_EQ( metadata.size(), 3 );  // 3 scatter points
+    EXPECT_EQ( metadata.getType(), std::type_index( typeid(real64) ) );
+    if( idx == 0 )
+      EXPECT_EQ( metadata.getName(), "scatterData" );
+    else
+      EXPECT_TRUE( metadata.getName().find( "coordinate" ) != string::npos );
+  }
+
+  // Trigger buffer population before writing
+  m_collection->collect( *m_domain );
+
+  // Now test the actual I/O execution!
+  EXPECT_NO_THROW( m_timeHistoryOutput->execute( 0.0, 1.0, 0, 1, 1.0, *m_domain ) );
+
+  // Verify HDF5 file was created
+  EXPECT_TRUE( std::filesystem::exists( "testOutput.hdf5" ) );
+
+  // Read back the HDF5 file and verify the contents
+  hid_t file_id = H5Fopen( "testOutput.hdf5", H5F_ACC_RDONLY, H5P_DEFAULT );
+  EXPECT_GE( file_id, 0 );
+
+  // Check scatter data values
+  {
+    const char * dataset_names[] = { "/scatterData", "/coordinateX", "/coordinateY", "/coordinateZ" };
+    double values[3];
+    auto & scatterData = m_provider->getScatterData();
+    auto & coordinates = m_provider->getScatterCoordinates();
+    for( int i = 0; i < 4; ++i )
+    {
+      hid_t dataset_id = H5Dopen2( file_id, dataset_names[i], H5P_DEFAULT );
+      EXPECT_GE( dataset_id, 0 ) << "Failed to open dataset " << dataset_names[i];
+      herr_t status = H5Dread( dataset_id, H5T_NATIVE_DOUBLE, H5S_ALL, H5S_ALL, H5P_DEFAULT, values );
+      EXPECT_GE( status, 0 ) << "Failed to read dataset " << dataset_names[i];
+      for( int j = 0; j < 3; ++j )
+      {
+        double expected = 0.0;
+        if( i == 0 )
+          expected = scatterData[j];
+        else
+          expected = coordinates( j, i-1 );
+        EXPECT_DOUBLE_EQ( values[j], expected ) << "Mismatch in " << dataset_names[i] << " at index " << j;
+      }
+      H5Dclose( dataset_id );
+    }
+  }
+  H5Fclose( file_id );
+}
+
+int main( int argc, char * *argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  basicSetup( argc, argv );
+  int result = RUN_ALL_TESTS();
+  basicCleanup();
+  return result;
+}

--- a/src/coreComponents/unitTests/fileIOTests/testScatterDataProvider.cpp
+++ b/src/coreComponents/unitTests/fileIOTests/testScatterDataProvider.cpp
@@ -1,0 +1,90 @@
+/*
+ * ------------------------------------------------------------------------------------------------------------
+ * SPDX-License-Identifier: LGPL-2.1-only
+ *
+ * Copyright (c) 2016-2024 Lawrence Livermore National Security LLC
+ * Copyright (c) 2018-2024 TotalEnergies
+ * Copyright (c) 2018-2024 The Board of Trustees of the Leland Stanford Junior University
+ * Copyright (c) 2023-2024 Chevron
+ * Copyright (c) 2019-     GEOS/GEOSX Contributors
+ * All rights reserved
+ *
+ * See top level LICENSE, COPYRIGHT, CONTRIBUTORS, NOTICE, and ACKNOWLEDGEMENTS files for details.
+ * ------------------------------------------------------------------------------------------------------------
+ */
+
+#include "fileIO/timeHistory/ScatterDataProvider.hpp"
+#include <gtest/gtest.h>
+
+using namespace geos;
+
+class MinimalScatterDataProvider : public ScatterDataProvider
+{
+public:
+  MinimalScatterDataProvider()
+  {
+    m_scatterData.resize( 0 );
+    m_coordinates.resize( 0, 3 );
+    m_metadata.resize( 0 );
+  }
+  localIndex getNumScatterPoints() const override { return 0; }
+  array1d< real64 > const & getScatterData() const override { return m_scatterData; }
+  array2d< real64 > const & getScatterCoordinates() const override { return m_coordinates; }
+  string_array const & getScatterMetadata() const override { return m_metadata; }
+private:
+  array1d< real64 > m_scatterData;
+  array2d< real64 > m_coordinates;
+  string_array m_metadata;
+};
+
+TEST( ScatterDataProviderTest, ZeroScatterPoints )
+{
+  MinimalScatterDataProvider provider;
+  EXPECT_EQ( provider.getNumScatterPoints(), 0 );
+  EXPECT_EQ( provider.getScatterData().size(), 0 );
+  EXPECT_EQ( provider.getScatterCoordinates().size( 0 ), 0 );
+  EXPECT_EQ( provider.getScatterCoordinates().size( 1 ), 3 );
+  EXPECT_EQ( provider.getScatterMetadata().size(), 0 );
+}
+
+class EdgeCaseScatterDataProvider : public ScatterDataProvider
+{
+public:
+  EdgeCaseScatterDataProvider()
+  {
+    m_scatterData.resize( 2 );
+    m_scatterData[0] = -1e10; m_scatterData[1] = 1e10;
+    m_coordinates.resize( 2, 3 );
+    m_coordinates( 0, 0 ) = -1e5; m_coordinates( 0, 1 ) = 0.0; m_coordinates( 0, 2 ) = 1e5;
+    m_coordinates( 1, 0 ) = 1e-5; m_coordinates( 1, 1 ) = -1e-5; m_coordinates( 1, 2 ) = 0.0;
+    m_metadata.resize( 2 );
+    m_metadata[0] = "";
+    m_metadata[1] = "Special_Station_#1";
+  }
+  localIndex getNumScatterPoints() const override { return 2; }
+  array1d< real64 > const & getScatterData() const override { return m_scatterData; }
+  array2d< real64 > const & getScatterCoordinates() const override { return m_coordinates; }
+  string_array const & getScatterMetadata() const override { return m_metadata; }
+private:
+  array1d< real64 > m_scatterData;
+  array2d< real64 > m_coordinates;
+  string_array m_metadata;
+};
+
+TEST( ScatterDataProviderTest, EdgeCases )
+{
+  EdgeCaseScatterDataProvider provider;
+  EXPECT_EQ( provider.getNumScatterPoints(), 2 );
+  EXPECT_DOUBLE_EQ( provider.getScatterData()[0], -1e10 );
+  EXPECT_DOUBLE_EQ( provider.getScatterData()[1], 1e10 );
+  EXPECT_DOUBLE_EQ( provider.getScatterCoordinates()( 0, 0 ), -1e5 );
+  EXPECT_DOUBLE_EQ( provider.getScatterCoordinates()( 0, 2 ), 1e5 );
+  EXPECT_EQ( provider.getScatterMetadata()[0], "" );
+  EXPECT_EQ( provider.getScatterMetadata()[1], "Special_Station_#1" );
+}
+
+int main( int argc, char * *argv )
+{
+  ::testing::InitGoogleTest( &argc, argv );
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR introduces a `ScatterDataHistoryCollection` feature, enabling collection and output of time history data from scattered points.
Typical application can be found in geophysics, e.g.  data extraction at seismic receivers, or gravimeter stations (see an example in #3715 )

The implementation includes:
- `ScatterDataHistoryCollection`: responsible for collecting, organizing, and outputting scatter data from a specified provider.
- `ScatterDataProvider`:
  - Base interface for any class that supplies scatter data to the output system, defines:
     - `getNumScatterPoints()`: Returns the number of scatter points.
     - `getScatterData()`: Provides the main data array.
     - `getScatterCoordinates()`: Supplies coordinates for each point.
     - `getScatterMetadata()`: Supplies metadata (e.g., station names).
  - Enables decoupling between data sources and output logic, allowing any solver (wave equation, gravity, etc.) to act as a provider.
- HDF5 support, leveraging the output capabilities inherited from `TimeHistoryOutput`
- A comprehensive test