### PR TITLE
fix: Fix scatterByBlock initialization

### DIFF
--- a/src/coreComponents/mesh/generators/VTKUtilities.cpp
+++ b/src/coreComponents/mesh/generators/VTKUtilities.cpp
@@ -794,8 +794,14 @@ scatterByBlock( vtkDataSet & mesh )
   }
   else
   {
-    // Other ranks have empty mesh
-    localParts->SetNumberOfPartitions( 0 );
+    // Other ranks have an empty mesh, but we still need to create the
+    // partitioned data set structure.
+    localParts->SetNumberOfPartitions( size );
+    for( int r = 0; r < size; ++r )
+    {
+      vtkNew< vtkUnstructuredGrid > emptyPartition;
+      localParts->SetPartition( r, emptyPartition );
+    }
   }
 
   //Send cells to appropriate ranks

--- a/src/pygeosx/pygeosx.cpp
+++ b/src/pygeosx/pygeosx.cpp
@@ -27,6 +27,7 @@
 #include "fileIO/python/PyVTKOutputType.hpp"
 #include "mainInterface/initialization.hpp"
 #include "LvArray/src/python/PyArray.hpp"
+#include "mainInterface/version.hpp"
 
 // System includes
 #pragma GCC diagnostic push
@@ -86,6 +87,8 @@ PyObject * init( PyObject * const pyArgv, bool const performSetup, long const py
   {
     basicSetup( argv.size() - 1, argv.data(), false );
     g_alreadyInitialized = true;
+
+    outputVersionInfo();
 
     // Verify that the ranks match, there is no recovering from this if incorrect.
     GEOS_ERROR_IF_NE( pythonMPIRank, MpiWrapper::commRank() );


### PR DESCRIPTION
Correctly initialize the VTK structure, even for ranks with no data.