### PR TITLE
Fix GCC15 maybe-uninitialized in multifluid derivative conversion

### DIFF
--- a/src/coreComponents/constitutive/fluid/multifluid/MultiFluidBase.hpp
+++ b/src/coreComponents/constitutive/fluid/multifluid/MultiFluidBase.hpp
@@ -777,7 +777,6 @@ MultiFluidBase::KernelWrapper::
     // component weight can not be zero, checked in MultiFluidBase::postInputInitialization
     real64 const mwInv = 1.0 / m_componentMolarWeight[ic];
     compMoleFrac[ic] = composition[ic] * mwInv; // this is molality (units of mole/mass)
-    dCompMoleFrac_dCompMassFrac[ic][ic] = mwInv;
     totalMolality += compMoleFrac[ic];
   }
 
@@ -788,8 +787,9 @@ MultiFluidBase::KernelWrapper::
 
     for( integer jc = 0; jc < numComps; ++jc )
     {
-      dCompMoleFrac_dCompMassFrac[ic][jc] -= compMoleFrac[ic] / m_componentMolarWeight[jc];
-      dCompMoleFrac_dCompMassFrac[ic][jc] *= totalMolalityInv;
+      real64 const delta = ic == jc ? 1.0 : 0.0;
+      dCompMoleFrac_dCompMassFrac[ic][jc] =
+        ( delta - compMoleFrac[ic] ) * totalMolalityInv / m_componentMolarWeight[jc];
     }
   }
 }


### PR DESCRIPTION
This PR fixes a GCC 15 `-Werror=maybe-uninitialized` error in the multifluid mole-fraction derivative path.

In `MultiFluidBase.hpp`, the previous code updated `dCompMoleFrac_dCompMassFrac` with a read-modify-write pattern after only diagonal pre-initialization, which can leave an uninitialized read for off-diagonal terms.

The fix replaces that pattern with direct closed-form assignment for every `(ic, jc)` entry:
`(delta - compMoleFrac[ic]) * totalMolalityInv / m_componentMolarWeight[jc]`.