### PR TITLE
docs: update doc for Biot Porosity

### DIFF
--- a/src/coreComponents/constitutive/docs/BiotPorosity.rst
+++ b/src/coreComponents/constitutive/docs/BiotPorosity.rst
@@ -17,7 +17,7 @@ According to the linear thermoporoelasticity theory `(Coussy, 2004) <https://onl
 Here, :math:`\phi_{ref}` is the porosity at a reference state with pressure :math:`p_{ref}` and
 volumetric strain :math:`\epsilon_{v,\,ref}`. Additionally, :math:`\alpha` is the Biot coefficient,
 :math:`\epsilon_v` is the volumetric strain, :math:`p` is the fluid pressure, :math:`N = \frac{K_s}{\alpha - \phi_{ref}}`, where :math:`{K_s}` is the grain bulk modulus,
-:math:`T` is the temperature and :math:`\beta_{\phi} = \beta_s ( \alpha - phi_{ref} )`, where :math:`{\beta_s}` is the solid matrix thermal expansion coefficient.
+:math:`T_{ref}` is the reference temperature and :math:`\beta_{\phi} = \beta_s ( \alpha - \phi_{ref} )`, where :math:`{\beta_s}` is the solid matrix thermal expansion coefficient.
 
 
 Parameters

--- a/src/coreComponents/constitutive/docs/BiotPorosity.rst
+++ b/src/coreComponents/constitutive/docs/BiotPorosity.rst
@@ -9,15 +9,15 @@ Biot Porosity Model
 Overview
 ======================
 
-According to the poroelasticity theory, the porosity (pore volume), :math:`\phi`, can be computed as
+According to the linear thermoporoelasticity theory `(Coussy, 2004) <https://onlinelibrary.wiley.com/doi/book/10.1002/0470092718>`__ , the porosity (pore volume), :math:`\phi`, can be computed as
 
 .. math::
-   \phi = \phi_{ref} + \alpha ( \epsilon_v - \epsilon_{v,\,ref} ) + (p - p_{ref}) / N.
+   \phi = \phi_{ref} + \alpha ( \epsilon_v - \epsilon_{v,\,ref} ) + (p - p_{ref}) / N - 3 \beta_{\phi} (T - T_{ref}).
 
 Here, :math:`\phi_{ref}` is the porosity at a reference state with pressure :math:`p_{ref}` and
 volumetric strain :math:`\epsilon_{v,\,ref}`. Additionally, :math:`\alpha` is the Biot coefficient,
-:math:`\epsilon_v` is the volumetric strain, :math:`p` is the fluid pressure
-and :math:`N = \frac{K_s}{\alpha - \phi_{ref}}`, where :math:`{K_s}` is the grain bulk modulus.
+:math:`\epsilon_v` is the volumetric strain, :math:`p` is the fluid pressure, :math:`N = \frac{K_s}{\alpha - \phi_{ref}}`, where :math:`{K_s}` is the grain bulk modulus,
+:math:`T` is the temperature and :math:`\beta_{\phi} = \beta_s ( \alpha - phi_{ref} )`, where :math:`{\beta_s}` is the solid matrix thermal expansion coefficient.
 
 
 Parameters

--- a/src/coreComponents/constitutive/docs/CompressibleSinglePhaseFluid.rst
+++ b/src/coreComponents/constitutive/docs/CompressibleSinglePhaseFluid.rst
@@ -15,10 +15,10 @@ types of oil with negligible amounts of dissolved gas.
 Specifically, fluid density is computed as
 
 .. math::
-   \rho(p) = \rho_0 e^{c_\rho(p - p_0)}
+   \rho(p) = \rho_0 ( e^{c_\rho(p - p_0)} + e^{\beta_f (T - T_0)} )
 
 where :math:`c_\rho` is compressibility, :math:`p_0` is reference pressure, :math:`\rho_0` is
-density at reference pressure.
+density at reference pressure, :math:`\beta_f` is the fluid thermal expansion coefficient, :math:`T_0` is reference temperature
 Similarly,
 
 .. math::

--- a/src/coreComponents/constitutive/docs/CompressibleSinglePhaseFluid.rst
+++ b/src/coreComponents/constitutive/docs/CompressibleSinglePhaseFluid.rst
@@ -18,7 +18,8 @@ Specifically, fluid density is computed as
    \rho(p) = \rho_0 ( e^{c_\rho(p - p_0)} + e^{\beta_f (T - T_0)} )
 
 where :math:`c_\rho` is compressibility, :math:`p_0` is reference pressure, :math:`\rho_0` is
-density at reference pressure, :math:`\beta_f` is the fluid thermal expansion coefficient, :math:`T_0` is reference temperature
+density at reference pressure, :math:`\beta_f` is the fluid thermal expansion coefficient, :math:`T_0` is reference temperature.
+
 Similarly,
 
 .. math::

--- a/src/coreComponents/constitutive/docs/solid/DruckerPragerExtended.rst
+++ b/src/coreComponents/constitutive/docs/solid/DruckerPragerExtended.rst
@@ -25,7 +25,7 @@ the hyperbolic relationship
    b = b_i + \frac{\lambda}{m+\lambda} \left( b_r - b_i \right)
 
 with :math:`m` a parameter controlling the hardening rate.  Here, :math:`b_r` is the residual yield surface slope.  
-If :math:`b_r < b_i`, hardening behavior will be observed, while for :math:`b_r < b_i` softening behavior will occur.
+If :math:`b_r > b_i`, hardening behavior will be observed, while for :math:`b_r < b_i` softening behavior will occur.
 
 In the resulting model, the yield surface begins at an initial position defined by the initial cohesion and friction angle.
 As plastic deformation occurs, the friction angle hardens (or softens) so that it asymptoptically approaches a


### PR DESCRIPTION
This PR 

- updates doc for Biot Porosity to include temperature dependence (fix [#3860](https://github.com/GEOS-DEV/GEOS/issues/3860)) 
- adds thermal dependence for the density model of CompressibleSinglePhaseFluid
- fixes description for hardening behavoir of ExtendedDruckerPrager   