### PR TITLE
fix: vtk implicit-fallthrough

### DIFF
--- a/src/coreComponents/mesh/generators/VTKUtilities.cpp
+++ b/src/coreComponents/mesh/generators/VTKUtilities.cpp
@@ -640,6 +640,7 @@ partitionByCellGraph( AllMeshes & input,
       return parmetis::partition( graph.toViewConst(), elemDist, numParts, comm, numRefinements );
 #else
       GEOS_THROW( "GEOS must be built with ParMETIS support (ENABLE_PARMETIS=ON) to use 'parmetis' partitioning method", InputError );
+      return {};
 #endif
     }
     case PartitionMethod::ptscotch:
@@ -649,6 +650,7 @@ partitionByCellGraph( AllMeshes & input,
       return ptscotch::partition( graph.toViewConst(), numParts, comm );
 #else
       GEOS_THROW( "GEOS must be built with Scotch support (ENABLE_SCOTCH=ON) to use 'ptscotch' partitioning method", InputError );
+      return {};
 #endif
     }
     default:


### PR DESCRIPTION
Fix Pangea-4 compilation

```bash
[ 43%] Building CXX object coreComponents/mesh/CMakeFiles/mesh.dir/generators/ParMETISInterface.cpp.o
/XXXXX/sources/geos-daily/develop_c508d6e/src/coreComponents/mesh/generators/VTKUtilities.cpp: In function ‘geos::array1d<long int> geos::vtk::partitionByCellGraph(AllMeshes&, PartitionMethod, MPI_Comm, int, int, int)’:
/XXXXX/sources/geos-daily/develop_c508d6e/src/coreComponents/mesh/generators/VTKUtilities.cpp:653:5: error: this statement may fall through [-Werror=implicit-fallthrough=]
  653 |     }
      |     ^
/XXXXX/sources/geos-daily/develop_c508d6e/src/coreComponents/mesh/generators/VTKUtilities.cpp:654:5: note: here
  654 |     default:
      |     ^~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [coreComponents/mesh/CMakeFiles/mesh.dir/build
```