### PR TITLE
fix: validate well constraints

### DIFF
--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -459,7 +459,7 @@ void CompositionalMultiphaseWell::validateWellConstraints( real64 const & time_n
       ElementRegionBase const & region = elemManager.getRegion( wellControls.referenceReservoirRegion());
 
       // Check if regions statistics are being computed
-      GEOS_ERROR_IF( !region.hasWrapper( CompositionalMultiphaseStatistics::catalogName()),
+      GEOS_ERROR_IF( !region.hasWrapper( CompositionalMultiphaseStatistics::regionStatisticsName()),
                      GEOS_FMT( "{}: No region average quantities computed.  WellControl {} referenceReservoirRegion field requires CompositionalMultiphaseStatistics to be configured for region {} ",
                                getDataContext(), wellControls.getName(), regionName ));
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/SinglePhaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/SinglePhaseWell.cpp
@@ -167,7 +167,7 @@ void SinglePhaseWell::validateWellConstraints( real64 const & time_n,
       ElementRegionBase const & region = elemManager.getRegion( wellControls.referenceReservoirRegion() );
 
       // Check if regions statistics are being computed
-      GEOS_ERROR_IF( !region.hasWrapper( SinglePhaseStatistics::catalogName()),
+      GEOS_ERROR_IF( !region.hasWrapper( SinglePhaseStatistics::regionStatisticsName()),
                      GEOS_FMT( "{}: No region average quantities computed.  WellControl {} referenceReservoirRegion field requires SinglePhaseStatistics to be configured for region {} ",
                                getDataContext(), wellControls.getName(), regionName ));
 


### PR DESCRIPTION
Add a fix for `validateWellConstraints()` where the `regionStatistics` wrapper is checked to exist in element regions with a wrong name.