### PR TITLE
feat: enable high order quadrature rule for tet elements

### DIFF
--- a/src/coreComponents/physicsSolvers/solidMechanics/kernelSpecs.json
+++ b/src/coreComponents/physicsSolvers/solidMechanics/kernelSpecs.json
@@ -107,6 +107,7 @@
         "H1_Hexahedron_Lagrange1_GaussLegendre2",
         "H1_Wedge_Lagrange1_Gauss6",
         "H1_Tetrahedron_Lagrange1_Gauss1",
+        "H1_Tetrahedron_Lagrange1_Gauss14",
         "H1_Pyramid_Lagrange1_Gauss5",
         "H1_Tetrahedron_VEM_Gauss1",
         "H1_Prism5_VEM_Gauss1",


### PR DESCRIPTION
This PR enables the use of `H1_Tetrahedron_Lagrange1_Gauss14` for ALM solver.