### PR TITLE
fix: compilation issue with HIP build

### DIFF
--- a/src/coreComponents/constitutive/fluid/multifluid/CO2Brine/functions/CO2Solubility.hpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/CO2Brine/functions/CO2Solubility.hpp
@@ -192,8 +192,16 @@ CO2SolubilityUpdate::compute( real64 const & pressure,
 
   real64 const determinant = 1.0 - co2Solubility*watSolubility;
 
-  GEOS_ERROR_IF_LT_MSG ( LvArray::math::abs( determinant ), minForDivision,
-                         GEOS_FMT( "Failed to calculate solubility at pressure {} Pa and temperature {} C.", pressure, temperature ) );
+#if defined(GEOS_DEVICE_COMPILE)
+  GEOS_THROW_IF( LvArray::math::abs( determinant ) < minForDivision,
+                 "Failed to calculate solubility (device).",
+                 geos::InputError );
+#else
+  GEOS_THROW_IF( LvArray::math::abs( determinant ) < minForDivision,
+                 GEOS_FMT( "Failed to calculate solubility at pressure {} Pa and temperature {} C.",
+                           pressure, temperature ),
+                 geos::InputError );
+#endif
 
   real64 invDeterminant = 0.0;
   real64 invDeterminantDeriv[2]{ 0.0, 0.0 };


### PR DESCRIPTION
Follow-up to PR #3831 

Fixes one remaining build issue not addressed in the previous PR:

```
In file included from geos-path/src/coreComponents/constitutive/fluid/multifluid/CO2Brine/CO2BrineFluid.cpp:19:
In file included from geos-path/src/coreComponents/constitutive/fluid/multifluid/CO2Brine/CO2BrineFluid.hpp:29:
geos-path/src/coreComponents/constitutive/fluid/multifluid/CO2Brine/functions/CO2Solubility.hpp:196:26: error: reference to __host__ function 'format<const double &, const double &>' in __host__ __device__ function
  196 |                          GEOS_FMT( "Failed to calculate solubility at pressure {} Pa and temperature {} C.", pressure, temperature ) );
      |                          ^
geos-path/src/coreComponents/common/format/Format.hpp:81:43: note: expanded from macro 'GEOS_FMT'
   81 | #define GEOS_FMT( msg, ... ) GEOS_FMT_NS::format( msg, __VA_ARGS__ )
      |                                           ^
geos-path/src/coreComponents/constitutive/fluid/multifluid/CO2Brine/CO2BrineFluid.hpp:289:11: note: called by 'compute'
  289 |   m_flash.compute( pressure,
      |           ^
/usr/WS1/GEOS/GEOSX/TPLs_2026-03-02/tuolumne-llvm-amdgpu-6.4.3_tpls/llvm-amdgpu-6.4.3/fmt-11.0.2-vjwb72ugeomwqz4kcgt64id6mnkgqzhp/include/fmt/format.h:4363:31: note: 'format<const double &, const double &>' declared here
 4363 | FMT_NODISCARD FMT_INLINE auto format(format_string<T...> fmt, T&&... args)
      |                               ^
In file included from geos-path/src/coreComponents/constitutive/fluid/multifluid/CO2Brine/CO2BrineFluid.cpp:19:
In file included from geos-path/src/coreComponents/constitutive/fluid/multifluid/CO2Brine/CO2BrineFluid.hpp:29:
geos-path/src/coreComponents/constitutive/fluid/multifluid/CO2Brine/functions/CO2Solubility.hpp:196:36: error: reference to __host__ function 'basic_format_string<char[71], 0>' in __host__ __device__ function
  196 |                          GEOS_FMT( "Failed to calculate solubility at pressure {} Pa and temperature {} C.", pressure, temperature ) );

```