### PR TITLE
feat: register PorousExtendedDruckerPrager in kernelSpecs

### DIFF
--- a/src/coreComponents/physicsSolvers/solidMechanics/kernelSpecs.json
+++ b/src/coreComponents/physicsSolvers/solidMechanics/kernelSpecs.json
@@ -94,8 +94,12 @@
       "CONSTITUTIVE_TYPE": [
         "PorousSolid<ElasticIsotropic, ConstantPermeability>",
         "PorousSolid<ElasticIsotropic, CarmanKozenyPermeability>",
+        "PorousSolid<DruckerPragerExtended, ConstantPermeability>",
+        "PorousSolid<DruckerPragerExtended, CarmanKozenyPermeability>",
         "PorousSolid<ModifiedCamClay, ConstantPermeability>",
         "PorousSolid<ModifiedCamClay, CarmanKozenyPermeability>",
+        "PorousSolid<DuvautLionsSolid<DruckerPragerExtended>, ConstantPermeability>",
+        "PorousSolid<DuvautLionsSolid<DruckerPragerExtended>, CarmanKozenyPermeability>"
         "PorousSolid<DuvautLionsSolid<ModifiedCamClay>, ConstantPermeability>",
         "PorousSolid<DuvautLionsSolid<ModifiedCamClay>, CarmanKozenyPermeability>"
       ],

--- a/src/coreComponents/physicsSolvers/solidMechanics/kernelSpecs.json
+++ b/src/coreComponents/physicsSolvers/solidMechanics/kernelSpecs.json
@@ -99,7 +99,7 @@
         "PorousSolid<ModifiedCamClay, ConstantPermeability>",
         "PorousSolid<ModifiedCamClay, CarmanKozenyPermeability>",
         "PorousSolid<DuvautLionsSolid<DruckerPragerExtended>, ConstantPermeability>",
-        "PorousSolid<DuvautLionsSolid<DruckerPragerExtended>, CarmanKozenyPermeability>"
+        "PorousSolid<DuvautLionsSolid<DruckerPragerExtended>, CarmanKozenyPermeability>",
         "PorousSolid<DuvautLionsSolid<ModifiedCamClay>, ConstantPermeability>",
         "PorousSolid<DuvautLionsSolid<ModifiedCamClay>, CarmanKozenyPermeability>"
       ],


### PR DESCRIPTION
This PR enables `PorousExtendedDruckerPrager` and `PorousViscoExtendedDruckerPrager` model for `SolidMechanicsFixedStressThermoPoromechanicsKernels`