### PR TITLE
refactor: fix statistics time

### DIFF
--- a/src/coreComponents/integrationTests/testingUtilities/TestingTasks.cpp
+++ b/src/coreComponents/integrationTests/testingUtilities/TestingTasks.cpp
@@ -43,6 +43,13 @@ bool TimeStepChecker::execute( real64 const time_n,
   return false;
 }
 
+void TimeStepChecker::cleanup( real64 time_n, integer cycleNumber,
+                               integer eventCounter, real64 eventProgress,
+                               DomainPartition & domain )
+{
+  execute( time_n, 0.0, cycleNumber, eventCounter, eventProgress, domain );
+}
+
 REGISTER_CATALOG_ENTRY( TaskBase, TimeStepChecker, string const &, geos::dataRepository::Group * const )
 
 

--- a/src/coreComponents/integrationTests/testingUtilities/TestingTasks.hpp
+++ b/src/coreComponents/integrationTests/testingUtilities/TestingTasks.hpp
@@ -20,6 +20,7 @@
 #ifndef GEOS_EVENTS_TASKS_TESTINGTASKS_HPP_
 #define GEOS_EVENTS_TASKS_TESTINGTASKS_HPP_
 
+#include "common/DataTypes.hpp"
 #include "events/tasks/TaskBase.hpp"
 #include "codingUtilities/UnitTestUtilities.hpp"
 
@@ -65,6 +66,10 @@ public:
   static string catalogName() { return "TimeStepChecker"; }
 
   virtual bool execute( real64 time_n, real64 dt, integer cycleNumber,
+                        integer eventCounter, real64 eventProgress,
+                        DomainPartition & domain );
+
+  virtual void cleanup( real64 time_n, integer cycleNumber,
                         integer eventCounter, real64 eventProgress,
                         DomainPartition & domain );
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseStatistics.cpp
@@ -201,15 +201,13 @@ bool CompositionalMultiphaseStatistics::execute( real64 const time_n,
   {
     if( m_computeRegionStatistics )
     {
-      // current time is time_n + dt
-      computeRegionStatistics( time_n + dt, mesh, regionNames );
+      computeRegionStatistics( time_n, mesh, regionNames );
     }
   } );
 
   if( m_computeCFLNumbers )
   {
-    // current time is time_n + dt
-    computeCFLNumbers( time_n + dt, dt, domain );
+    computeCFLNumbers( time_n, dt, domain );
   }
 
   return false;

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseStatistics.cpp
@@ -192,22 +192,23 @@ bool CompositionalMultiphaseStatistics::execute( real64 const time_n,
                                                  real64 const dt,
                                                  integer const GEOS_UNUSED_PARAM( cycleNumber ),
                                                  integer const GEOS_UNUSED_PARAM( eventCounter ),
-                                                 real64 const GEOS_UNUSED_PARAM( eventProgress ),
+                                                 real64 const eventProgress,
                                                  DomainPartition & domain )
 {
+  real64 const time = time_n + dt * eventProgress;
   m_solver->forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                           MeshLevel & mesh,
                                                                           string_array const & regionNames )
   {
     if( m_computeRegionStatistics )
     {
-      computeRegionStatistics( time_n, mesh, regionNames );
+      computeRegionStatistics( time, mesh, regionNames );
     }
   } );
 
   if( m_computeCFLNumbers )
   {
-    computeCFLNumbers( time_n, dt, domain );
+    computeCFLNumbers( time, dt, domain );
   }
 
   return false;

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseStatistics.cpp
@@ -215,6 +215,16 @@ bool CompositionalMultiphaseStatistics::execute( real64 const time_n,
   return false;
 }
 
+void CompositionalMultiphaseStatistics::cleanup( real64 const time_n,
+                                                 integer const cycleNumber,
+                                                 integer const eventCounter,
+                                                 real64 const eventProgress,
+                                                 DomainPartition & domain )
+{
+  execute( time_n, 0.0, cycleNumber, eventCounter, eventProgress, domain );
+}
+
+
 void CompositionalMultiphaseStatistics::computeRegionStatistics( real64 const time,
                                                                  MeshLevel & mesh,
                                                                  string_array const & regionNames ) const

