### PR TITLE
fix: Fix K-Value warning

### DIFF
--- a/src/coreComponents/constitutive/fluid/multifluid/compositional/parameters/KValueFlashParameters.cpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/compositional/parameters/KValueFlashParameters.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include "common/Units.hpp"
+#include "common/MpiWrapper.hpp"
 #include "common/format/table/TableFormatter.hpp"
 
 namespace geos
@@ -423,8 +424,9 @@ bool KValueFlashParameters< NUM_PHASE >::validateKValues( MultiFluidBase const *
     }
 
     string const fluidName = fluid->getFullName();
-    GEOS_WARNING( GEOS_FMT( "{}: {}\n{}",
-                            fluidName, message, tableText.toString( tableData ) ));
+    GEOS_WARNING_IF( MpiWrapper::commRank() == 0,
+                     GEOS_FMT( "{}: {}\n{}",
+                               fluidName, message, tableText.toString( tableData ) ));
 
     GEOS_THROW_IF( hasAtLeastOneNegative, "negative k-value found. ",
                    InputError, fluid->getDataContext() );


### PR DESCRIPTION
This PR modifies the warning logic in `KValueFlashParameters.cpp` so that K-value validation warnings are only emitted by the root MPI process, preventing log spam in distributed runs.