### PR TITLE
fix: residual updates in CSV output

### DIFF
--- a/src/coreComponents/physicsSolvers/SolverStatistics.hpp
+++ b/src/coreComponents/physicsSolvers/SolverStatistics.hpp
@@ -300,7 +300,7 @@ public:
    * @param value The residual value
    */
   void setResidualValue( string const & key, real64 const value )
-  { if( m_CSVOutputRequest ) m_residuals.insert( {key, value} ); }
+  { if( m_CSVOutputRequest ) m_residuals.get_inserted( key ) = value; }
 
   /**
    * @brief Set the filename output file.


### PR DESCRIPTION
This PR ensures that residual values are correctly updated in the CSV output; previously, the first value was being repeated.