--- a/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseStatistics.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CompositionalMultiphaseStatistics.hpp
@@ -65,6 +65,15 @@ public:
                         real64 const eventProgress,
                         DomainPartition & domain ) override;
 
+  /**
+   * @copydoc ExecutableGroup::cleanup()
+   */
+  virtual void cleanup( real64 const time_n,
+                        integer const cycleNumber,
+                        integer const eventCounter,
+                        real64 const eventProgress,
+                        DomainPartition & domain ) override;
+
   /**@}*/
 
   struct RegionStatistics

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.cpp
@@ -103,8 +103,7 @@ bool SinglePhaseStatistics::execute( real64 const time_n,
                                                                           MeshLevel & mesh,
                                                                           string_array const & regionNames )
   {
-    // current time is time_n + dt
-    computeRegionStatistics( time_n + dt, mesh, regionNames );
+    computeRegionStatistics( time_n, mesh, regionNames );
   } );
   return false;
 }

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.cpp
@@ -96,14 +96,15 @@ bool SinglePhaseStatistics::execute( real64 const time_n,
                                      real64 const dt,
                                      integer const GEOS_UNUSED_PARAM( cycleNumber ),
                                      integer const GEOS_UNUSED_PARAM( eventCounter ),
-                                     real64 const GEOS_UNUSED_PARAM( eventProgress ),
+                                     real64 const eventProgress,
                                      DomainPartition & domain )
 {
+  real64 const time = time_n + dt * eventProgress;
   m_solver->forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                           MeshLevel & mesh,
                                                                           string_array const & regionNames )
   {
-    computeRegionStatistics( time_n, mesh, regionNames );
+    computeRegionStatistics( time, mesh, regionNames );
   } );
   return false;
 }

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.cpp
@@ -109,6 +109,15 @@ bool SinglePhaseStatistics::execute( real64 const time_n,
   return false;
 }
 
+void SinglePhaseStatistics::cleanup( real64 const time_n,
+                                      integer const cycleNumber,
+                                      integer const eventCounter,
+                                      real64 const eventProgress,
+                                      DomainPartition & domain )
+{
+  execute( time_n, 0.0, cycleNumber, eventCounter, eventProgress, domain );
+}
+
 void SinglePhaseStatistics::computeRegionStatistics( real64 const time,
                                                      MeshLevel & mesh,
                                                      string_array const & regionNames ) const

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.cpp
@@ -110,10 +110,10 @@ bool SinglePhaseStatistics::execute( real64 const time_n,
 }
 
 void SinglePhaseStatistics::cleanup( real64 const time_n,
-                                      integer const cycleNumber,
-                                      integer const eventCounter,
-                                      real64 const eventProgress,
-                                      DomainPartition & domain )
+                                     integer const cycleNumber,
+                                     integer const eventCounter,
+                                     real64 const eventProgress,
+                                     DomainPartition & domain )
 {
   execute( time_n, 0.0, cycleNumber, eventCounter, eventProgress, domain );
 }

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseStatistics.hpp
@@ -63,6 +63,15 @@ public:
                         real64 const eventProgress,
                         DomainPartition & domain ) override;
 
