### PR TITLE
fix: dane warning/error

### DIFF
--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreExport.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreExport.cpp
@@ -238,15 +238,13 @@ void HypreExport::importVector( arrayView1d< real64 const > const & values,
     // Receive local chunk into host buffer and then copy to hypre local vector (host/device)
     array1d< real64 > recvBuf( myLocal );
 
-    MPI_CHECK_ERROR( MPI_Scatterv( const_cast< real64 * >( sendBuf ),
-                                   counts.data(),
-                                   displs.data(),
-                                   MPI_DOUBLE,
-                                   recvBuf.data(),
-                                   myLocal,
-                                   MPI_DOUBLE,
-                                   /*root*/ 0,
-                                   m_subComm ) );
+    MPI_CHECK_ERROR( MpiWrapper::scatterv( sendBuf,
+                                           counts.data(),
+                                           displs.data(),
+                                           recvBuf.data(),
+                                           myLocal,
+                                           /*root*/ 0,
+                                           m_subComm ) );
 
     hypre_TMemcpy( hypre_VectorData( localVector ),
                    recvBuf.data(),

--- a/src/coreComponents/linearAlgebra/interfaces/hypre/HypreExport.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/hypre/HypreExport.cpp
@@ -238,7 +238,7 @@ void HypreExport::importVector( arrayView1d< real64 const > const & values,
     // Receive local chunk into host buffer and then copy to hypre local vector (host/device)
     array1d< real64 > recvBuf( myLocal );
 
-    MPI_CHECK_ERROR( MPI_Scatterv( sendBuf,
+    MPI_CHECK_ERROR( MPI_Scatterv( const_cast< real64 * >( sendBuf ),
                                    counts.data(),
                                    displs.data(),
                                    MPI_DOUBLE,

--- a/src/coreComponents/mesh/generators/VTKUtilities.cpp
+++ b/src/coreComponents/mesh/generators/VTKUtilities.cpp
@@ -654,10 +654,11 @@ partitionByCellGraph( AllMeshes & input,
     default:
     {
       GEOS_THROW( "Unknown partition method", InputError );
+      return{};
     }
   }
 
-  return{};
+
 }
 
 /**

--- a/src/coreComponents/mesh/generators/VTKUtilities.cpp
+++ b/src/coreComponents/mesh/generators/VTKUtilities.cpp
@@ -656,6 +656,8 @@ partitionByCellGraph( AllMeshes & input,
       GEOS_THROW( "Unknown partition method", InputError );
     }
   }
+
+  return{};
 }
 
 /**


### PR DESCRIPTION
`build-dane-toss_4_x86_64_ib-clang@14.0.6-release`

```
/usr/WS1/castel/geos_bubble/GEOS/src/coreComponents/linearAlgebra/interfaces/hypre/HypreExport.cpp:241:36: error: argument type 'const geos::real64 *' (aka 'const double *') doesn't match specified 'MPI' type tag that requires 'double *' [-Werror,-Wtype-safety]
    MPI_CHECK_ERROR( MPI_Scatterv( sendBuf,
                                   ^~~~~~~
/usr/WS1/castel/geos_bubble/GEOS/src/coreComponents/common/MpiWrapper.hpp:96:42: note: expanded from macro 'MPI_CHECK_ERROR'
#define MPI_CHECK_ERROR( error ) ((void) error)
```
            
                             
`build-dane-toss_4_x86_64_ib-gcc@12.1.1-debug`

```
/usr/WS1/castel/geos_bubble/GEOS/src/coreComponents/mesh/generators/VTKUtilities.cpp: In function ‘geos::array1d<long int> geos::vtk::partitionByCellGraph(AllMeshes&, PartitionMethod, MPI_Comm, int, int, int)’:
/usr/WS1/castel/geos_bubble/GEOS/src/coreComponents/mesh/generators/VTKUtilities.cpp:659:1: error: control reaches end of non-void function [-Werror=return-type]
  659 | }
      | ^
cc1plus: all warnings being treated as errors
```