### PR TITLE
fix: MPI runs for smoke tests with surfaceGenerator

### DIFF
--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr4068-16802-8281e61
+  baseline: integratedTests/baseline_integratedTests-pr4068-16828-c74157c
 
 allow_fail:
   all: ''

--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr4062-16784-6d8782e
+  baseline: integratedTests/baseline_integratedTests-pr4068-16802-8281e61
 
 allow_fail:
   all: ''

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -5,7 +5,7 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
-PR #4068 (2026-05-28) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr4068-16802-8281e61.tar.gz>
+PR #4068 (2026-05-28) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr4068-16828-c74157c.tar.gz>
 =====================
 Add MPI runs for smoke tests with surfaceGenerator
 

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -5,28 +5,40 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
+PR #4068 (2026-05-28) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr4068-16802-8281e61.tar.gz>
+=====================
+Add MPI runs for smoke tests with surfaceGenerator
+
 PR #4062 (2026-05-26) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr4062-16784-6d8782e.tar.gz>
+=====================
 Add Porous Solid other than PorousElasticity for ALM solver
 
 PR #4057 (2026-05-21) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr4057-16739-5dde641.tar.gz>
+=====================
 Remove dependency on PVT package
 
 PR #3814 (2026-05-20) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3814-16717-d17ea59.tar.gz>
+=====================
 Fix RLF coloring
 
 PR #4008 (2026-05-18) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr4008-16688-17c55fe.tar.gz>
+=====================
 Fix Fracture/3D cell co-location in parallel mesh redistribution
 
 PR #4055 (2026-05-18) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr4055-16683-0251bb6.tar.gz>
+=====================
 Trim some fluid model tests
 
 PR #4041 (2026-05-16) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr4041-16664-9a29348.tar.gz>
+=====================
 Fix wellbore nonlinear thermal diffusion
 
 PR #3977 (2026-05-15) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3977-16644-9fc03e7.tar.gz>
+=====================
 Change face normal, centers and area for local Newell's formula
 
 PR #3999 (2026-05-14) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3999-16602-542583d.tar.gz>
+=====================
 Fault Perm Update for Contact solvers
 
 PR #4029 (2026-05-06) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr4029-16507-7e3d8b5.tar.gz>

--- a/inputFiles/poromechanicsFractures/Contact/AugmentedLagrangianMultipliers/ALM_inclinedFault_ISG_DruckerPrager_smoke.xml
+++ b/inputFiles/poromechanicsFractures/Contact/AugmentedLagrangianMultipliers/ALM_inclinedFault_ISG_DruckerPrager_smoke.xml
@@ -159,7 +159,12 @@
         krylovTol="1.0e-8"
         logLevel="1"/>
     </SinglePhaseFVM>
-    <SurfaceGenerator name="SurfaceGen" targetRegions="{ Domain, Fault}" fractureRegion="Fault" initialRockToughness="1.0"/>
+    <SurfaceGenerator 
+        name="SurfaceGen" 
+        targetRegions="{ Domain, Fault}" 
+        fractureRegion="Fault" 
+        initialRockToughness="1.0"
+        mpiCommOrder="1"/>
   </Solvers>
 <!-- SPHINX_SINGLEPHASEFVM_END -->
 

--- a/inputFiles/poromechanicsFractures/Contact/AugmentedLagrangianMultipliers/ALM_inclinedFault_ISG_smoke.xml
+++ b/inputFiles/poromechanicsFractures/Contact/AugmentedLagrangianMultipliers/ALM_inclinedFault_ISG_smoke.xml
@@ -155,7 +155,12 @@
         krylovTol="1.0e-8"
         logLevel="1"/>
     </SinglePhaseFVM>
-    <SurfaceGenerator name="SurfaceGen" targetRegions="{ Domain, Fault}" fractureRegion="Fault" initialRockToughness="1.0"/>
+    <SurfaceGenerator 
+        name="SurfaceGen" 
+        targetRegions="{ Domain, Fault}" 
+        fractureRegion="Fault" 
+        initialRockToughness="1.0"
+        mpiCommOrder="1"/>
   </Solvers>
 <!-- SPHINX_SINGLEPHASEFVM_END -->
 

