### PR TITLE
fix: fracture stencil bug

### DIFF
--- a/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
+++ b/src/coreComponents/finiteVolume/TwoPointFluxApproximation.cpp
@@ -140,7 +140,9 @@ void TwoPointFluxApproximation::computeCellStencil( MeshLevel & mesh ) const
 
   forAll< serialPolicy >( faceManager.size(), [=, &stencil]( localIndex const kf )
   {
-    // Filter out boundary faces
+    // Filter out faces that are not surrounded by matrix cells on this rank
+    // This means that if either element associated with a face is not present, it is excluded from the stencil.
+    // Similarly if an element is not present in the faceElement, it is excluded from the faceToMatrix stencil.
     if( elemList[kf][0] < 0 || elemList[kf][1] < 0 || isZero( transMultiplier[kf] ) )
     {
       return;
@@ -473,53 +475,56 @@ void TwoPointFluxApproximation::addFractureMatrixConnectionsDFM( MeshLevel & mes
 
       localIndex connectorIndex = faceToCellStencil.size();
 
-      for( localIndex ke = 0; ke < numElems; ++ke )
+      if( elemList[kfe][0] >= 0 && elemList[kfe][1] >= 0 )
       {
-        connectorIndex += ke;
-
-        localIndex const faceIndex = faceMap[kfe][ke];
-        localIndex const er  = elemRegionList[kfe][ke];
-        localIndex const esr = elemSubRegionList[kfe][ke];
-        localIndex const ei  = elemList[kfe][ke];
-
-        // remove cell-to-cell connections from cell stencil and add in new connections
-        if( !regionIndices.contains( er ) )
+        for( localIndex ke = 0; ke < numElems; ++ke )
         {
-          continue;
+          connectorIndex += ke;
+
+          localIndex const faceIndex = faceMap[kfe][ke];
+          localIndex const er  = elemRegionList[kfe][ke];
+          localIndex const esr = elemSubRegionList[kfe][ke];
+          localIndex const ei  = elemList[kfe][ke];
+
+          // remove cell-to-cell connections from cell stencil and add in new connections
+          if( !regionIndices.contains( er ) )
+          {
+            continue;
+          }
+
+          // Filter out entries where both fracture and cell element are ghosted
+          if( elemGhostRank[fractureRegionIndex][0][kfe] >= 0 && elemGhostRank[er][esr][ei] >= 0 )
+          {
+            continue;
+          }
+
+          LvArray::tensorOps::copy< 3 >( faceNormalVector, faceNormal[faceIndex] );
+
+          LvArray::tensorOps::copy< 3 >( cellToFaceVec, faceCenter[faceIndex] );
+          LvArray::tensorOps::subtract< 3 >( cellToFaceVec, elemCenter[er][esr][ei] );
+
+          real64 const c2fDistance = LvArray::tensorOps::normalize< 3 >( cellToFaceVec );
+
+          real64 const ht = faceArea[faceIndex] / c2fDistance;
+          // Note: this is done solely to avoid crashes when using the SolidMechanicsLagrangeContact that builds a stencil but does not
+          // register the
+          // hydraulicAperture
+          real64 const aperture_h =  hydraulicAperture[fractureRegionIndex][0].size() == 0 ? 1.0 : hydraulicAperture[fractureRegionIndex][0][kfe];
+
+          localIndex const stencilCellsRegionIndex[2]{ er, fractureRegionIndex };
+          localIndex const stencilCellsSubRegionIndex[2]{ esr, 0 };
+          localIndex const stencilCellsIndex[2]{ ei, kfe };
+          real64 const stencilWeights[2]{ ht, 2. * faceArea[faceIndex] / aperture_h };
+
+          faceToCellStencil.add( 2,
+                                 stencilCellsRegionIndex,
+                                 stencilCellsSubRegionIndex,
+                                 stencilCellsIndex,
+                                 stencilWeights,
+                                 connectorIndex );
+
+          faceToCellStencil.addVectors( transMultiplier[faceIndex], faceNormalVector, cellToFaceVec );
         }
-
-        // Filter out entries where both fracture and cell element are ghosted
-        if( elemGhostRank[fractureRegionIndex][0][kfe] >= 0 && elemGhostRank[er][esr][ei] >= 0 )
-        {
-          continue;
-        }
-
-        LvArray::tensorOps::copy< 3 >( faceNormalVector, faceNormal[faceIndex] );
-
-        LvArray::tensorOps::copy< 3 >( cellToFaceVec, faceCenter[faceIndex] );
-        LvArray::tensorOps::subtract< 3 >( cellToFaceVec, elemCenter[er][esr][ei] );
-
-        real64 const c2fDistance = LvArray::tensorOps::normalize< 3 >( cellToFaceVec );
-
-        real64 const ht = faceArea[faceIndex] / c2fDistance;
-        // Note: this is done solely to avoid crashes when using the SolidMechanicsLagrangeContact that builds a stencil but does not
-        // register the
-        // hydraulicAperture
-        real64 const aperture_h =  hydraulicAperture[fractureRegionIndex][0].size() == 0 ? 1.0 : hydraulicAperture[fractureRegionIndex][0][kfe];
-
-        localIndex const stencilCellsRegionIndex[2]{ er, fractureRegionIndex };
-        localIndex const stencilCellsSubRegionIndex[2]{ esr, 0 };
-        localIndex const stencilCellsIndex[2]{ ei, kfe };
-        real64 const stencilWeights[2]{ ht, 2. * faceArea[faceIndex] / aperture_h };
-
-        faceToCellStencil.add( 2,
-                               stencilCellsRegionIndex,
-                               stencilCellsSubRegionIndex,
-                               stencilCellsIndex,
-                               stencilWeights,
-                               connectorIndex );
-
-        faceToCellStencil.addVectors( transMultiplier[faceIndex], faceNormalVector, cellToFaceVec );
       }
     }
   } );


### PR DESCRIPTION
restrict creation of fracture stencil entries s.t. they mush have both surrounding matrix elements on rank