### PR TITLE
fix: Filter INFO messages in external error detection

### DIFF
--- a/src/coreComponents/common/initializeEnvironment.cpp
+++ b/src/coreComponents/common/initializeEnvironment.cpp
@@ -91,13 +91,15 @@ void setupLogger()
                                                            string_view detectionLocation )
     {
       // Filter out INFO level messages from external libraries (e.g., VTK)
-      // TODO: use dedicated functions to make the process easier to read ( error / signal lambda would calls either an error function or an info function, depending on a filtering function )
+      // TODO: use dedicated functions to make the process easier to read
+      // ( error / signal lambda would calls either an error function or an info function, depending on a filtering function )
       if( errorMsg.find( "INFO|" ) != string_view::npos )
       {
         // Just print the message without error formatting
         GEOS_LOG( errorMsg );
         return;
       }
+
       std::string const stackHistory = LvArray::system::stackTrace( true );
 
       GEOS_LOG( GEOS_FMT( "***** ERROR\n"

--- a/src/coreComponents/common/initializeEnvironment.cpp
+++ b/src/coreComponents/common/initializeEnvironment.cpp
@@ -90,6 +90,13 @@ void setupLogger()
     ExternalErrorHandler::instance().setErrorHandling( []( string_view errorMsg,
                                                            string_view detectionLocation )
     {
+      // Filter out INFO level messages from external libraries (e.g., VTK)
+      if( errorMsg.find( "INFO|" ) != string_view::npos )
+      {
+        // Just print the message without error formatting
+        GEOS_LOG( errorMsg );
+        return;
+      }
       std::string const stackHistory = LvArray::system::stackTrace( true );
 
       GEOS_LOG( GEOS_FMT( "***** ERROR\n"

--- a/src/coreComponents/common/initializeEnvironment.cpp
+++ b/src/coreComponents/common/initializeEnvironment.cpp
@@ -91,6 +91,7 @@ void setupLogger()
                                                            string_view detectionLocation )
     {
       // Filter out INFO level messages from external libraries (e.g., VTK)
+      // TODO: use dedicated functions to make the process easier to read ( error / signal lambda would calls either an error function or an info function, depending on a filtering function )
       if( errorMsg.find( "INFO|" ) != string_view::npos )
       {
         // Just print the message without error formatting


### PR DESCRIPTION
After PR #3856 introduced external error detection, VTK's informational messages are being incorrectly flagged as error.

This PR adds filtering in the external error handler lambda (in `initializeEnvironment.cpp`) to skip messages containing `INFO|`  patterns before treating them as errors.



**Before:**
```
***** ERROR
***** LOCATION: (external error, detected post GEOS loading)
2025-12-01 10:26:29.658 (   1.194s) [    7FC6BFD99040]    vtkExtractEdges.cxx:329   INFO| Executing edge extractor with original point numbering

** StackTrace of 6 frames **
Frame 0: geos::OutputStreamDeviation::flush(std::function<void (std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >)> const&, std::basic_string_view<char, std::char_traits<char> >) 
Frame 1: geos::EventManager::run(geos::DomainPartition&) 
Frame 2: geos::GeosxState::run() 
Frame 3: main 
Frame 4: /lib64/libc.so.6 
Frame 5: __libc_start_main 
Frame 6: _start 
=====
```


**After:**
```
2025-12-10 16:25:31.316 (   0.510s) [    7FE267A91040]    vtkExtractEdges.cxx:329   INFO| Executing edge extractor with original point numbering
```