--- a/inputFiles/poromechanicsFractures/Contact/AugmentedLagrangianMultipliers/AugmentedLagrangianMultipliers.ats
+++ b/inputFiles/poromechanicsFractures/Contact/AugmentedLagrangianMultipliers/AugmentedLagrangianMultipliers.ats
@@ -36,7 +36,7 @@ decks = [
     TestDeck(
         name="ALM_inclinedFault_ISG_smoke",
         description='PoroElastic ALM inclined fault with internal surface generator (elastic)',
-        partitions=((1, 1, 1),),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=0,
         check_step=1,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
@@ -50,7 +50,7 @@ decks = [
     TestDeck(
         name="ALM_inclinedFault_ISG_DruckerPrager_smoke",
         description='PoroElastic ALM inclined fault with internal surface generator (DruckerPrager plastic)',
-        partitions=((1, 1, 1),),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=0,
         check_step=1,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -993,7 +993,7 @@ bool SurfaceGenerator::processNode( const localIndex nodeID,
     std::set< localIndex > facialRupturePath;
     map< localIndex, int > edgeLocations;
     map< localIndex, int > faceLocations;
-    map< std::pair< CellElementSubRegion const *, localIndex >, int > elemLocations;
+    ElemLocMapType elemLocations;
 
     fracturePlaneFlag = findFracturePlanes( nodeID,
                                             nodeManager,
@@ -1045,7 +1045,7 @@ bool SurfaceGenerator::findFracturePlanes( localIndex const nodeID,
                                            std::set< localIndex > & separationPathFaces,
                                            map< localIndex, int > & edgeLocations,
                                            map< localIndex, int > & faceLocations,
-                                           map< std::pair< CellElementSubRegion const *, localIndex >, int > & elemLocations )
+                                           ElemLocMapType & elemLocations )
 {
   GEOS_MARK_FUNCTION;
 
@@ -1585,7 +1585,7 @@ bool SurfaceGenerator::assignLocationsBFS( std::set< localIndex > const & separa
                                            map< localIndex, std::pair< localIndex, localIndex > > const & localFacesToEdges,
                                            map< localIndex, int > & edgeLocations,
                                            map< localIndex, int > & faceLocations,
-                                           map< std::pair< CellElementSubRegion const *, localIndex >, int > & elemLocations )
+                                           ElemLocMapType & elemLocations )
 {
   GEOS_MARK_FUNCTION;
 
@@ -1835,7 +1835,7 @@ void SurfaceGenerator::performFracture( const localIndex nodeID,
                                         const std::set< localIndex > & separationPathFaces,
                                         const map< localIndex, int > & edgeLocations,
                                         const map< localIndex, int > & faceLocations,
-                                        const map< std::pair< CellElementSubRegion const *, localIndex >, int > & elemLocations )
+                                        const ElemLocMapType & elemLocations )
 {
   GEOS_MARK_FUNCTION;
 
@@ -2151,7 +2151,7 @@ void SurfaceGenerator::performFracture( const localIndex nodeID,
   array1d< localIndex > const & childFaceIndex = faceManager.getField< fields::childIndex >();
 
   // 1) loop over all elements attached to the nodeID
-  for( map< std::pair< CellElementSubRegion const *, localIndex >, int >::const_iterator iter_elem = elemLocations.begin(); iter_elem != elemLocations.end(); ++iter_elem )
+  for( ElemLocMapType::const_iterator iter_elem = elemLocations.begin(); iter_elem != elemLocations.end(); ++iter_elem )
   {
     const int & location = iter_elem->second;
 
@@ -2515,7 +2515,7 @@ void SurfaceGenerator::mapConsistencyCheck( localIndex const GEOS_UNUSED_PARAM( 
                                             EdgeManager const & edgeManager,
                                             FaceManager const & faceManager,
                                             ElementRegionManager const & elementManager,
-                                            map< std::pair< CellElementSubRegion const *, localIndex >, int > const & elemLocations )
+                                            ElemLocMapType const & elemLocations )
 {
   GEOS_MARK_FUNCTION;
 
@@ -2544,7 +2544,7 @@ void SurfaceGenerator::mapConsistencyCheck( localIndex const GEOS_UNUSED_PARAM( 
   {
     std::cout << "CONSISTENCY CHECKING OF THE MAPS" << std::endl;
 
-    for( map< std::pair< CellElementSubRegion const *, localIndex >, int >::const_iterator iter_elem = elemLocations.cbegin(); iter_elem != elemLocations.cend(); ++iter_elem )
+    for( ElemLocMapType::const_iterator iter_elem = elemLocations.cbegin(); iter_elem != elemLocations.cend(); ++iter_elem )
     {
       const std::pair< CellElementSubRegion const *, localIndex > & elem = iter_elem->first;
 

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.cpp
@@ -1492,7 +1492,7 @@ bool SurfaceGenerator::findFracturePlanes( localIndex const nodeID,
 
   for( auto k = nodeToElementMaps.cbegin(); k != nodeToElementMaps.cend(); ++k )
   {
-    elemLocations[*k] = INT_MIN;
+    elemLocations.get_inserted( *k ) = INT_MIN;
   }
 
 

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.hpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.hpp
@@ -392,7 +392,7 @@ private:
                            std::set< localIndex > & separationPathFaces,
                            map< localIndex, int > & edgeLocations,
                            map< localIndex, int > & faceLocations,
-                           map< std::pair< CellElementSubRegion const *, localIndex >, int > & elemLocations );
+                           ElemLocMapType & elemLocations );
 
 
   /**
@@ -422,14 +422,14 @@ private:
                         std::set< localIndex > const & separationPathFaces,
                         map< localIndex, int > const & edgeLocations,
                         map< localIndex, int > const & faceLocations,
-                        map< std::pair< CellElementSubRegion const *, localIndex >, int > const & elemLocations );
+                        ElemLocMapType const & elemLocations );
 
   void mapConsistencyCheck( localIndex const nodeID,
                             NodeManager const & nodeManager,
                             EdgeManager const & edgeManager,
                             FaceManager const & faceManager,
                             ElementRegionManager const & elementManager,
-                            map< std::pair< CellElementSubRegion const *, localIndex >, int > const & elemLocations );
+                            ElemLocMapType const & elemLocations );
 
   /**
    * @brief Assign fracture-plane sides to all elements, faces, and edges
@@ -469,7 +469,7 @@ private:
                            map< localIndex, std::pair< localIndex, localIndex > > const & localFacesToEdges,
                            map< localIndex, int > & edgeLocations,
                            map< localIndex, int > & faceLocations,
-                           map< std::pair< CellElementSubRegion const *, localIndex >, int > & elemLocations );
+                           ElemLocMapType & elemLocations );
 
   /**
    *

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.hpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.hpp
@@ -37,7 +37,7 @@ class ElementRegionBase;
 
 /**
  * @brief Comparator for (CellElementSubRegion const *, localIndex) pairs that
- * provides deterministic ordering based on region/subregion indices
+ * provides deterministic ordering based on localIndex/region/subregion indices in that precedence
  */
 struct ElemLocComparator
 {

--- a/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.hpp
+++ b/src/coreComponents/physicsSolvers/surfaceGeneration/SurfaceGenerator.hpp
@@ -22,6 +22,7 @@
 #include "mesh/mpiCommunications/NeighborCommunicator.hpp"
 #include "physicsSolvers/PhysicsSolverBase.hpp"
 #include "mesh/DomainPartition.hpp"
+#include "mesh/CellElementSubRegion.hpp"
 #include "ParallelTopologyChange.hpp"
 
 namespace geos
@@ -33,6 +34,30 @@ class EdgeManager;
 class FaceManager;
 class ElementRegionManager;
 class ElementRegionBase;
+
+/**
+ * @brief Comparator for (CellElementSubRegion const *, localIndex) pairs that
+ * provides deterministic ordering based on region/subregion indices
+ */
+struct ElemLocComparator
+{
+  bool operator()( std::pair< CellElementSubRegion const *, localIndex > const & a,
+                   std::pair< CellElementSubRegion const *, localIndex > const & b ) const
+  {
+    if( a.first != b.first )
+    {
+      localIndex const regionA = a.first->getParent().getParent().getIndexInParent();
+      localIndex const regionB = b.first->getParent().getParent().getIndexInParent();
+      if( regionA != regionB )
+        return regionA < regionB;
+      return a.first->getIndexInParent() < b.first->getIndexInParent();
+    }
+    return a.second < b.second;
+  }
+};
+
+/// Type alias for the element location map with deterministic ordering.
+using ElemLocMapType = stdMap< std::pair< CellElementSubRegion const *, localIndex >, int, ElemLocComparator >;
 
 /**
  * @class SurfaceGenerator


### PR DESCRIPTION
Another attempt to fix CI failures for MPI runs of two newly added smoke tests using `surfaceGenerator`, see [PR#4062](https://github.com/GEOS-DEV/GEOS/pull/4062) 

The original code is functionally correct but generates results ordering which is not strictly deterministic across runs.
- Enable `mpiCommOrder="1"`in the XML inputs
- Replace pointer-based ordering of `elemLocations` with a comparator using deterministic region/subregion indices