### PR TITLE
Fixing macOS build

### DIFF
--- a/src/coreComponents/constitutive/solid/Damage.cpp
+++ b/src/coreComponents/constitutive/solid/Damage.cpp
@@ -168,6 +168,8 @@ void Damage< BASE >::saveConvergedState() const
   } );
 }
 
+template class Damage< ElasticIsotropic >;
+
 typedef Damage< ElasticIsotropic > DamageElasticIsotropic;
 
 REGISTER_CATALOG_ENTRY( ConstitutiveBase, DamageElasticIsotropic, string const &, Group * const )

--- a/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/PhysicsSolverBase.cpp
@@ -1651,16 +1651,17 @@ Timestamp PhysicsSolverBase::getMeshModificationTimestamp( DomainPartition & dom
 
 R1Tensor const PhysicsSolverBase::gravityVector() const
 {
-  R1Tensor rval;
-  if( dynamicCast< PhysicsSolverManager const * >( &getParent() ) != nullptr )
+  // Avoid dynamic_cast< PhysicsSolverManager const * > here: it would force the
+  // base library (physicsSolversBase) to link against PhysicsSolverManager's
+  // typeinfo, which lives in the dependent physicsSolvers library — circular
+  // on macOS dylibs. Probe by wrapper presence; the gravityVector wrapper is
+  // only ever registered by PhysicsSolverManager.
+  auto const key = PhysicsSolverManager::viewKeyStruct::gravityVectorString();
+  if( getParent().hasWrapper( key ) )
   {
-    rval = getParent().getReference< R1Tensor >( PhysicsSolverManager::viewKeyStruct::gravityVectorString() );
+    return getParent().getReference< R1Tensor >( key );
   }
-  else
-  {
-    rval = {0.0, 0.0, -9.81};
-  }
-  return rval;
+  return { 0.0, 0.0, -9.81 };
 }
 
 bool PhysicsSolverBase::checkSequentialSolutionIncrements( DomainPartition & GEOS_UNUSED_PARAM( domain ) ) const

--- a/src/coreComponents/physicsSolvers/fluidFlow/CMakeLists.txt
+++ b/src/coreComponents/physicsSolvers/fluidFlow/CMakeLists.txt
@@ -213,8 +213,10 @@ generateKernels( TEMPLATE "CompositionalMultiphaseFVMKernel_thermal.cpp.template
 list(APPEND fluidFlowSolvers_headers ${headerFiles})
 list(APPEND fluidFlowSolvers_sources ${sourceFiles})
 
+set( dependencyList ${parallelDeps} physicsSolversBase )
 
-
+geos_decorate_link_dependencies( LIST decoratedDependencies
+                                 DEPENDENCIES ${dependencyList} )
 
 
 blt_add_library( NAME       fluidFlowSolvers

--- a/src/coreComponents/physicsSolvers/multiphysics/CMakeLists.txt
+++ b/src/coreComponents/physicsSolvers/multiphysics/CMakeLists.txt
@@ -87,7 +87,7 @@ set( multiPhysicsSolvers_sources
 
 #include(poromechanicsKernels/PoromechanicsKernels.cmake)
 
-set( dependencyList ${parallelDeps} fluidFlowSolvers simplePDESolvers solidMechanicsSolvers )
+set( dependencyList ${parallelDeps} fluidFlowSolvers simplePDESolvers solidMechanicsSolvers surfaceGeneration )
 
 geos_decorate_link_dependencies( LIST decoratedDependencies DEPENDENCIES ${dependencyList} )
 


### PR DESCRIPTION
- replace `dynamic_cast` with `hasWrapper` in `PhysicsSolverBase::gravityVector` to break   
  `libphysicsSolversBase` -- `libphysicsSolvers` typeinfo cycle (tolerated in Linux not in macOS)
- declare `physicsSolversBase` as `fluidFlow` dependency (was silently inherited)
- add `surfaceGeneration` to `multiphysics` dependency list (used by                    
  `HydrofractureSolver`)
- explicit template instantiation for `Damage<ElasticIsotropic>`

Updated PVTPackage submodule: GEOS-DEV/PVTPackage/pull/54