### PR TITLE
fix: stats update logic for coupled solvers

### DIFF
--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3790-13899-bb7b286
+  baseline: integratedTests/baseline_integratedTests-pr3838-13915-07c068d
 
 allow_fail:
   all: ''

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -6,6 +6,10 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
+PR #3838 (2025-09-30) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3838-13915-07c068d.tar.gz>
+=====================
+Fix statistics update logic for coupled solvers.
+
 PR #3790 (2025-09-29) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3790-13899-bb7b286.tar.gz>
 =====================
 Enable Kozeny-Carman Permeability for PorousSolid.

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVM.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseFVM.cpp
@@ -128,14 +128,6 @@ void CompositionalMultiphaseFVM::postInputInitialization()
 {
   CompositionalMultiphaseBase::postInputInitialization();
 
-  if( m_scalingType == ScalingType::Local &&
-      m_nonlinearSolverParameters.m_lineSearchAction != NonlinearSolverParameters::LineSearchAction::None )
-  {
-    GEOS_ERROR( GEOS_FMT( "{}: line search is not supported for {} = {}",
-                          getName(), viewKeyStruct::scalingTypeString(),
-                          EnumStrings< ScalingType >::toString( ScalingType::Local )) );
-  }
-
   if( m_formulationType == CompositionalMultiphaseFormulationType::OverallComposition )
   {
     string const formulationName = EnumStrings< CompositionalMultiphaseFormulationType >::toString( CompositionalMultiphaseFormulationType::OverallComposition );
@@ -193,6 +185,14 @@ void CompositionalMultiphaseFVM::registerDataForCFL( Group & meshBodies )
 void CompositionalMultiphaseFVM::initializePreSubGroups()
 {
   CompositionalMultiphaseBase::initializePreSubGroups();
+
+  if( m_scalingType == ScalingType::Local &&
+      m_nonlinearSolverParameters.m_lineSearchAction != NonlinearSolverParameters::LineSearchAction::None )
+  {
+    GEOS_ERROR( GEOS_FMT( "{}: line search is not supported for {} = {}",
+                          getName(), viewKeyStruct::scalingTypeString(),
+                          EnumStrings< ScalingType >::toString( ScalingType::Local )) );
+  }
 
   m_linearSolverParameters.get().mgr.strategy = m_isThermal
                                                 ? LinearSolverParameters::MGR::StrategyType::thermalCompositionalMultiphaseFVM

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
@@ -250,6 +250,7 @@ public:
   updateAndWriteConvergenceStep( real64 const & time_n, real64 const & dt,
                                  integer const cycleNumber, integer const iteration ) override
   {
+    PhysicsSolverBase::updateAndWriteConvergenceStep( time_n, dt, cycleNumber, iteration );
     forEachArgInTuple( m_solvers, [&]( auto & solver, auto )
     {
       solver->updateAndWriteConvergenceStep( time_n, dt, cycleNumber, iteration );

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
@@ -398,6 +398,16 @@ public:
     return result;
   }
 
+  virtual void
+  synchronizeNonlinearSolverParameters() override
+  {
+    forEachArgInTuple( m_solvers, [&]( auto & solver, auto )
+    {
+      solver->getNonlinearSolverParameters() = getNonlinearSolverParameters();
+      solver->synchronizeNonlinearSolverParameters();
+    } );
+  }
+
 protected:
 
   /**
@@ -699,11 +709,6 @@ protected:
                              EnumStrings< NonlinearSolverParameters::LineSearchAction >::toString( NonlinearSolverParameters::LineSearchAction::None ) ),
                    InputError );
 
-    if( !isSequential )
-    {
-      synchronizeNonlinearSolverParameters();
-    }
-
     if( m_nonlinearSolverParameters.m_nonlinearAccelerationType != NonlinearSolverParameters::NonlinearAccelerationType::None )
     {
       validateNonlinearAcceleration();
@@ -719,13 +724,13 @@ protected:
                  InputError );
   }
 
-  virtual void
-  synchronizeNonlinearSolverParameters() override
+  virtual void initializePostSubGroups() override
   {
-    forEachArgInTuple( m_solvers, [&]( auto & solver, auto )
+    bool const isSequential = getNonlinearSolverParameters().couplingType() == NonlinearSolverParameters::CouplingType::Sequential;
+    if( !isSequential )
     {
-      solver->getNonlinearSolverParameters() = getNonlinearSolverParameters();
-    } );
+      synchronizeNonlinearSolverParameters();
+    }
   }
 
   virtual void startSequentialIteration( integer const & iter,

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
@@ -724,8 +724,10 @@ protected:
                  InputError );
   }
 
-  virtual void initializePostSubGroups() override
+  virtual void initializePreSubGroups() override
   {
+    PhysicsSolverBase::initializePreSubGroups();
+
     bool const isSequential = getNonlinearSolverParameters().couplingType() == NonlinearSolverParameters::CouplingType::Sequential;
     if( !isSequential )
     {

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledSolver.hpp
@@ -252,10 +252,7 @@ public:
   {
     forEachArgInTuple( m_solvers, [&]( auto & solver, auto )
     {
-      if( m_writeStatisticsCSV >= 2 )
-      {
-        solver->updateAndWriteConvergenceStep( time_n, dt, cycleNumber, iteration );
-      }
+      solver->updateAndWriteConvergenceStep( time_n, dt, cycleNumber, iteration );
     } );
   }
 


### PR DESCRIPTION
- make `synchronizeNonlinearSolverParameters` recursive for subsolvers
- clarify `updateAndWriteConvergenceStep` logic for coupled solver