### PR TITLE
fix: Implement state initialisation for compositional fluid

### DIFF
--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3285-13414-69e5962
+  baseline: integratedTests/baseline_integratedTests-pr3812-13496-8dc0bc6
 
 allow_fail:
   all: ''

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -6,6 +6,10 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
+PR #3812 (2025-09-11) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3812-13496-8dc0bc6.tar.gz>
+=====================
+Add reset of k-values for compositional fluid model. Improves the convergence of models at the start.
+
 PR #3285 (2025-09-09) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3285-13414-69e5962.tar.gz>
 =====================
 Add hydrofrac verification cases for leak-off.

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.cpp
@@ -214,6 +214,9 @@ void CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::resizeFields
   MultiFluidBase::resizeFields( size, numPts );
 
   m_kValues.resize( size, numPts, numFluidPhases()-1, numFluidComponents() );
+
+  // Zero k-Values to force re-initialisation
+  m_kValues.zero();  
 }
 
 template< typename FLASH, typename PHASE1, typename PHASE2, typename PHASE3 >

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.cpp
@@ -216,7 +216,7 @@ void CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::resizeFields
   m_kValues.resize( size, numPts, numFluidPhases()-1, numFluidComponents() );
 
   // Zero k-Values to force re-initialisation
-  m_kValues.zero();  
+  m_kValues.zero();
 }
 
 template< typename FLASH, typename PHASE1, typename PHASE2, typename PHASE3 >

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.cpp
@@ -100,12 +100,21 @@ string CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::catalogNam
 }
 
 template< typename FLASH, typename PHASE1, typename PHASE2, typename PHASE3 >
+void CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::initializeState() const
+{
+  // Zero k-Values to force re-initialisation
+  m_kValues.zero();
+
+  MultiFluidBase::initializeState();
+}
+
+template< typename FLASH, typename PHASE1, typename PHASE2, typename PHASE3 >
 void CompositionalMultiphaseFluid< FLASH, PHASE1, PHASE2, PHASE3 >::allocateConstitutiveData( dataRepository::Group & parent,
                                                                                               localIndex const numConstitutivePointsPerParentIndex )
 {
   MultiFluidBase::allocateConstitutiveData( parent, numConstitutivePointsPerParentIndex );
 
-  // Zero k-Values to force initialisation with Wilson k-Values
+  // Zero k-Values to force re-initialisation
   m_kValues.zero();
 }
 

--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.hpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/CompositionalMultiphaseFluid.hpp
@@ -84,6 +84,8 @@ public:
     GEOS_UNUSED_VAR( pressure, temperature );
   }
 
+  virtual void initializeState() const override;
+
   virtual void allocateConstitutiveData( dataRepository::Group & parent,
                                          localIndex const numConstitutivePointsPerParentIndex ) override;
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -680,6 +680,7 @@ void CompositionalMultiphaseWell::updateVolRatesForConstraint( WellElementSubReg
 
   string const & fluidName = subRegion.getReference< string >( viewKeyStruct::fluidNamesString() );
   MultiFluidBase & fluid = subRegion.getConstitutiveModel< MultiFluidBase >( fluidName );
+  fluid.initializeState();
   integer const isThermal = fluid.isThermal();
   arrayView3d< real64 const, constitutive::multifluid::USD_PHASE > const & phaseFrac = fluid.phaseFraction();
   arrayView4d< real64 const, constitutive::multifluid::USD_PHASE_DC > const & dPhaseFrac = fluid.dPhaseFraction();
@@ -902,6 +903,8 @@ void CompositionalMultiphaseWell::updateFluidModel( WellElementSubRegion & subRe
   string const & fluidName = subRegion.getReference< string >( viewKeyStruct::fluidNamesString() );
   MultiFluidBase & fluid = subRegion.getConstitutiveModel< MultiFluidBase >( fluidName );
 
+  fluid.initializeState();
+
   constitutive::constitutiveUpdatePassThru( fluid, [&] ( auto & castedFluid )
   {
     using FluidType = TYPEOFREF( castedFluid );
@@ -915,7 +918,6 @@ void CompositionalMultiphaseWell::updateFluidModel( WellElementSubRegion & subRe
                             temp,
                             compFrac );
   } );
-
 }
 
 real64 CompositionalMultiphaseWell::updatePhaseVolumeFraction( WellElementSubRegion & subRegion ) const

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -680,7 +680,6 @@ void CompositionalMultiphaseWell::updateVolRatesForConstraint( WellElementSubReg
 
   string const & fluidName = subRegion.getReference< string >( viewKeyStruct::fluidNamesString() );
   MultiFluidBase & fluid = subRegion.getConstitutiveModel< MultiFluidBase >( fluidName );
-  fluid.initializeState();
   integer const isThermal = fluid.isThermal();
   arrayView3d< real64 const, constitutive::multifluid::USD_PHASE > const & phaseFrac = fluid.phaseFraction();
   arrayView4d< real64 const, constitutive::multifluid::USD_PHASE_DC > const & dPhaseFrac = fluid.dPhaseFraction();
@@ -903,8 +902,6 @@ void CompositionalMultiphaseWell::updateFluidModel( WellElementSubRegion & subRe
   string const & fluidName = subRegion.getReference< string >( viewKeyStruct::fluidNamesString() );
   MultiFluidBase & fluid = subRegion.getConstitutiveModel< MultiFluidBase >( fluidName );
 
-  fluid.initializeState();
-
   constitutive::constitutiveUpdatePassThru( fluid, [&] ( auto & castedFluid )
   {
     using FluidType = TYPEOFREF( castedFluid );
@@ -918,6 +915,7 @@ void CompositionalMultiphaseWell::updateFluidModel( WellElementSubRegion & subRe
                             temp,
                             compFrac );
   } );
+
 }
 
 real64 CompositionalMultiphaseWell::updatePhaseVolumeFraction( WellElementSubRegion & subRegion ) const


### PR DESCRIPTION
This PR adds a k-value reset for compositional fluid. This allows the well model to force a re-initialisation of the k-values when well conditions switch to guarantee a better fluid state.
