### PR TITLE
feat: add a warning when direct linear solver is used for > 100k dofs system

### DIFF
--- a/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
@@ -1388,9 +1388,10 @@ void PhysicsSolverBase::solveLinearSystem( DofManager const & dofManager,
 
   matrix.setDofManager( &dofManager );
 
-  GEOS_WARNING_IF(isDirectSolver && dofManager.numGlobalDofs() > 100000,
-                  "Direct solver used for large system ( > 100,000 DOFs ). "
-                  "This may lead to high memory consumption and long computation times.");
+  GEOS_WARNING_IF( isDirectSolver && dofManager.numGlobalDofs() > 100000,
+                   "Direct solver used for large system ( > 100,000 DOFs ). "
+                   "This may lead to high memory consumption and long computation times. "
+                   "Consider using an iterative solver for better performance." );
 
   // Apply physics-based scaling to the linear system if enabled
   if( m_usePhysicsScaling )

--- a/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
@@ -1388,6 +1388,10 @@ void PhysicsSolverBase::solveLinearSystem( DofManager const & dofManager,
 
   matrix.setDofManager( &dofManager );
 
+  GEOS_WARNING_IF(isDirectSolver && dofManager.numGlobalDofs() > 100000,
+                  "Direct solver used for large system ( > 100,000 DOFs ). "
+                  "This may lead to high memory consumption and long computation times.");
+
   // Apply physics-based scaling to the linear system if enabled
   if( m_usePhysicsScaling )
   {


### PR DESCRIPTION
add a warning when direct linear solver is used for > 100k dofs system