### PR TITLE
fix: matrix setup for poromechanics with contact and wells

### DIFF
--- a/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
@@ -1197,7 +1197,7 @@ void PhysicsSolverBase::setupSystem( DomainPartition & domain,
   if( setSparsity )
   {
     SparsityPattern< globalIndex > pattern;
-    setSparsityPattern( domain, dofManager, pattern );
+    setSparsityPattern( domain, dofManager, localMatrix, pattern );
     localMatrix.assimilate< parallelDevicePolicy<> >( std::move( pattern ) );
   }
   localMatrix.setName( this->getName() + "/matrix" );
@@ -1211,6 +1211,7 @@ void PhysicsSolverBase::setupSystem( DomainPartition & domain,
 
 void PhysicsSolverBase::setSparsityPattern( DomainPartition & GEOS_UNUSED_PARAM( domain ),
                                             DofManager & dofManager,
+                                            CRSMatrix< real64, globalIndex > & GEOS_UNUSED_PARAM( localMatrix ),
                                             SparsityPattern< globalIndex > & pattern )
 {
   dofManager.setSparsityPattern( pattern );

--- a/src/coreComponents/physicsSolvers/PhysicsSolverBase.hpp
+++ b/src/coreComponents/physicsSolvers/PhysicsSolverBase.hpp
@@ -411,6 +411,7 @@ public:
   virtual void
   setSparsityPattern( DomainPartition & domain,
                       DofManager & dofManager,
+                      CRSMatrix< real64, globalIndex > & localMatrix,
                       SparsityPattern< globalIndex > & pattern );
 
   /**

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.hpp
@@ -107,41 +107,19 @@ public:
   }
 
   /**
-   * @brief default destructor
-   */
-  virtual ~CoupledReservoirAndWellsBase () override {}
-
-  /**
    * @defgroup Solver Interface Functions
    *
    * These functions provide the primary interface that is required for derived classes
    */
   /**@{*/
 
-  virtual void
-  setupSystem( DomainPartition & domain,
-               DofManager & dofManager,
-               CRSMatrix< real64, globalIndex > & localMatrix,
-               ParallelVector & rhs,
-               ParallelVector & solution,
-               bool const setSparsity = true ) override
-  {
-    GEOS_MARK_FUNCTION;
-
-    // call reservoir solver setup (needed in case of SinglePhasePoromechanicsConformingFractures)
-    // TODO this logic does not really work - the pattern can be overwritten below
-    reservoirSolver()->setupSystem( domain, dofManager, localMatrix, rhs, solution, setSparsity );
-
-    PhysicsSolverBase::setupSystem( domain, dofManager, localMatrix, rhs, solution, setSparsity );
-  }
-
   virtual void setSparsityPattern( DomainPartition & domain,
                                    DofManager & dofManager,
                                    SparsityPattern< globalIndex > & pattern ) override
   {
-    // Set the sparsity pattern without reservoir-well coupling
+    // Set the reservoir sparsity pattern without reservoir-well coupling
     SparsityPattern< globalIndex > patternDiag;
-    dofManager.setSparsityPattern( patternDiag );
+    reservoirSolver()->setSparsityPattern( domain, dofManager, patternDiag );
 
     // Get the original row lengths (diagonal blocks only)
     array1d< localIndex > rowLengths( patternDiag.numRows());

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.hpp
@@ -115,11 +115,12 @@ public:
 
   virtual void setSparsityPattern( DomainPartition & domain,
                                    DofManager & dofManager,
+                                   CRSMatrix< real64, globalIndex > & localMatrix,
                                    SparsityPattern< globalIndex > & pattern ) override
   {
     // Set the reservoir sparsity pattern without reservoir-well coupling
     SparsityPattern< globalIndex > patternDiag;
-    reservoirSolver()->setSparsityPattern( domain, dofManager, patternDiag );
+    reservoirSolver()->setSparsityPattern( domain, dofManager, localMatrix, patternDiag );
 
     // Get the original row lengths (diagonal blocks only)
     array1d< localIndex > rowLengths( patternDiag.numRows());

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
@@ -264,11 +264,11 @@ real64 HydrofractureSolver< POROMECHANICS_SOLVER >::fullyCoupledSolverStep( real
     // Only build the sparsity pattern if the mesh has changed
     if( meshModificationTimestamp > getSystemSetupTimestamp() )
     {
-      setupSystem( domain,
-                   m_dofManager,
-                   m_localMatrix,
-                   m_rhs,
-                   m_solution );
+      this->setupSystem( domain,
+                         m_dofManager,
+                         m_localMatrix,
+                         m_rhs,
+                         m_solution );
       setSystemSetupTimestamp( meshModificationTimestamp );
     }
 
@@ -486,23 +486,9 @@ void HydrofractureSolver< POROMECHANICS_SOLVER >::setupCoupling( DomainPartition
 }
 
 template< typename POROMECHANICS_SOLVER >
-void HydrofractureSolver< POROMECHANICS_SOLVER >::setupSystem( DomainPartition & domain,
-                                                               DofManager & dofManager,
-                                                               CRSMatrix< real64, globalIndex > & localMatrix,
-                                                               ParallelVector & rhs,
-                                                               ParallelVector & solution,
-                                                               bool const setSparsity )
-{
-  GEOS_MARK_FUNCTION;
-
-  PhysicsSolverBase::setupSystem( domain, dofManager, localMatrix, rhs, solution, setSparsity );
-
-  setUpDflux_dApertureMatrix( domain, dofManager, localMatrix );
-}
-
-template< typename POROMECHANICS_SOLVER >
 void HydrofractureSolver< POROMECHANICS_SOLVER >::setSparsityPattern( DomainPartition & domain,
                                                                       DofManager & dofManager,
+                                                                      CRSMatrix< real64, globalIndex > & localMatrix,
                                                                       SparsityPattern< globalIndex > & pattern )
 {
   SparsityPattern< globalIndex > patternOriginal;
@@ -532,6 +518,8 @@ void HydrofractureSolver< POROMECHANICS_SOLVER >::setSparsityPattern( DomainPart
 
   // Add the nonzeros from coupling
   addFluxApertureCouplingSparsityPattern( domain, dofManager, pattern.toView());
+
+  setUpDflux_dApertureMatrix( domain, dofManager, localMatrix );
 }
 
 template< typename POROMECHANICS_SOLVER >

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.hpp
@@ -102,15 +102,9 @@ public:
   virtual void setupCoupling( DomainPartition const & domain,
                               DofManager & dofManager ) const override final;
 
-  virtual void setupSystem( DomainPartition & domain,
-                            DofManager & dofManager,
-                            CRSMatrix< real64, globalIndex > & localMatrix,
-                            ParallelVector & rhs,
-                            ParallelVector & solution,
-                            bool const setSparsity = true ) override;
-
   virtual void setSparsityPattern( DomainPartition & domain,
                                    DofManager & dofManager,
+                                   CRSMatrix< real64, globalIndex > & localMatrix,
                                    SparsityPattern< globalIndex > & pattern ) override;
 
   virtual void implicitStepSetup( real64 const & time_n,

--- a/src/coreComponents/physicsSolvers/multiphysics/PoromechanicsConformingFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PoromechanicsConformingFractures.hpp
@@ -84,9 +84,9 @@ public:
                                    DofManager & dofManager,
                                    SparsityPattern< globalIndex > & pattern ) override
   {
-    /// 2. Add coupling terms not added by the DofManager.
+    // start with the flow solver sparsity pattern (it could be reservoir + wells)
     SparsityPattern< globalIndex > patternOriginal;
-    dofManager.setSparsityPattern( patternOriginal );
+    this->flowSolver()->setSparsityPattern( domain, dofManager, patternOriginal );
 
     // Get the original row lengths (diagonal blocks only)
     array1d< localIndex > rowLengths( patternOriginal.numRows());

--- a/src/coreComponents/physicsSolvers/multiphysics/PoromechanicsConformingFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PoromechanicsConformingFractures.hpp
@@ -183,6 +183,8 @@ protected:
   {
     GEOS_MARK_FUNCTION;
 
+    integer const numComp = numFluidComponents();
+
     this->forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &, //  meshBodyName,
                                                                         MeshLevel const & mesh,
                                                                         string_array const & ) // regionNames
@@ -228,7 +230,10 @@ protected:
                 if( k1 != k0 )
                 {
                   localIndex const numNodesPerElement = elemsToNodes[sei[iconn][k1]].size();
-                  rowLengths[rowNumber] += 3*numNodesPerElement;
+                  for( integer ic = 0; ic < numComp; ic++ )
+                  {
+                    rowLengths[rowNumber + ic] += 3*numNodesPerElement;
+                  }
                 }
               }
             }
@@ -250,6 +255,8 @@ protected:
                                            SparsityPatternView< globalIndex > const & pattern ) const
   {
     GEOS_MARK_FUNCTION;
+
+    integer const numComp = numFluidComponents();
 
     this->forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                         MeshLevel const & mesh,
@@ -325,7 +332,10 @@ protected:
                     for( localIndex i = 0; i < 3; ++i )
                     {
                       globalIndex const colIndex = dispDofNumber[faceToNodeMap( faceIndex, a )] + LvArray::integerConversion< globalIndex >( i );
-                      pattern.insertNonZero( rowIndex, colIndex );
+                      for( integer ic = 0; ic < numComp; ic++ )
+                      {
+                        pattern.insertNonZero( rowIndex + ic, colIndex );
+                      }
                     }
                   }
                 }

--- a/src/coreComponents/physicsSolvers/multiphysics/PoromechanicsConformingFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PoromechanicsConformingFractures.hpp
@@ -61,32 +61,14 @@ public:
                             DofManager::Connector::Elem );
   }
 
-  virtual void setupSystem( DomainPartition & domain,
-                            DofManager & dofManager,
-                            CRSMatrix< real64, globalIndex > & localMatrix,
-                            ParallelVector & rhs,
-                            ParallelVector & solution,
-                            bool const setSparsity = true ) override
-  {
-    GEOS_MARK_FUNCTION;
-
-    PhysicsSolverBase::setupSystem( domain, dofManager, localMatrix, rhs, solution, setSparsity );
-
-    setUpDflux_dApertureMatrix( domain, dofManager, localMatrix );
-
-    // if( !m_precond && m_linearSolverParameters.get().solverType != LinearSolverParameters::SolverType::direct )
-    // {
-    //   m_precond = createPreconditioner( domain );
-    // }
-  }
-
   virtual void setSparsityPattern( DomainPartition & domain,
                                    DofManager & dofManager,
+                                   CRSMatrix< real64, globalIndex > & localMatrix,
                                    SparsityPattern< globalIndex > & pattern ) override
   {
     // start with the flow solver sparsity pattern (it could be reservoir + wells)
     SparsityPattern< globalIndex > patternOriginal;
-    this->flowSolver()->setSparsityPattern( domain, dofManager, patternOriginal );
+    this->flowSolver()->setSparsityPattern( domain, dofManager, localMatrix, patternOriginal );
 
     // Get the original row lengths (diagonal blocks only)
     array1d< localIndex > rowLengths( patternOriginal.numRows());
@@ -112,6 +94,8 @@ public:
 
     // Add the nonzeros from coupling
     addTransmissibilityCouplingPattern( domain, dofManager, pattern.toView());
+
+    setUpDflux_dApertureMatrix( domain, dofManager, localMatrix );
   }
 
   virtual void assembleSystem( real64 const time_n,
@@ -358,7 +342,12 @@ protected:
                                    DofManager const & GEOS_UNUSED_PARAM( dofManager ),
                                    CRSMatrix< real64, globalIndex > & localMatrix )
   {
+
+    std::cout << "PoromechanicsConformingFractures::setUpDflux_dApertureMatrix\n";
+
     integer const numComp = numFluidComponents();
+
+    std::cout << " numComp = " << numComp << '\n';
 
     this->forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                         MeshLevel const & mesh,

--- a/src/coreComponents/physicsSolvers/multiphysics/PoromechanicsConformingFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PoromechanicsConformingFractures.hpp
@@ -342,12 +342,7 @@ protected:
                                    DofManager const & GEOS_UNUSED_PARAM( dofManager ),
                                    CRSMatrix< real64, globalIndex > & localMatrix )
   {
-
-    std::cout << "PoromechanicsConformingFractures::setUpDflux_dApertureMatrix\n";
-
     integer const numComp = numFluidComponents();
-
-    std::cout << " numComp = " << numComp << '\n';
 
     this->forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                         MeshLevel const & mesh,

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsEmbeddedFractures.cpp
@@ -123,6 +123,7 @@ void SinglePhasePoromechanicsEmbeddedFractures::setupCoupling( DomainPartition c
 
 void SinglePhasePoromechanicsEmbeddedFractures::setSparsityPattern( DomainPartition & domain,
                                                                     DofManager & dofManager,
+                                                                    CRSMatrix< real64, globalIndex > & GEOS_UNUSED_PARAM( localMatrix ),
                                                                     SparsityPattern< globalIndex > & pattern )
 {
   // Set the sparsity pattern without the Kwu and Kuw blocks.

--- a/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsEmbeddedFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/SinglePhasePoromechanicsEmbeddedFractures.hpp
@@ -54,6 +54,7 @@ public:
 
   virtual void setSparsityPattern( DomainPartition & domain,
                                    DofManager & dofManager,
+                                   CRSMatrix< real64, globalIndex > & localMatrix,
                                    SparsityPattern< globalIndex > & pattern ) override;
 
   virtual void

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.cpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.cpp
@@ -89,6 +89,7 @@ LaplaceFEM::LaplaceFEM( const string & name,
  */
 void LaplaceFEM::setSparsityPattern( DomainPartition & domain,
                                      DofManager & dofManager,
+                                     CRSMatrix< real64, globalIndex > & GEOS_UNUSED_PARAM( localMatrix ),
                                      SparsityPattern< globalIndex > & pattern )
 {
   pattern.resize( dofManager.numLocalDofs(),

--- a/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.hpp
+++ b/src/coreComponents/physicsSolvers/simplePDE/LaplaceFEM.hpp
@@ -58,6 +58,7 @@ public:
 
   virtual void setSparsityPattern( DomainPartition & domain,
                                    DofManager & dofManager,
+                                   CRSMatrix< real64, globalIndex > & localMatrix,
                                    SparsityPattern< globalIndex > & pattern ) override;
 
   virtual void

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.cpp
@@ -989,6 +989,7 @@ void SolidMechanicsLagrangianFEM::setupSystem( DomainPartition & domain,
 
 void SolidMechanicsLagrangianFEM::setSparsityPattern( DomainPartition & domain,
                                                       DofManager & dofManager,
+                                                      CRSMatrix< real64, globalIndex > & GEOS_UNUSED_PARAM( localMatrix ),
                                                       SparsityPattern< globalIndex > & pattern )
 {
   pattern.resize( dofManager.numLocalDofs(),

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsLagrangianFEM.hpp
@@ -116,6 +116,7 @@ public:
   virtual void
   setSparsityPattern( DomainPartition & domain,
                       DofManager & dofManager,
+                      CRSMatrix< real64, globalIndex > & localMatrix,
                       SparsityPattern< globalIndex > & pattern ) override;
 
   virtual std::unique_ptr< PreconditionerBase< LAInterface > >

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsAugmentedLagrangianContact.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsAugmentedLagrangianContact.cpp
@@ -217,6 +217,7 @@ void SolidMechanicsAugmentedLagrangianContact::setupSystem( DomainPartition & do
 
 void SolidMechanicsAugmentedLagrangianContact::setSparsityPattern( DomainPartition & domain,
                                                                    DofManager & dofManager,
+                                                                   CRSMatrix< real64, globalIndex > & GEOS_UNUSED_PARAM( localMatrix ),
                                                                    SparsityPattern< globalIndex > & pattern )
 {
   // Set the sparsity pattern without the Abu and Aub blocks.

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsAugmentedLagrangianContact.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsAugmentedLagrangianContact.hpp
@@ -61,6 +61,7 @@ public:
 
   virtual void setSparsityPattern( DomainPartition & domain,
                                    DofManager & dofManager,
+                                   CRSMatrix< real64, globalIndex > & localMatrix,
                                    SparsityPattern< globalIndex > & pattern ) override final;
 
   virtual void implicitStepSetup( real64 const & time_n,

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsEmbeddedFractures.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsEmbeddedFractures.cpp
@@ -230,11 +230,12 @@ void SolidMechanicsEmbeddedFractures::setupDofs( DomainPartition const & domain,
 
 void SolidMechanicsEmbeddedFractures::setSparsityPattern( DomainPartition & domain,
                                                           DofManager & dofManager,
+                                                          CRSMatrix< real64, globalIndex > & localMatrix,
                                                           SparsityPattern< globalIndex > & pattern )
 {
   if( m_useStaticCondensation )
   {
-    SolidMechanicsLagrangianFEM::setSparsityPattern( domain, dofManager, pattern );
+    SolidMechanicsLagrangianFEM::setSparsityPattern( domain, dofManager, localMatrix, pattern );
     return;
   }
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsEmbeddedFractures.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsEmbeddedFractures.hpp
@@ -52,6 +52,7 @@ public:
 
   virtual void setSparsityPattern( DomainPartition & domain,
                                    DofManager & dofManager,
+                                   CRSMatrix< real64, globalIndex > & localMatrix,
                                    SparsityPattern< globalIndex > & pattern ) override;
 
   virtual void implicitStepComplete( real64 const & time_n,

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsLagrangeContact.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsLagrangeContact.cpp
@@ -215,10 +215,11 @@ void SolidMechanicsLagrangeContact::initializePreSubGroups()
 
 void SolidMechanicsLagrangeContact::setSparsityPattern( DomainPartition & domain,
                                                         DofManager & dofManager,
+                                                        CRSMatrix< real64, globalIndex > & localMatrix,
                                                         SparsityPattern< globalIndex > & pattern )
 {
   // avoid calling SolidMechanicsLagrangianFEM::setSparsityPattern
-  PhysicsSolverBase::setSparsityPattern( domain, dofManager, pattern );
+  PhysicsSolverBase::setSparsityPattern( domain, dofManager, localMatrix, pattern );
 }
 
 void SolidMechanicsLagrangeContact::implicitStepSetup( real64 const & time_n,

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsLagrangeContact.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsLagrangeContact.hpp
@@ -59,6 +59,7 @@ public:
 
   virtual void setSparsityPattern( DomainPartition & domain,
                                    DofManager & dofManager,
+                                   CRSMatrix< real64, globalIndex > & localMatrix,
                                    SparsityPattern< globalIndex > & pattern ) override;
 
   virtual std::unique_ptr< PreconditionerBase< LAInterface > >

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsLagrangeContactBubbleStab.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsLagrangeContactBubbleStab.cpp
@@ -217,6 +217,7 @@ void SolidMechanicsLagrangeContactBubbleStab::setupSystem( DomainPartition & dom
 
 void SolidMechanicsLagrangeContactBubbleStab::setSparsityPattern( DomainPartition & domain,
                                                                   DofManager & dofManager,
+                                                                  CRSMatrix< real64, globalIndex > & GEOS_UNUSED_PARAM( localMatrix ),
                                                                   SparsityPattern< globalIndex > & pattern )
 {
   // Set the sparsity pattern without the Abu and Aub blocks.

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsLagrangeContactBubbleStab.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsLagrangeContactBubbleStab.hpp
@@ -71,6 +71,7 @@ public:
 
   virtual void setSparsityPattern( DomainPartition & domain,
                                    DofManager & dofManager,
+                                   CRSMatrix< real64, globalIndex > & localMatrix,
                                    SparsityPattern< globalIndex > & pattern ) override final;
 
   virtual void


### PR DESCRIPTION
depends on https://github.com/GEOS-DEV/GEOS/pull/3834
trying to fix https://github.com/GEOS-DEV/GEOS/issues/3823
- one fix is for case with wells, to avoid overwriting matrix pattern when wells are added
- another fix is for multiphase where component loop was missing in two places