### PR TITLE
docs: update proppant case

### DIFF
--- a/inputFiles/proppant/ProppantSlotTest_benchmark.xml
+++ b/inputFiles/proppant/ProppantSlotTest_benchmark.xml
@@ -67,7 +67,12 @@
       proppantSolverName="ProppantTransport"
       flowSolverName="SinglePhaseFVM"
       targetRegions="{ Fracture }"
-      logLevel="1"/>
+      logLevel="1">
+      <NonlinearSolverParameters
+        newtonMaxIter="8"
+	lineSearchAction="None"  	  
+        couplingType="Sequential"/>
+    </FlowProppantTransport>
 <!-- SPHINX_PROPPANT_COUPLEDSOLVER_END -->
 
 


### PR DESCRIPTION
This small PR fixes the reported [convergence issues](https://github.com/GEOS-DEV/GEOS/issues/3903) for `ProppantSlotTest_benchmark.xml`, as `couplingType` is missing.