+  /**
+   * @copydoc ExecutableGroup::cleanup()
+   */
+  virtual void cleanup( real64 const time_n,
+                        integer const cycleNumber,
+                        integer const eventCounter,
+                        real64 const eventProgress,
+                        DomainPartition & domain ) override;
+
   /**@}*/
 
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/SourceFluxStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SourceFluxStatistics.cpp
@@ -282,6 +282,15 @@ bool SourceFluxStatsAggregator::execute( real64 const GEOS_UNUSED_PARAM( time_n 
   return false;
 }
 
+void SourceFluxStatsAggregator::cleanup( real64 const time_n,
+                                         integer const cycleNumber,
+                                         integer const eventCounter,
+                                         real64 const eventProgress,
+                                         DomainPartition & domain )
+{
+  execute( time_n, 0.0, cycleNumber, eventCounter, eventProgress, domain );
+}
+
 
 
 void SourceFluxStatsAggregator::StatData::allocate( integer phaseCount )

--- a/src/coreComponents/physicsSolvers/fluidFlow/SourceFluxStatistics.hpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SourceFluxStatistics.hpp
@@ -224,6 +224,15 @@ private:
                         DomainPartition & domain ) override;
 
   /**
+   * @copydoc ExecutableGroup::cleanup()
+   */
+  virtual void cleanup( real64 const time_n,
+                        integer const cycleNumber,
+                        integer const eventCounter,
+                        real64 const eventProgress,
+                        DomainPartition & domain ) override;
+
+  /**
    * @brief Apply a functor to WrappedStats that combines all stats for each target solver
    *        discretization mesh levels.
    * @param domain   the domain for which we want the statistics

--- a/src/coreComponents/physicsSolvers/fluidFlow/unitTests/testFlowStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/unitTests/testFlowStatistics.cpp
@@ -137,7 +137,7 @@ struct TestSet
         sinkMeanRate[ip] += inputs.sinkRates[timestepId][ip] * inputs.sinkRateFactor;
       }
       // mean rates calculation
-      real64 const ratesMeanDivisor = 1.0 / double( timestepCount );
+      real64 const ratesMeanDivisor = 1.0 / double( timestepCount - 1 );
       sourceMeanRate[ip] *= ratesMeanDivisor;
       sinkMeanRate[ip] *= ratesMeanDivisor;
       // totals
@@ -470,10 +470,6 @@ TestSet getTestSet()
   </Geometry>
 
   <Events maxTime="5000.0">
-    <PeriodicEvent name="solverApplications"
-                   forceDt="500.0"
-                   target="/Solvers/testSolver" />
-
     <PeriodicEvent name="timestepStatsEvent"
                    timeFrequency="500.0"
                    target="/Tasks/timeStepFluxStats" />
@@ -481,13 +477,17 @@ TestSet getTestSet()
                    timeFrequency="500.0"
                    target="/Tasks/timeStepReservoirStats" />
 
+    <PeriodicEvent name="wholeSimStatsEvent"
+                   timeFrequency="5000.0"
+                   target="/Tasks/wholeSimFluxStats" />
+
     <PeriodicEvent name="timestepsCheckEvent"
                    timeFrequency="500.0"
                    target="/Tasks/timeStepChecker" />
 
-    <PeriodicEvent name="wholeSimStatsEvent"
-                   timeFrequency="5000.0"
-                   target="/Tasks/wholeSimFluxStats" />
+    <PeriodicEvent name="solverApplications"
+                   forceDt="500.0"
+                   target="/Solvers/testSolver" />
   </Events>
 
   <Tasks>
@@ -536,6 +536,7 @@ TestSet getTestSet()
   // FluxRate table from 0.0s to 5000.0s
   setRateTable( testInputs.sourceRates,
                 { { 0.000 },
+                  { 0.000 },
                   { 0.767 },
                   { 0.894 },
                   { 0.561 },
@@ -544,7 +545,6 @@ TestSet getTestSet()
                   { 0.178 },
                   { 0.162 },
                   { 0.059 },
-                  { 0.000 },
                   { 0.000 } } );
   testInputs.sinkRates=testInputs.sourceRates;
 
@@ -713,12 +713,7 @@ TestSet getTestSet()
          xMax="{ 10.01, 10.01,  0.01 }" />
   </Geometry>
 
-  <!-- We are adding 500s to the whole sim time to force the wholeSimStatsEvent to be executed -->
   <Events maxTime="5000.0">
-    <PeriodicEvent name="solverApplications"
-                   forceDt="500.0"
-                   target="/Solvers/testSolver" />
-
     <PeriodicEvent name="timestepFluxStatsEvent"
                    timeFrequency="500.0"
                    target="/Tasks/timeStepFluxStats" />
@@ -726,13 +721,17 @@ TestSet getTestSet()
                    timeFrequency="500.0"
                    target="/Tasks/timeStepReservoirStats" />
 
+    <PeriodicEvent name="wholeSimStatsEvent"
+                   timeFrequency="5000.0"
+                   target="/Tasks/wholeSimFluxStats" />
+
     <PeriodicEvent name="timestepsCheckEvent"
                    timeFrequency="500.0"
                    target="/Tasks/timeStepChecker" />
 
-    <PeriodicEvent name="wholeSimStatsEvent"
-                   timeFrequency="5000.0"
-                   target="/Tasks/wholeSimFluxStats" />
+    <PeriodicEvent name="solverApplications"
+                   forceDt="500.0"
+                   target="/Solvers/testSolver" />
   </Events>
 
   <Tasks>
@@ -813,6 +812,7 @@ TestSet getTestSet()
   // FluxInjectionRate & FluxProductionRate table from 0.0s to 5000.0s
   setRateTable( testInputs.sourceRates,
                 { { 0.000, 0.0 },
+                  { 0.000, 0.0 },
                   { 0.267, 0.0 },
                   { 0.561, 0.0 },
                   { 0.194, 0.0 },
@@ -821,10 +821,10 @@ TestSet getTestSet()
                   { 0.000, 0.0 },
                   { 0.000, 0.0 },
                   { 0.000, 0.0 },
-                  { 0.000, 0.0 },
                   { 0.000, 0.0 } } );
   setRateTable( testInputs.sinkRates,
                 { { 0.0, 0.000 },
+                  { 0.0, 0.000 },
                   { 0.0, 0.003 },
                   { 0.0, 0.062 },
                   { 0.0, 0.121 },
@@ -833,7 +833,6 @@ TestSet getTestSet()
                   { 0.0, 0.199 },
                   { 0.0, 0.083 },
                   { 0.0, 0.027 },
-                  { 0.0, 0.000 },
                   { 0.0, 0.000 } } );
 
   testInputs.sourceRateFactor = -44e-3;
@@ -985,12 +984,7 @@ TestSet getTestSet()
          xMax="{ 10.01, 10.01,  0.01 }" />
   </Geometry>
 
-  <!-- We are adding 500s to the whole sim time to force the wholeSimStatsEvent to be executed -->
-  <Events maxTime="5500.0">
-    <PeriodicEvent name="solverApplications"
-                   forceDt="500.0"
-                   target="/Solvers/testSolver" />
-
+  <Events maxTime="5000.0">
     <PeriodicEvent name="timestepFluxStatsEvent"
                    timeFrequency="500.0"
                    target="/Tasks/timeStepFluxStats" />
@@ -998,13 +992,17 @@ TestSet getTestSet()
                    timeFrequency="500.0"
                    target="/Tasks/timeStepReservoirStats" />
 
+    <PeriodicEvent name="wholeSimStatsEvent"
+                   timeFrequency="5000.0"
+                   target="/Tasks/wholeSimFluxStats" />
+
     <PeriodicEvent name="timestepsCheckEvent"
                    timeFrequency="500.0"
                    target="/Tasks/timeStepChecker" />
 
-    <PeriodicEvent name="wholeSimStatsEvent"
-                   timeFrequency="5000.0"
-                   target="/Tasks/wholeSimFluxStats" />
+    <PeriodicEvent name="solverApplications"
+                   forceDt="500.0"
+                   target="/Solvers/testSolver" />
   </Events>
 
   <Tasks>
@@ -1030,16 +1028,16 @@ TestSet getTestSet()
       name="FluxInjectionRate"
       inputVarNames="{ time }"
       interpolation="lower"
-      coordinates="{    0.0,  500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0, 5500.0 }"
-      values="{       0.000,  0.000,  0.267,  0.561,  0.194,  0.102,  0.059,  0.000,  0.000,  0.000,  0.000,  0.000 }"
+      coordinates="{    0.0,  500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0 }"
+      values="{       0.000,  0.267,  0.561,  0.194,  0.102,  0.059,  0.000,  0.000,  0.000,  0.000,  0.000 }"
     />
     <!-- water depletion rates in mol/s -->
     <TableFunction
       name="FluxProductionRate"
       inputVarNames="{ time }"
       interpolation="lower"
-      coordinates="{    0.0,  500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0, 5500.0 }"
-      values="{       0.000,  0.000,  0.003,  0.062,  0.121,  0.427,  0.502,  0.199,  0.083,  0.027,  0.000,  0.000 }"
+      coordinates="{    0.0,  500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0 }"
+      values="{       0.000,  0.003,  0.062,  0.121,  0.427,  0.502,  0.199,  0.083,  0.027,  0.000,  0.000 }"
     />
 
     <TableFunction name="initGasCompFracTable"

--- a/src/coreComponents/physicsSolvers/fluidFlow/unitTests/testFlowStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/unitTests/testFlowStatistics.cpp
@@ -137,7 +137,7 @@ struct TestSet
         sinkMeanRate[ip] += inputs.sinkRates[timestepId][ip] * inputs.sinkRateFactor;
       }
       // mean rates calculation
-      real64 const ratesMeanDivisor = 1.0 / double( timestepCount - 1 );
+      real64 const ratesMeanDivisor = 1.0 / double( timestepCount );
       sourceMeanRate[ip] *= ratesMeanDivisor;
       sinkMeanRate[ip] *= ratesMeanDivisor;
       // totals
@@ -469,8 +469,7 @@ TestSet getTestSet()
          xMax="{ 10.01, 10.01, 0.01 }" />
   </Geometry>
 
-  <!-- We are adding 500s to the whole sim time to force the wholeSimStatsEvent to be executed -->
-  <Events maxTime="5500.0">
+  <Events maxTime="5000.0">
     <PeriodicEvent name="solverApplications"
                    forceDt="500.0"
                    target="/Solvers/testSolver" />
@@ -514,8 +513,8 @@ TestSet getTestSet()
       name="FluxRate"
       inputVarNames="{ time }"
       interpolation="lower"
-      coordinates="{    0.0,  500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0, 5500.0 }"
-      values="{       0.000,  0.000,  0.767,  0.894,  0.561,  0.234,  0.194,  0.178,  0.162,  0.059,  0.000,  0.000 }"
+      coordinates="{    0.0,  500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0 }"
+      values="{       0.000,  0.767,  0.894,  0.561,  0.234,  0.194,  0.178,  0.162,  0.059,  0.000,  0.000 }"
     />
   </Functions>
 
@@ -537,7 +536,6 @@ TestSet getTestSet()
   // FluxRate table from 0.0s to 5000.0s
   setRateTable( testInputs.sourceRates,
                 { { 0.000 },
-                  { 0.000 },
                   { 0.767 },
                   { 0.894 },
                   { 0.561 },
@@ -546,6 +544,7 @@ TestSet getTestSet()
                   { 0.178 },
                   { 0.162 },
                   { 0.059 },
+                  { 0.000 },
                   { 0.000 } } );
   testInputs.sinkRates=testInputs.sourceRates;
 
@@ -715,7 +714,7 @@ TestSet getTestSet()
   </Geometry>
 
   <!-- We are adding 500s to the whole sim time to force the wholeSimStatsEvent to be executed -->
-  <Events maxTime="5500.0">
+  <Events maxTime="5000.0">
     <PeriodicEvent name="solverApplications"
                    forceDt="500.0"
                    target="/Solvers/testSolver" />
@@ -759,16 +758,16 @@ TestSet getTestSet()
       name="FluxInjectionRate"
       inputVarNames="{ time }"
       interpolation="lower"
-      coordinates="{    0.0,  500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0, 5500.0 }"
-      values="{       0.000,  0.000,  0.267,  0.561,  0.194,  0.102,  0.059,  0.000,  0.000,  0.000,  0.000,  0.000 }"
+      coordinates="{    0.0,  500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0 }"
+      values="{       0.000,  0.267,  0.561,  0.194,  0.102,  0.059,  0.000,  0.000,  0.000,  0.000,  0.000 }"
     />
     <!-- water depletion rates in mol/s -->
     <TableFunction
       name="FluxProductionRate"
       inputVarNames="{ time }"
       interpolation="lower"
-      coordinates="{    0.0,  500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0, 5500.0 }"
-      values="{       0.000,  0.000,  0.003,  0.062,  0.121,  0.427,  0.502,  0.199,  0.083,  0.027,  0.000,  0.000 }"
+      coordinates="{    0.0,  500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0 }"
+      values="{       0.000,  0.003,  0.062,  0.121,  0.427,  0.502,  0.199,  0.083,  0.027,  0.000,  0.000 }"
     />
 
     <TableFunction name="initGasCompFracTable"
@@ -814,7 +813,6 @@ TestSet getTestSet()
   // FluxInjectionRate & FluxProductionRate table from 0.0s to 5000.0s
   setRateTable( testInputs.sourceRates,
                 { { 0.000, 0.0 },
-                  { 0.000, 0.0 },
                   { 0.267, 0.0 },
                   { 0.561, 0.0 },
                   { 0.194, 0.0 },
@@ -823,10 +821,10 @@ TestSet getTestSet()
                   { 0.000, 0.0 },
                   { 0.000, 0.0 },
                   { 0.000, 0.0 },
+                  { 0.000, 0.0 },
                   { 0.000, 0.0 } } );
   setRateTable( testInputs.sinkRates,
                 { { 0.0, 0.000 },
-                  { 0.0, 0.000 },
                   { 0.0, 0.003 },
                   { 0.0, 0.062 },
                   { 0.0, 0.121 },
@@ -835,6 +833,7 @@ TestSet getTestSet()
                   { 0.0, 0.199 },
                   { 0.0, 0.083 },
                   { 0.0, 0.027 },
+                  { 0.0, 0.000 },
                   { 0.0, 0.000 } } );
 
   testInputs.sourceRateFactor = -44e-3;

--- a/src/coreComponents/physicsSolvers/fluidFlow/unitTests/testFlowStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/unitTests/testFlowStatistics.cpp
@@ -313,6 +313,10 @@ void checkTimeStepFluxStats( ProblemManager & problem, TestSet const & testSet,
   SourceFluxStatsAggregator & timestepStats =
     problem.getGroupByPath< SourceFluxStatsAggregator >( testSet.inputs.timeStepFluxStatsPath );
 
+  // Stats run before the solver, so at t=0 elements counts are at 0
+  integer const sourceElementsCount = ( timestepId == 0 ) ? 0 : testSet.inputs.sourceElementsCount;
+  integer const sinkElementsCount   = ( timestepId == 0 ) ? 0 : testSet.inputs.sinkElementsCount;
+
   timestepStats.forMeshLevelStatsWrapper( domain,
                                           [&] ( MeshLevel & meshLevel,
                                                 SourceFluxStatsAggregator::WrappedStats & )
@@ -325,14 +329,14 @@ void checkTimeStepFluxStats( ProblemManager & problem, TestSet const & testSet,
       {
         checkFluxStats( testSet.sourceMassProd[timestepId],
                         testSet.sourceRates[timestepId],
-                        testSet.inputs.sourceElementsCount,
+                        sourceElementsCount,
                         fluxStats, GEOS_FMT( "for timestep at t = {} s", time_n ) );
       }
       else if( fluxStats.getFluxName() == testSet.inputs.sinkFluxName )
       {
         checkFluxStats( testSet.sinkMassProd[timestepId],
                         testSet.sinkRates[timestepId],
-                        testSet.inputs.sinkElementsCount,
+                        sinkElementsCount,
                         fluxStats, GEOS_FMT( "for timestep at t = {} s", time_n ) );
       }
       else
@@ -347,8 +351,12 @@ void checkTimeStepStats( TestSet const & testSet,
                          real64 const time_n,
                          integer const timestepId )
 {
-  EXPECT_LT( timestepId, testSet.timestepCount ) << GEOS_FMT( "The tested time-step count were higher than expected (t = {} s).",
-                                                              time_n );
+  EXPECT_LT( timestepId, testSet.timestepCount )
+    << GEOS_FMT( "The tested time-step count were higher than expected (t = {} s).", time_n );
+
+  EXPECT_DOUBLE_EQ( time_n, timestepId * testSet.inputs.dt )
+    << GEOS_FMT( "Unexpected time for timestep {}: expected {}, got {}",
+                 timestepId, timestepId * testSet.inputs.dt, time_n );
 }
 
 void checkWholeSimTimeStepStats( ProblemManager & problem,

--- a/src/coreComponents/physicsSolvers/fluidFlow/unitTests/testFlowStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/unitTests/testFlowStatistics.cpp
@@ -51,6 +51,9 @@ struct TestInputs
   array2d< real64 > sourceRates;
   array2d< real64 > sinkRates;
 
+  // Time coordinates matching the rates tables
+  array1d< real64 > timeCoordinates;
+
   // parameters for precomputing results
   real64 dt;
   real64 sourceRateFactor;
@@ -97,8 +100,9 @@ struct TestSet
     inputs( inputParams )
   {
     // tables must provide the same timestep & phase rates
-    EXPECT_EQ( inputs.sourceRates.size( 0 ), inputs.sinkRates.size( 0 ));
-    EXPECT_EQ( inputs.sourceRates.size( 1 ), inputs.sinkRates.size( 1 ));
+    EXPECT_EQ( inputs.sourceRates.size( 0 ), inputs.sinkRates.size( 0 ) );
+    EXPECT_EQ( inputs.sourceRates.size( 1 ), inputs.sinkRates.size( 1 ) );
+    EXPECT_EQ( inputs.timeCoordinates.size( 0 ), inputs.sourceRates.size( 0 ) );
 
     timestepCount = inputs.sourceRates.size( 0 );
     phaseCount = inputs.sourceRates.size( 1 );
@@ -203,6 +207,16 @@ void setRateTable( array2d< real64 > & rateTable, std::initializer_list< std::in
       rateTable[timestepId][ip++] = phaseValue;
     }
     ++timestepId;
+  }
+}
+
+void setTimeCoordinates( array1d< real64 > & timeCoordinates, std::initializer_list< real64 > values )
+{
+  timeCoordinates.resize( values.size() );
+  integer i = 0;
+  for( auto const & value : values )
+  {
+    timeCoordinates[ i++ ] = value;
   }
 }
 
@@ -354,9 +368,9 @@ void checkTimeStepStats( TestSet const & testSet,
   EXPECT_LT( timestepId, testSet.timestepCount )
     << GEOS_FMT( "The tested time-step count were higher than expected (t = {} s).", time_n );
 
-  EXPECT_DOUBLE_EQ( time_n, timestepId * testSet.inputs.dt )
+  EXPECT_DOUBLE_EQ( time_n, testSet.inputs.timeCoordinates[ timestepId ] )
     << GEOS_FMT( "Unexpected time for timestep {}: expected {}, got {}",
-                 timestepId, timestepId * testSet.inputs.dt, time_n );
+                 timestepId, testSet.inputs.timeCoordinates[ timestepId ], time_n );
 }
 
 void checkWholeSimTimeStepStats( ProblemManager & problem,
@@ -540,6 +554,9 @@ TestSet getTestSet()
   testInputs.dt = 500.0;
   testInputs.sourceElementsCount = 2;
   testInputs.sinkElementsCount = 1;
+
+  setTimeCoordinates( testInputs.timeCoordinates,
+                      { 0.0, 500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0 } );
 
   // FluxRate table from 0.0s to 5000.0s
   setRateTable( testInputs.sourceRates,
@@ -817,6 +834,9 @@ TestSet getTestSet()
   testInputs.sourceElementsCount = 1;
   testInputs.sinkElementsCount = 1;
 
+  setTimeCoordinates( testInputs.timeCoordinates,
+                      { 0.0, 500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0 } );
+
   // FluxInjectionRate & FluxProductionRate table from 0.0s to 5000.0s
   setRateTable( testInputs.sourceRates,
                 { { 0.000, 0.0 },
@@ -1087,6 +1107,9 @@ TestSet getTestSet()
   testInputs.dt = 500.0;
   testInputs.sourceElementsCount = 1;
   testInputs.sinkElementsCount = 1;
+
+  setTimeCoordinates( testInputs.timeCoordinates,
+                      { 0.0, 500.0, 1000.0, 1500.0, 2000.0, 2500.0, 3000.0, 3500.0, 4000.0, 4500.0, 5000.0 } );
 
   // FluxInjectionRate & FluxProductionRate table from 0.0s to 5000.0s
   setRateTable( testInputs.sourceRates,

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsStatistics.cpp
@@ -81,17 +81,19 @@ bool SolidMechanicsStatistics::execute( real64 const time_n,
                                         real64 const dt,
                                         integer const GEOS_UNUSED_PARAM( cycleNumber ),
                                         integer const GEOS_UNUSED_PARAM( eventCounter ),
-                                        real64 const GEOS_UNUSED_PARAM( eventProgress ),
+                                        real64 const eventProgress,
                                         DomainPartition & domain )
 {
+  real64 const time = time_n + dt * eventProgress;
   m_solver->forDiscretizationOnMeshTargets( domain.getMeshBodies(), [&] ( string const &,
                                                                           MeshLevel & mesh,
                                                                           string_array const & )
   {
-    computeNodeStatistics( mesh, time_n );
+    computeNodeStatistics( mesh, time );
   } );
   return false;
 }
+
 void SolidMechanicsStatistics::cleanup( real64 const time_n,
                                         integer const cycleNumber,
                                         integer const eventCounter,

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsStatistics.cpp
@@ -93,6 +93,14 @@ bool SolidMechanicsStatistics::execute( real64 const time_n,
   } );
   return false;
 }
+void SolidMechanicsStatistics::cleanup( real64 const time_n,
+                                        integer const cycleNumber,
+                                        integer const eventCounter,
+                                        real64 const eventProgress,
+                                        DomainPartition & domain )
+{
+  execute( time_n, 0.0, cycleNumber, eventCounter, eventProgress, domain );
+}
 
 void SolidMechanicsStatistics::computeNodeStatistics( MeshLevel & mesh, real64 const time ) const
 {

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsStatistics.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsStatistics.cpp
@@ -88,8 +88,7 @@ bool SolidMechanicsStatistics::execute( real64 const time_n,
                                                                           MeshLevel & mesh,
                                                                           string_array const & )
   {
-    // current time is time_n + dt
-    computeNodeStatistics( mesh, time_n + dt );
+    computeNodeStatistics( mesh, time_n );
   } );
   return false;
 }

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsStatistics.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsStatistics.hpp
@@ -61,6 +61,15 @@ public:
                         real64 const eventProgress,
                         DomainPartition & domain ) override;
 
+  /**
+   * @copydoc ExecutableGroup::cleanup()
+   */
+  virtual void cleanup( real64 const time_n,
+                        integer const cycleNumber,
+                        integer const eventCounter,
+                        real64 const eventProgress,
+                        DomainPartition & domain ) override;
+
   /**@}*/
 
   /**


### PR DESCRIPTION
This PR fixes some time misalignements in the statistics.

**Statistics time label misaligned by one timestep, starting at _t1_ instead of _t0_.**
Here is an example (`resvol_constraint.xml`) starting at _t0_ = 2500s while values correspond to the values in the XML input file (5000000 Pa pressure)
```csv
Time [s],Min pressure [Pa],Average pressure [Pa],Max pressure [Pa], ...
    2500,          5000000,              5000000,          5000000
    5000,          4571243,              4960905,          5264805
    7500,          4470766,              4951167,          5345129
   10000,          4428837,              4945246,          5381950
...
```
Now:
```csv
Time [s],Min pressure [Pa],Average pressure [Pa],Max pressure [Pa], ...
       0,          5000000,              5000000,          5000000
    2500,          4571243,              4960905,          5264805
    5000,          4470766,              4951167,          5345129
    7500,          4428837,              4945246,          5381950
   10000,          4398290,              4940123,          5408567
...
```
<details>
Stats events previously used `time + dt` to label time and now uses `time + dt * eventProgress` to output the correct time at which statistics are launched/computed. 
`eventProgress`  (always?) equals `0` in those cases, so stats basically run at `time = time`, but I added it if one day stats could launch/be computed at mid-event, I can remove it if it's not correct.
</details>

**Statistics were missing the last timestep**
Now statistics implements the `ExecutableGroup::cleanup()` to trigger a last execution, similar to other components such as `VTKOutput`, etc.
<details>

Statistics were missing a last timestep, and some people had to modify the `maxTime` to `maxTime + 1 dt` to inspect the last timestep statistics.

This was the case in the `testFlowStatistics.cpp` file, which defined `maxTime = 5500` instead of  `maxTime = 5000` (with 500s timesteps) to be able to output the last statistic.
</details>