### PR TITLE
Avoid method hiding warning

### DIFF
--- a/src/coreComponents/constitutiveDrivers/fluid/multiFluid/PVTDriver.hpp
+++ b/src/coreComponents/constitutiveDrivers/fluid/multiFluid/PVTDriver.hpp
@@ -47,6 +47,8 @@ public:
 
   void postInputInitialization() override;
 
+  using ConstitutiveDriver::execute;
+
   bool execute() override;
 
   void getColumnNames( string_array & columnNames ) const override;


### PR DESCRIPTION
On GPU builds I was getting many warnings of the form

```
src/coreComponents/constitutiveDrivers/fluid/multiFluid/PVTDriver.hpp(50): warning #997-D: function "geos::ExecutableGroup::execute(geos::real64, geos::real64, geos::integer, geos::integer, geos::real64, geos::DomainPartition &)" is hidden by "geos::PVTDriver::execute" -- virtual function override intended?
    bool execute() override;
         ^
```

This change makes it more explicit to avoid this warning.