### PR TITLE
feat: register PorousViscoModifiedCamClay in kernelSpecs

### DIFF
--- a/src/coreComponents/physicsSolvers/solidMechanics/kernelSpecs.json
+++ b/src/coreComponents/physicsSolvers/solidMechanics/kernelSpecs.json
@@ -93,7 +93,8 @@
       ],
       "CONSTITUTIVE_TYPE": [
         "PorousSolid<ElasticIsotropic>",
-        "PorousSolid<ModifiedCamClay>"
+        "PorousSolid<ModifiedCamClay>",
+        "PorousSolid<DuvautLionsSolid<ModifiedCamClay>>"
       ],
       "FE_TYPE": [
         "H1_Hexahedron_Lagrange1_GaussLegendre2",


### PR DESCRIPTION
This PR enables `PorousViscoModifiedCamClay` model for `SolidMechanicsFixedStressThermoPoromechanicsKernels`