### PR TITLE
fix: Fix macOS build due to missing include in ErrorHandler

### DIFF
--- a/src/coreComponents/common/logger/ExternalErrorHandler.cpp
+++ b/src/coreComponents/common/logger/ExternalErrorHandler.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <stdio.h>
 #include <sys/types.h>
+#include <sys/socket.h>
 #include <unistd.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
There is a missing include when compiling on macOS. This PR adds it.