### PR TITLE
fix: Add fix to fracture state in case of high cohesion

### DIFF
--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3940-15307-53de7ba
+  baseline: integratedTests/baseline_integratedTests-pr3964-15460-26718eb
 
 allow_fail:
   all: ''

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -6,6 +6,10 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
+PR #3940 (2026-02-09) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3964-15460-26718eb.tar.gz>
+=====================
+Fix fracture state update for ALM solver
+
 PR #3940 (2026-01-27) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3940-15307-53de7ba.tar.gz>
 =====================
 Fix the transimissibility calculated between a cell and a surface element

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsAugmentedLagrangianContact.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsAugmentedLagrangianContact.cpp
@@ -912,6 +912,21 @@ void SolidMechanicsAugmentedLagrangianContact::applySystemSolution( DofManager c
                                contact::incrementalBubbleDisplacement::key(),
                                scalingFactor );
 
+  // Synchronize bubble displacements before computing displacement jump
+  forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
+                                                                MeshLevel & mesh,
+                                                                string_array const & )
+  {
+    FieldIdentifiers fieldsToBeSync;
+    fieldsToBeSync.addFields( FieldLocation::Face,
+                              { contact::incrementalBubbleDisplacement::key(),
+                                contact::totalBubbleDisplacement::key() } );
+
+    CommunicationTools::getInstance().synchronizeFields( fieldsToBeSync,
+                                                         mesh,
+                                                         domain.getNeighbors(),
+                                                         true );
+  } );
 
   // Loop for updating the displacement jump
   forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const & meshName,
@@ -962,19 +977,14 @@ void SolidMechanicsAugmentedLagrangianContact::applySystemSolution( DofManager c
     } );
   } );
 
+  // Synchronize displacement jump after computation
   forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                 MeshLevel & mesh,
                                                                 string_array const & )
-
   {
     FieldIdentifiers fieldsToBeSync;
 
-    fieldsToBeSync.addFields( FieldLocation::Face,
-                              { contact::incrementalBubbleDisplacement::key(),
-                                contact::totalBubbleDisplacement::key() } );
-
-    fieldsToBeSync.addElementFields( { contact::traction::key(),
-                                       contact::dispJump::key(),
+    fieldsToBeSync.addElementFields( { contact::dispJump::key(),
                                        contact::deltaDispJump::key() },
                                      { getUniqueFractureRegionName() } );
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/kernels/SolidMechanicsALMKernelsBase.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/kernels/SolidMechanicsALMKernelsBase.hpp
@@ -151,7 +151,7 @@ struct UpdateStateKernel
         // When normal traction is very small, check if cohesion allows stick state
         // before deciding to transition to slip (fix for high cohesion materials)
         real64 dLimitTau_dTraction = 0.0;
-        real64 const limitTau = contactWrapper.computeLimitTangentialTractionNorm( 0.0, dLimitTau_dTraction );
+        real64 const limitTau = contactWrapper.computeLimitTangentialTractionNorm( localTractionNew[ 0 ], dLimitTau_dTraction );
         real64 const currentTau = LvArray::math::sqrt( localTractionNew[1] * localTractionNew[1] +
                                                         localTractionNew[2] * localTractionNew[2] );
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/kernels/SolidMechanicsALMKernelsBase.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/kernels/SolidMechanicsALMKernelsBase.hpp
@@ -148,7 +148,7 @@ struct UpdateStateKernel
       }
       else if( LvArray::math::abs( localTractionNew[ 0 ] ) < normalTractionTolerance[k] )
       {
-        // When normal traction is very small, check if cohesion allows stick state
+        // When normal traction is lower than normalTractionTolerance, check if cohesion allows stick state
         // before deciding to transition to slip (fix for high cohesion materials)
         real64 dLimitTau_dTraction = 0.0;
         real64 const limitTau = contactWrapper.computeLimitTangentialTractionNorm( localTractionNew[ 0 ], dLimitTau_dTraction );
@@ -158,7 +158,6 @@ struct UpdateStateKernel
         if( currentTau > limitTau )
         {
           // Tangential traction exceeds cohesion limit: transition to slip
-          LvArray::tensorOps::fill< 3 >( localTractionNew, 0.0 );
           fractureState[k] = fields::contact::FractureState::Slip;
         }
         // else: cohesion allows stick state, keep traction as computed by updateTraction()

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/kernels/SolidMechanicsALMKernelsBase.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/kernels/SolidMechanicsALMKernelsBase.hpp
@@ -153,7 +153,7 @@ struct UpdateStateKernel
         real64 dLimitTau_dTraction = 0.0;
         real64 const limitTau = contactWrapper.computeLimitTangentialTractionNorm( localTractionNew[ 0 ], dLimitTau_dTraction );
         real64 const currentTau = LvArray::math::sqrt( localTractionNew[1] * localTractionNew[1] +
-                                                        localTractionNew[2] * localTractionNew[2] );
+                                                       localTractionNew[2] * localTractionNew[2] );
 
         if( currentTau > limitTau )
         {

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/kernels/SolidMechanicsALMKernelsBase.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/kernels/SolidMechanicsALMKernelsBase.hpp
@@ -144,13 +144,24 @@ struct UpdateStateKernel
 
       if( fractureState[k] == fields::contact::FractureState::Open )
       {
-
         LvArray::tensorOps::fill< 3 >( localTractionNew, 0.0 );
       }
       else if( LvArray::math::abs( localTractionNew[ 0 ] ) < normalTractionTolerance[k] )
       {
-        LvArray::tensorOps::fill< 3 >( localTractionNew, 0.0 );
-        fractureState[k] = fields::contact::FractureState::Slip;
+        // When normal traction is very small, check if cohesion allows stick state
+        // before deciding to transition to slip (fix for high cohesion materials)
+        real64 dLimitTau_dTraction = 0.0;
+        real64 const limitTau = contactWrapper.computeLimitTangentialTractionNorm( 0.0, dLimitTau_dTraction );
+        real64 const currentTau = LvArray::math::sqrt( localTractionNew[1] * localTractionNew[1] +
+                                                        localTractionNew[2] * localTractionNew[2] );
+
+        if( currentTau > limitTau )
+        {
+          // Tangential traction exceeds cohesion limit: transition to slip
+          LvArray::tensorOps::fill< 3 >( localTractionNew, 0.0 );
+          fractureState[k] = fields::contact::FractureState::Slip;
+        }
+        // else: cohesion allows stick state, keep traction as computed by updateTraction()
       }
 
       LvArray::tensorOps::copy< 3 >( traction[k], localTractionNew );


### PR DESCRIPTION
This PR tries to correct a condition found in the ALM method.

The implementation is based from the LM method (  physicsSolvers/solidMechanics/contact/SolidMechanicsLagrangeContact.cpp:2274-2335) : 

 - when normal traction is smaller than normalTractionTolerance, check if cohesion allows stick state before deciding to transition to slip (fix for high cohesion materials)


Some tests have been performed showing a better consistency in Aramis case with very high cohesion (1e20): 
Previous implementation:
<img width="2666" height="1122" alt="image" src="https://github.com/user-attachments/assets/96511150-0892-4286-8159-79e8de65d46e" />

With the fix: 
<img width="2603" height="1140" alt="image" src="https://github.com/user-attachments/assets/8cb2f88f-49f3-46d4-889a-42a7dd134f10" />
