### PR TITLE
ci: Unit tests check when switch to streak2 for Ubuntu debug build

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -166,6 +166,12 @@ jobs:
             ENABLE_HYPRE: OFF
             ENABLE_TRILINOS: ON
             GEOS_ENABLE_BOUNDS_CHECK: ON
+            RUNS_ON: streak2
+            NPROC: 8
+            DOCKER_RUN_ARGS: "--cpus=8 --memory=256g --runtime=nvidia -v /etc/pki/ca-trust/source/anchors/:/usr/local/share/ca-certificates/llnl:ro"
+            DOCKER_CERTS_DIR: "/usr/local/share/ca-certificates"
+            DOCKER_CERTS_UPDATE_COMMAND: "update-ca-certificates"
+
             HOST_CONFIG: /spack-generated.cmake
 
           - name: Ubuntu (20.04, gcc 10.5.0, open-mpi 4.0.3) - github codespaces
@@ -233,12 +239,16 @@ jobs:
       CMAKE_BUILD_TYPE: ${{ matrix.CMAKE_BUILD_TYPE }}
       DOCKER_IMAGE_TAG: ${{ needs.is_not_draft_pull_request.outputs.DOCKER_IMAGE_TAG }}
       DOCKER_REPOSITORY: ${{ matrix.DOCKER_REPOSITORY }}
+      DOCKER_CERTS_DIR: ${{ matrix.DOCKER_CERTS_DIR || '' }}
+      DOCKER_CERTS_UPDATE_COMMAND: ${{ matrix.DOCKER_CERTS_UPDATE_COMMAND || '' }}
+      DOCKER_RUN_ARGS: ${{ matrix.DOCKER_RUN_ARGS || '' }}
       ENABLE_HYPRE: ${{ matrix.ENABLE_HYPRE }}
       ENABLE_TRILINOS: ${{ matrix.ENABLE_TRILINOS }}
       GEOS_ENABLE_BOUNDS_CHECK: ${{ matrix.GEOS_ENABLE_BOUNDS_CHECK }}
       GCP_BUCKET: ${{ matrix.GCP_BUCKET }}
       HOST_CONFIG: ${{ matrix.HOST_CONFIG }}
-      RUNS_ON: ubuntu-22.04
+      NPROC: ${{ matrix.NPROC || '' }}
+      RUNS_ON: ${{ matrix.RUNS_ON || 'ubuntu-22.04' }}
     secrets: inherit
 
   # If the 'ci: run integrated tests' PR label is found, the integrated tests will be run immediately after the cpu jobs.


### PR DESCRIPTION
Hey, here I'm testing a Ubuntu debug build when switching the runner to streak2. 

There are a few tests that take much longer time than that before we changing to streak2. For example, `testFlowStatistics` takes 346 seconds on streak2, while it took only 4 seconds in the recent develop test. 

@rrsettgast, @MelReyCG, @arng40, could you help look into that? 