### PR TITLE
test: parallel run for contact tests

### DIFF
--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3838-13915-07c068d
+  baseline: integratedTests/baseline_integratedTests-pr3842-13948-6f07e39
 
 allow_fail:
   all: ''

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -6,6 +6,10 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
+PR #3838 (2025-10-01) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3842-13948-6f07e39.tar.gz>
+=====================
+Enable parallel run for some contact tests.
+
 PR #3838 (2025-09-30) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3838-13915-07c068d.tar.gz>
 =====================
 Fix statistics update logic for coupled solvers.

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -6,7 +6,7 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
-PR #3838 (2025-10-01) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3842-13948-6f07e39.tar.gz>
+PR #3842 (2025-10-01) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3842-13948-6f07e39.tar.gz>
 =====================
 Enable parallel run for some contact tests.
 

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_PassingCrack_smoke.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_PassingCrack_smoke.xml
@@ -13,6 +13,7 @@
       stabilizationName="TPFAstabilization"
       logLevel="1"
       discretization="FE1"
+      stabilizationScalingCoefficient="0.6"
       targetRegions="{ Region, Fracture }">
       <NonlinearSolverParameters
         newtonTol="1.0e-6"

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_SingleFracCompression_benchmark.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_SingleFracCompression_benchmark.xml
@@ -14,6 +14,7 @@
       stabilizationName="TPFAstabilization"
       logLevel="1"
       discretization="FE1"
+      stabilizationScalingCoefficient="0.6"
       targetRegions="{ Region, Fracture }">
       <NonlinearSolverParameters
         newtonTol="1.0e-8"

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_SingleFracCompression_benchmark.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_SingleFracCompression_benchmark.xml
@@ -14,7 +14,7 @@
       stabilizationName="TPFAstabilization"
       logLevel="1"
       discretization="FE1"
-      stabilizationScalingCoefficient="0.6"
+      stabilizationScalingCoefficient="0.5"
       targetRegions="{ Region, Fracture }">
       <NonlinearSolverParameters
         newtonTol="1.0e-8"

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_SingleFracCompression_smoke.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_SingleFracCompression_smoke.xml
@@ -14,6 +14,7 @@
       stabilizationName="TPFAstabilization"
       logLevel="1"
       discretization="FE1"
+      stabilizationScalingCoefficient="0.6"
       targetRegions="{ Region, Fracture }">
       <NonlinearSolverParameters
         newtonTol="1.0e-8"

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_UnstructuredCrack_benchmark.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_UnstructuredCrack_benchmark.xml
@@ -13,6 +13,7 @@
       stabilizationName="TPFAstabilization"
       logLevel="1"
       discretization="FE1"
+      stabilizationScalingCoefficient="0.6"
       targetRegions="{ Region, Fracture }">
       <NonlinearSolverParameters
         newtonTol="1.0e-8"

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_UnstructuredCrack_benchmark.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_UnstructuredCrack_benchmark.xml
@@ -13,7 +13,7 @@
       stabilizationName="TPFAstabilization"
       logLevel="1"
       discretization="FE1"
-      stabilizationScalingCoefficient="0.6"
+      stabilizationScalingCoefficient="0.5"
       targetRegions="{ Region, Fracture }">
       <NonlinearSolverParameters
         newtonTol="1.0e-8"

--- a/inputFiles/lagrangianContactMechanics/ContactMechanics_UnstructuredCrack_smoke.xml
+++ b/inputFiles/lagrangianContactMechanics/ContactMechanics_UnstructuredCrack_smoke.xml
@@ -13,6 +13,7 @@
       stabilizationName="TPFAstabilization"
       logLevel="1"
       discretization="FE1"
+      stabilizationScalingCoefficient="0.6"
       targetRegions="{ Region, Fracture }">
       <NonlinearSolverParameters
         newtonTol="1.0e-8"

--- a/inputFiles/lagrangianContactMechanics/contactMechanics.ats
+++ b/inputFiles/lagrangianContactMechanics/contactMechanics.ats
@@ -26,7 +26,7 @@ decks = [
     TestDeck(
         name="ContactMechanics_UnstructuredCrack_smoke",
         description="A thick plane with a crack in it (unstructured grid)",
-        partitions=((1, 1, 1), ),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=1,
         check_step=2,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
@@ -50,17 +50,17 @@ decks = [
         name="ContactMechanics_SingleFracCompression_smoke",
         description=
         "Single tilted fracture subjected to remote compression (unstructured grid)",
-        partitions=((1, 1, 1),),
-        restart_step=1,
-        check_step=2,
+        partitions=((1, 1, 1), (2, 2, 1)),
+        restart_step=0,
+        check_step=1,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
     TestDeck(
         name="ContactMechanics_PassingCrack_smoke",
         description=
         "Analytical benchmark for shear behavior: constant solution",
-        partitions=((1, 1, 1),),
-        restart_step=1,
-        check_step=2,
+        partitions=((1, 1, 1), (2, 2, 1)),
+        restart_step=0,
+        check_step=1,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
     TestDeck(
         name="ContactMechanics_PEBICrack_smoke",


### PR DESCRIPTION
Thanks to @bd713, by adjusting `stabilizationScalingCoefficient`, some contact examples can now be running in parallel.

Following [PR#3821](https://github.com/GEOS-DEV/GEOS/pull/3821), another try to enable parallel run for contact smoke tests.