### PR TITLE
feature: detect MPI desynchronizations

### DIFF
--- a/src/cmake/GeosxConfig.cmake
+++ b/src/cmake/GeosxConfig.cmake
@@ -14,6 +14,7 @@ set( PREPROCESSOR_DEFINES BOUNDS_CHECK
                           METIS
                           MKL
                           MPI
+                          MPI_DESYNC_DETECTION
                           PARMETIS
                           PETSC
                           PYGEOSX

--- a/src/cmake/GeosxOptions.cmake
+++ b/src/cmake/GeosxOptions.cmake
@@ -92,6 +92,8 @@ endif()
 
 option( ENABLE_MPI "" ON )
 
+option( ENABLE_MPI_DESYNC_DETECTION "" OFF )
+
 option( ENABLE_CUDA "" OFF )
 
 option( ENABLE_HIP "" OFF )

--- a/src/coreComponents/common/GeosxConfig.hpp.in
+++ b/src/coreComponents/common/GeosxConfig.hpp.in
@@ -44,6 +44,9 @@
 /// Enables use of MPI (CMake option ENABLE_MPI)
 #cmakedefine GEOS_USE_MPI
 
+/// Enables use of MPI (CMake option ENABLE_MPI_DESYNC_DETECTION)
+#cmakedefine GEOS_USE_MPI_DESYNC_DETECTION
+
 /// Enables use of OpenMP (CMake option ENABLE_OPENMP)
 #cmakedefine GEOS_USE_OPENMP
 

--- a/src/coreComponents/common/MemoryInfos.cpp
+++ b/src/coreComponents/common/MemoryInfos.cpp
@@ -140,9 +140,7 @@ void MemoryLogging::memoryStatsReport() const
     return;
 
   umpire::ResourceManager & rm = umpire::ResourceManager::getInstance();
-  integer size;
-  MPI_Comm_size( MPI_COMM_WORLD, &size );
-  size_t nbRank = (std::size_t)size;
+  std::size_t const nbRank = static_cast< std::size_t >( MpiWrapper::commSize( MPI_COMM_WORLD ) );
   // Get a list of all the allocators and sort it so that it's in the same order on each rank.
   stdVector< string > allocatorNames = rm.getAllocatorNames();
   std::sort( allocatorNames.begin(), allocatorNames.end() );

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -41,10 +41,10 @@ int MPI_COMM_GEOS = 0;
 void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  MPI_Barrier( comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
+  MPI_Barrier( comm );
 #endif
 }
 

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -111,28 +111,12 @@ void MpiDesyncGuard::succeeded()
 
 void MpiDesyncGuard::detectMpiDesync()
 {
-  MPI_Request request;
-  MPI_Ibarrier( m_comm, &request );
+  int minId = m_collectiveOperationTag; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MIN, m_comm );
+  int maxId = m_collectiveOperationTag; MPI_Allreduce( MPI_IN_PLACE, &maxId, 1, MPI_INT, MPI_MAX, m_comm );
 
-  int flag = 0;
-  double start = MpiWrapper::wtime();
-  while( true )
-  {
-    MpiWrapper::test( &request, &flag, MPI_STATUS_IGNORE );
-    if( flag )
-    {
-      succeeded();
-      return;
-    }
+  if( minId != maxId ) { failed(); }
 
-    if( MpiWrapper::wtime() - start > 10 )
-    {
-      failed();
-      return;
-    }
-
-    std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
-  }
+  succeeded();
 }
 #endif
 
@@ -142,7 +126,7 @@ void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   MPI_Barrier( comm );
 #endif

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -74,10 +74,10 @@ string MpiDesyncGuard::symbolizeStackTrace( stdArray< void *, maxFrames > const 
   // adapted from LvArray::system::getFunctionNameFromFrame()
   std::ostringstream oss;
 #if defined(__GLIBC__) || defined(__APPLE__)
-  for( int i = 0; i < m_frameCount; ++i )
+  for( int i = 0; i < frameCount; ++i )
   {
     Dl_info dli;
-    bool const dlOk = dladdr( m_frames[ i ], &dli );
+    bool const dlOk = dladdr( frames[ i ], &dli );
 
     oss << "Frame " << i << ": "
         << ( dlOk ?
@@ -93,12 +93,12 @@ string MpiDesyncGuard::symbolizeStackTrace( stdArray< void *, maxFrames > const 
 
 void MpiDesyncGuard::failed()
 {
-  GEOS_LOG_RANK_0( GEOS_FMT( "MPI desync detected: rank timed out\n"
-                             "{}\n"
-                             "Last successful stacktrace:\n"
-                             "{}",
-                             symbolizeStackTrace( m_frames, m_frameCount ),
-                             symbolizeStackTrace( g_lastSuccessfulFrames, g_lastSuccessfulFrameCount ) ) );
+  GEOS_LOG_RANK( GEOS_FMT( "MPI desync detected: rank timed out\n"
+                           "{}\n"
+                           "Last successful stacktrace:\n"
+                           "{}",
+                           symbolizeStackTrace( m_frames, m_frameCount ),
+                           symbolizeStackTrace( g_lastSuccessfulFrames, g_lastSuccessfulFrameCount ) ) );
   MPI_Abort( m_comm, 1 );
 }
 

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -19,7 +19,10 @@
 
 #include "MpiWrapper.hpp"
 #include "LvArray/src/system.hpp"
+#include "common/logger/Logger.hpp"
 #include <unistd.h>
+#include <chrono>
+#include <thread>
 
 #if defined(__clang__)
   #pragma clang diagnostic push
@@ -50,65 +53,45 @@ void MpiWrapper::saveStackTrace()
 
 void MpiWrapper::MpiDesyncGuard::failed()
 {
-  std::cerr << g_lastSuccessfulStacktrace << '\n' << g_currentStacktrace;
+  GEOS_LOG_RANK_0( GEOS_FMT( "MPI desync detected: rank {) timed out\n"
+                             "{}\n"
+                             "Last successful stacktrace:\n"
+                             "{}",
+                             g_currentStacktrace, g_lastSuccessfulStacktrace ) );
   MPI_Abort( m_comm, 1 );
 }
 
 void MpiWrapper::MpiDesyncGuard::succeeded()
 {
-  // the MPI_Barrier did not hang
-  this->m_collectiveOperationSuccess = true;
+  m_collectiveOperationSuccess.store( true, std::memory_order_release );
   g_lastSuccessfulStacktrace = g_currentStacktrace;
 }
 
-void MpiWrapper::MpiDesyncGuard::timeout()
-{
-  std::this_thread::sleep_for( std::chrono::seconds( 10 ) );
-  if( !this->m_collectiveOperationSuccess ) 
-  {
-    failed();
-  }
-}
-
-// void MpiWrapper::MpiDesyncGuard::detectMpiDesync()
-// {
-//   // start a timeout for the following MPI_Barrier 
-//   std::thread timeout( &MpiWrapper::MpiDesyncGuard::timeout, this );
-//   MPI_Barrier( this->m_comm );
-//   succeeded();
-// }
-
 void MpiWrapper::MpiDesyncGuard::detectMpiDesync()
 {
-  // start a timeout for the following MPI_Barrier 
-  std::thread timeout( [this]{
-    std::this_thread::sleep_for( std::chrono::seconds( 10 ) );
-    if( !this->m_collectiveOperationSuccess ) 
+  MPI_Request request;
+  MPI_Ibarrier( m_comm, &request );
+
+  int flag = 0;
+  double start = MpiWrapper::wtime();
+  while( true )
+  {
+    MpiWrapper::test( &request, &flag, MPI_STATUS_IGNORE );
+    if( flag )
+    {
+      succeeded();
+      return;
+    }
+
+    if( MpiWrapper::wtime() - start > 10 )
     {
       failed();
+      return;
     }
-  } );
-  MPI_Barrier( this->m_comm );
-  succeeded();
-}
 
-// void MpiWrapper::MpiDesyncGuard::detectMpiDesync()
-// {
-//   // start a timeout for the following MPI_Barrier 
-//   std::thread timeout( [this]{
-//     std::this_thread::sleep_for( std::chrono::seconds( 10 ) );
-//     if( !this->m_collectiveOperationSuccess ) 
-//     {
-//       // (Timeout reached, desync detected)
-//       std::cerr << g_lastSuccessfulStacktrace << '\n' << g_currentStacktrace;
-//       MPI_Abort( m_comm, 1 );
-//     }
-//   } );
-//   MPI_Barrier( this->m_comm );
-//   // Successful operation for this rank
-//   this->m_collectiveOperationSuccess = true;
-//   g_lastSuccessfulStacktrace = g_currentStacktrace;
-// }
+    std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+  }
+}
 #endif
 
 void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -41,12 +41,9 @@ int MPI_COMM_GEOS = 0;
 void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
+  MPI_Barrier( comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  int id = ++g_currentMpiOperationTag;
-  MPI_Barrier( comm );
-  detectMpiDesync( comm, id );
-#else
-  MPI_Barrier( comm );
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
 #endif
 #endif
 }

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -42,16 +42,19 @@ MPI_Comm MPI_COMM_GEOS;
 int MPI_COMM_GEOS = 0;
 #endif
 
+namespace internal
+{
+
 #if defined( GEOS_USE_MPI ) && defined( GEOS_USE_MPI_DESYNC_DETECTION )
 std::string g_currentStacktrace;
 std::string g_lastSuccessfulStacktrace;
 
-void MpiWrapper::saveStackTrace()
+void saveStackTrace()
 {
   g_currentStacktrace = LvArray::system::stackTrace( true );
 }
 
-void MpiWrapper::MpiDesyncGuard::failed()
+void MpiDesyncGuard::failed()
 {
   GEOS_LOG_RANK_0( GEOS_FMT( "MPI desync detected: rank {) timed out\n"
                              "{}\n"
@@ -61,13 +64,13 @@ void MpiWrapper::MpiDesyncGuard::failed()
   MPI_Abort( m_comm, 1 );
 }
 
-void MpiWrapper::MpiDesyncGuard::succeeded()
+void MpiDesyncGuard::succeeded()
 {
   m_collectiveOperationSuccess.store( true, std::memory_order_release );
   g_lastSuccessfulStacktrace = g_currentStacktrace;
 }
 
-void MpiWrapper::MpiDesyncGuard::detectMpiDesync()
+void MpiDesyncGuard::detectMpiDesync()
 {
   MPI_Request request;
   MPI_Ibarrier( m_comm, &request );
@@ -94,11 +97,13 @@ void MpiWrapper::MpiDesyncGuard::detectMpiDesync()
 }
 #endif
 
+} // namespace internal
+
 void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   MPI_Barrier( comm );
 #endif

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -39,8 +39,7 @@ MPI_Comm MPI_COMM_GEOS;
 int MPI_COMM_GEOS = 0;
 #endif
 
-#ifdef GEOS_USE_MPI
-#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+#if defined( GEOS_USE_MPI ) && defined( GEOS_USE_MPI_DESYNC_DETECTION )
 std::string g_currentStacktrace;
 std::string g_lastSuccessfulStacktrace;
 
@@ -49,16 +48,67 @@ void MpiWrapper::saveStackTrace()
   g_currentStacktrace = LvArray::system::stackTrace( true );
 }
 
-void MpiWrapper::detectMpiDesync( MPI_Comm const & MPI_PARAM( comm ), int operationId )
+void MpiWrapper::MpiDesyncGuard::failed()
 {
-  int minId = operationId; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MIN, comm );
-  int maxId = operationId; MPI_Allreduce( MPI_IN_PLACE, &maxId, 1, MPI_INT, MPI_MAX, comm );
-  if( minId != maxId ) 
-  {
-    MPI_Abort( comm, 1 );
-  }
+  std::cerr << g_lastSuccessfulStacktrace << '\n' << g_currentStacktrace;
+  MPI_Abort( m_comm, 1 );
+}
+
+void MpiWrapper::MpiDesyncGuard::succeeded()
+{
+  // the MPI_Barrier did not hang
+  this->m_collectiveOperationSuccess = true;
   g_lastSuccessfulStacktrace = g_currentStacktrace;
 }
+
+void MpiWrapper::MpiDesyncGuard::timeout()
+{
+  std::this_thread::sleep_for( std::chrono::seconds( 10 ) );
+  if( !this->m_collectiveOperationSuccess ) 
+  {
+    failed();
+  }
+}
+
+// void MpiWrapper::MpiDesyncGuard::detectMpiDesync()
+// {
+//   // start a timeout for the following MPI_Barrier 
+//   std::thread timeout( &MpiWrapper::MpiDesyncGuard::timeout, this );
+//   MPI_Barrier( this->m_comm );
+//   succeeded();
+// }
+
+void MpiWrapper::MpiDesyncGuard::detectMpiDesync()
+{
+  // start a timeout for the following MPI_Barrier 
+  std::thread timeout( [this]{
+    std::this_thread::sleep_for( std::chrono::seconds( 10 ) );
+    if( !this->m_collectiveOperationSuccess ) 
+    {
+      failed();
+    }
+  } );
+  MPI_Barrier( this->m_comm );
+  succeeded();
+}
+
+// void MpiWrapper::MpiDesyncGuard::detectMpiDesync()
+// {
+//   // start a timeout for the following MPI_Barrier 
+//   std::thread timeout( [this]{
+//     std::this_thread::sleep_for( std::chrono::seconds( 10 ) );
+//     if( !this->m_collectiveOperationSuccess ) 
+//     {
+//       // (Timeout reached, desync detected)
+//       std::cerr << g_lastSuccessfulStacktrace << '\n' << g_currentStacktrace;
+//       MPI_Abort( m_comm, 1 );
+//     }
+//   } );
+//   MPI_Barrier( this->m_comm );
+//   // Successful operation for this rank
+//   this->m_collectiveOperationSuccess = true;
+//   g_lastSuccessfulStacktrace = g_currentStacktrace;
+// }
 #endif
 
 void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -38,31 +38,13 @@ MPI_Comm MPI_COMM_GEOS;
 int MPI_COMM_GEOS = 0;
 #endif
 
-void detectMPIDesync( MPI_Comm const & MPI_PARAM( comm ), int id )
-{
-#ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  int min_id = MpiWrapper::min( id );
-  int max_id = MpiWrapper::max( id );
-
-  std::cout << "(detectMPIDesync) my_id = " << id << '\n';
-  std::cout << "min_id = " << min_id << '\n';
-  std::cout << "max_id = " << max_id << std::endl;
-
-  if( min_id != max_id )
-  {
-    std::cerr << "MPI desync detected" << std::endl;
-    MPI_Abort( comm, 1 );
-  }
-#endif
-}
-
 void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
   int id = ++g_currentMpiOperationTag;
   MPI_Barrier( comm );
-  detectMPIDesync( comm, id );
+  detectMpiDesync( comm, id );
 #else
   MPI_Barrier( comm );
 #endif

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -38,10 +38,34 @@ MPI_Comm MPI_COMM_GEOS;
 int MPI_COMM_GEOS = 0;
 #endif
 
+void detectMPIDesync( MPI_Comm const & MPI_PARAM( comm ), int id )
+{
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  int min_id = MpiWrapper::min( id );
+  int max_id = MpiWrapper::max( id );
+
+  std::cout << "(detectMPIDesync) my_id = " << id << '\n';
+  std::cout << "min_id = " << min_id << '\n';
+  std::cout << "max_id = " << max_id << std::endl;
+
+  if( min_id != max_id )
+  {
+    std::cerr << "MPI desync detected" << std::endl;
+    MPI_Abort( comm, 1 );
+  }
+#endif
+}
+
 void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  int id = ++g_currentMpiOperationTag;
   MPI_Barrier( comm );
+  detectMPIDesync( comm, id );
+#else
+  MPI_Barrier( comm );
+#endif
 #endif
 }
 

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -49,35 +49,32 @@ MPI_Comm MPI_COMM_GEOS;
 int MPI_COMM_GEOS = 0;
 #endif
 
-namespace internal
+namespace desyncDetection
 {
 
 #if defined( GEOS_USE_MPI ) && defined( GEOS_USE_MPI_DESYNC_DETECTION )
-stdArray< void *, MpiDesyncGuard::maxFrames > g_lastSuccessfulFrames;
-int g_lastSuccessfulFrameCount = 0;
-
-void MpiDesyncGuard::saveStackFrames()
+void StackTrace::saveStackFrames()
 {
   // LvArray already implements an equivalent (see internal `collect()` in LvArray/src/system.cpp)
   // but it is not exposed to the public API. (TODO) Remove this in favor of LvArray's `collect()`
   // if it becomes public.
 #if defined(__GLIBC__) || defined(__APPLE__)
-  m_frameCount = backtrace( m_frames.data(), MpiDesyncGuard::maxFrames );
+  m_frameCount = backtrace( m_frames.data(), maxFrames );
 #else
   m_frameCount = 0;
 #endif
 }
 
-string MpiDesyncGuard::symbolizeStackTrace( stdArray< void *, maxFrames > const & frames,
-                                            int const frameCount ) const
+/// @brief Symbolize and demangle the captured stacktrace frames
+string symbolizeStackTrace( StackTrace const & trace )
 {
   // adapted from LvArray::system::getFunctionNameFromFrame()
   std::ostringstream oss;
 #if defined(__GLIBC__) || defined(__APPLE__)
-  for( int i = 0; i < frameCount; ++i )
+  for( int i = 0; i < trace.m_frameCount; ++i )
   {
     Dl_info dli;
-    bool const dlOk = dladdr( frames[ i ], &dli );
+    bool const dlOk = dladdr( trace.m_frames[ i ], &dli );
 
     oss << "Frame " << i << ": "
         << ( dlOk ?
@@ -91,25 +88,25 @@ string MpiDesyncGuard::symbolizeStackTrace( stdArray< void *, maxFrames > const 
   return oss.str();
 }
 
-void MpiDesyncGuard::failed()
+void failed( MPI_Comm const & comm )
 {
+  g_lastCollectiveOperationSuccess = false;
   GEOS_LOG_RANK( GEOS_FMT( "MPI desync detected: rank timed out\n"
                            "{}\n"
                            "Last successful stacktrace:\n"
                            "{}",
-                           symbolizeStackTrace( m_frames, m_frameCount ),
-                           symbolizeStackTrace( g_lastSuccessfulFrames, g_lastSuccessfulFrameCount ) ) );
-  MPI_Abort( m_comm, 1 );
+                           symbolizeStackTrace( g_lastStackTrace ),
+                           symbolizeStackTrace( g_lastSuccessfulStackTrace ) ) );
+  MPI_Abort( comm, 1 );
 }
 
-void MpiDesyncGuard::succeeded()
+void succeeded()
 {
-  m_collectiveOperationSuccess = true;
-  g_lastSuccessfulFrames = m_frames;
-  g_lastSuccessfulFrameCount = m_frameCount;
+  g_lastCollectiveOperationSuccess = true;
+  g_lastSuccessfulStackTrace = g_lastStackTrace;
 }
 
-void MpiDesyncGuard::detectMpiDesync()
+bool MpiDesyncGuard::detectMpiDesync()
 {
   MPI_Request request;
   MPI_Ibarrier( m_comm, &request );
@@ -119,16 +116,14 @@ void MpiDesyncGuard::detectMpiDesync()
   while( true )
   {
     MpiWrapper::test( &request, &flag, MPI_STATUS_IGNORE );
+
     if( flag )
     {
-      succeeded();
-      return;
+      return false;
     }
-
     if( MpiWrapper::wtime() - start > 10 )
     {
-      failed();
-      return;
+      return true;
     }
 
     std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
@@ -136,13 +131,13 @@ void MpiDesyncGuard::detectMpiDesync()
 }
 #endif
 
-} // namespace internal
+} // namespace desyncDetection
 
 void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   MPI_Barrier( comm );
 #endif

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "MpiWrapper.hpp"
+#include "LvArray/src/system.hpp"
 #include <unistd.h>
 
 #if defined(__clang__)
@@ -36,6 +37,28 @@ namespace geos
 MPI_Comm MPI_COMM_GEOS;
 #else
 int MPI_COMM_GEOS = 0;
+#endif
+
+#ifdef GEOS_USE_MPI
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+std::string g_currentStacktrace;
+std::string g_lastSuccessfulStacktrace;
+
+void MpiWrapper::saveStackTrace()
+{
+  g_currentStacktrace = LvArray::system::stackTrace( true );
+}
+
+void MpiWrapper::detectMpiDesync( MPI_Comm const & MPI_PARAM( comm ), int operationId )
+{
+  int minId = operationId; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MIN, comm );
+  int maxId = operationId; MPI_Allreduce( MPI_IN_PLACE, &maxId, 1, MPI_INT, MPI_MAX, comm );
+  if( minId != maxId ) 
+  {
+    MPI_Abort( comm, 1 );
+  }
+  g_lastSuccessfulStacktrace = g_currentStacktrace;
+}
 #endif
 
 void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -43,7 +43,7 @@ void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )
 #ifdef GEOS_USE_MPI
   MPI_Barrier( comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
 #endif
 }

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -111,12 +111,28 @@ void MpiDesyncGuard::succeeded()
 
 void MpiDesyncGuard::detectMpiDesync()
 {
-  int minId = m_collectiveOperationTag; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MIN, m_comm );
-  int maxId = m_collectiveOperationTag; MPI_Allreduce( MPI_IN_PLACE, &maxId, 1, MPI_INT, MPI_MAX, m_comm );
+  MPI_Request request;
+  MPI_Ibarrier( m_comm, &request );
 
-  if( minId != maxId ) { failed(); }
+  int flag = 0;
+  double start = MpiWrapper::wtime();
+  while( true )
+  {
+    MpiWrapper::test( &request, &flag, MPI_STATUS_IGNORE );
+    if( flag )
+    {
+      succeeded();
+      return;
+    }
 
-  succeeded();
+    if( MpiWrapper::wtime() - start > 10 )
+    {
+      failed();
+      return;
+    }
+
+    std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+  }
 }
 #endif
 
@@ -126,7 +142,7 @@ void MpiWrapper::barrier( MPI_Comm const & MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   MPI_Barrier( comm );
 #endif

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -24,6 +24,13 @@
 #include <chrono>
 #include <thread>
 
+#if defined( GEOS_USE_MPI ) && defined( GEOS_USE_MPI_DESYNC_DETECTION )
+#if defined(__GLIBC__) || defined(__APPLE__)
+#include <dlfcn.h>
+#include <execinfo.h>
+#endif
+#endif
+
 #if defined(__clang__)
   #pragma clang diagnostic push
   #pragma clang diagnostic ignored "-Wunused-parameter"
@@ -46,28 +53,60 @@ namespace internal
 {
 
 #if defined( GEOS_USE_MPI ) && defined( GEOS_USE_MPI_DESYNC_DETECTION )
-std::string g_currentStacktrace;
-std::string g_lastSuccessfulStacktrace;
+stdArray< void *, MpiDesyncGuard::maxFrames > g_lastSuccessfulFrames;
+int g_lastSuccessfulFrameCount = 0;
 
-void saveStackTrace()
+void MpiDesyncGuard::saveStackFrames()
 {
-  g_currentStacktrace = LvArray::system::stackTrace( true );
+  // LvArray already implements an equivalent (see internal `collect()` in LvArray/src/system.cpp)
+  // but it is not exposed to the public API. (TODO) Remove this in favor of LvArray's `collect()`
+  // if it becomes public.
+#if defined(__GLIBC__) || defined(__APPLE__)
+  m_frameCount = backtrace( m_frames.data(), MpiDesyncGuard::maxFrames );
+#else
+  m_frameCount = 0;
+#endif
+}
+
+string MpiDesyncGuard::symbolizeStackTrace( stdArray< void *, maxFrames > const & frames,
+                                            int const frameCount ) const
+{
+  // adapted from LvArray::system::getFunctionNameFromFrame()
+  std::ostringstream oss;
+#if defined(__GLIBC__) || defined(__APPLE__)
+  for( int i = 0; i < m_frameCount; ++i )
+  {
+    Dl_info dli;
+    bool const dlOk = dladdr( m_frames[ i ], &dli );
+
+    oss << "Frame " << i << ": "
+        << ( dlOk ?
+         ( dli.dli_sname ? LvArray::system::demangle( dli.dli_sname ) : dli.dli_fname ) :
+         "Unknown" )
+        << "\n";
+  }
+#else
+  GEOS_UNUSED_VAR( frames, frameCount );
+#endif
+  return oss.str();
 }
 
 void MpiDesyncGuard::failed()
 {
-  GEOS_LOG_RANK_0( GEOS_FMT( "MPI desync detected: rank {) timed out\n"
+  GEOS_LOG_RANK_0( GEOS_FMT( "MPI desync detected: rank timed out\n"
                              "{}\n"
                              "Last successful stacktrace:\n"
                              "{}",
-                             g_currentStacktrace, g_lastSuccessfulStacktrace ) );
+                             symbolizeStackTrace( m_frames, m_frameCount ),
+                             symbolizeStackTrace( g_lastSuccessfulFrames, g_lastSuccessfulFrameCount ) ) );
   MPI_Abort( m_comm, 1 );
 }
 
 void MpiDesyncGuard::succeeded()
 {
   m_collectiveOperationSuccess = true;
-  g_lastSuccessfulStacktrace = g_currentStacktrace;
+  g_lastSuccessfulFrames = m_frames;
+  g_lastSuccessfulFrameCount = m_frameCount;
 }
 
 void MpiDesyncGuard::detectMpiDesync()

--- a/src/coreComponents/common/MpiWrapper.cpp
+++ b/src/coreComponents/common/MpiWrapper.cpp
@@ -66,7 +66,7 @@ void MpiDesyncGuard::failed()
 
 void MpiDesyncGuard::succeeded()
 {
-  m_collectiveOperationSuccess.store( true, std::memory_order_release );
+  m_collectiveOperationSuccess = true;
   g_lastSuccessfulStacktrace = g_currentStacktrace;
 }
 

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -943,7 +943,25 @@ MPI_Op getMpiPairReductionOp()
   return mpiOp;
 }
 
+} // namespace internal
+
+namespace desyncDetection
+{
+
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
+struct StackTrace
+{
+  static constexpr int maxFrames = 30;
+  stdArray< void *, maxFrames > m_frames{};
+  int m_frameCount = 0;
+
+  void saveStackFrames();
+};
+
+static bool g_lastCollectiveOperationSuccess{};
+inline StackTrace g_lastSuccessfulStackTrace;
+inline StackTrace g_lastStackTrace;
+
 /**
  * @struct MpiDesyncGuard
  * @brief RAII helper to detect MPI desynchronizations from MPI collective operations.
@@ -951,41 +969,47 @@ MPI_Op getMpiPairReductionOp()
 struct MpiDesyncGuard
 {
   MPI_Comm const & m_comm;
-  bool m_collectiveOperationSuccess{ false };
-
-  static constexpr int maxFrames = 30;
-  stdArray< void *, maxFrames > m_frames{};
-  int m_frameCount = 0;
-
-  explicit MpiDesyncGuard( MPI_Comm const & comm )
-    : m_comm( comm )
-  { saveStackFrames(); }
-
-  ~MpiDesyncGuard()
-  { detectMpiDesync(); }
-
-  /// @brief Detects MPI desynchronizations from MPI collective operations.
-  void detectMpiDesync();
 
   /// @brief Method ran when a desynchronization is detected.
-  void failed();
-
+  std::function< void( MPI_Comm const & ) > m_detectionFn;
   /// @brief Method ran when no desynchronizations are detected.
-  void succeeded();
+  std::function< void() > m_noDetectionFn;
+
+  MpiDesyncGuard( MPI_Comm const & comm,
+                  std::function< void( MPI_Comm const & ) > const & detectionFn,
+                  std::function< void() > const & noDetectionFn )
+    : m_comm( comm )
+    , m_detectionFn( detectionFn )
+    , m_noDetectionFn( noDetectionFn )
+  { g_lastStackTrace.saveStackFrames(); }
+
+  ~MpiDesyncGuard()
+  { detectMpiDesync() ? m_detectionFn( m_comm ) : m_noDetectionFn(); }
 
   MpiDesyncGuard( MpiDesyncGuard const & ) = delete;
   MpiDesyncGuard & operator=( MpiDesyncGuard const & ) = delete;
 
-  /// @brief Save the stacktrace frames
-  void saveStackFrames();
-  /// @brief Symbolize and demangle the captured stacktrace frames
-  string symbolizeStackTrace( stdArray< void *, maxFrames > const & frames,
-                              int const frameCount ) const;
-
+  /// @brief Detects MPI desynchronizations from MPI collective operations.
+  /// @return True if a desynchronization as been detected.
+  bool detectMpiDesync();
 };
+
+/**
+ * Method ran when a desynchronization is detected
+ * @brief MPI_Abort the program, output the current stack trace and the stack trace
+ *        from the previous MPI collective that succeeded.
+ */
+void failed( MPI_Comm const & comm );
+
+/**
+ * Method ran when no desynchronization is detected
+ * @brief Stores the stack trace from the current MPI collective
+ */
+void succeeded();
 #endif
 
-} // namespace internal
+} // namespace desyncDetection
+
 
 inline MPI_Op MpiWrapper::getMpiOp( Reduction const op )
 {
@@ -1030,7 +1054,7 @@ int MpiWrapper::allgather( T_SEND const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   return MPI_Allgather( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
                         recvbuf, recvcount, internal::getMpiType< T_RECV >(),
@@ -1054,7 +1078,7 @@ int MpiWrapper::allgatherv( T_SEND const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   return MPI_Allgatherv( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
                          recvbuf, recvcounts, displacements, internal::getMpiType< T_RECV >(),
@@ -1074,7 +1098,7 @@ void MpiWrapper::allGather( T const myValue, array1d< T > & allValues, MPI_Comm 
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   int const mpiSize = commSize( comm );
   allValues.resize( mpiSize );
@@ -1097,7 +1121,7 @@ int MpiWrapper::allGather( arrayView1d< T const > const & sendValues,
   int const sendSize = LvArray::integerConversion< int >( sendValues.size() );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   int const mpiSize = commSize( comm );
   allValues.resize( mpiSize * sendSize );
@@ -1127,7 +1151,7 @@ int MpiWrapper::allGatherv( arrayView1d< T const > const & sendValues,
   int const sendSize = LvArray::integerConversion< int >( sendValues.size() );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   int const mpiSize = commSize( comm );
   array1d< int > counts;
@@ -1163,7 +1187,7 @@ int MpiWrapper::allReduce( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   MPI_Datatype const mpiType = internal::getMpiType< T >();
   return MPI_Allreduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, comm );
@@ -1186,7 +1210,7 @@ int MpiWrapper::reduce( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   MPI_Datatype const mpiType = internal::getMpiType< T >();
   return MPI_Reduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, root, comm );
@@ -1208,7 +1232,7 @@ int MpiWrapper::scan( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   return MPI_Scan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #else
@@ -1226,7 +1250,7 @@ int MpiWrapper::exscan( T const * const MPI_PARAM( sendbuf ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   return MPI_Exscan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #else
@@ -1243,7 +1267,7 @@ int MpiWrapper::bcast( T * const MPI_PARAM( buffer ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   return MPI_Bcast( buffer, count, internal::getMpiType< T >(), root, comm );
 #else
@@ -1257,7 +1281,7 @@ void MpiWrapper::broadcast( T & MPI_PARAM( value ), int MPI_PARAM( srcRank ), MP
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   MPI_Bcast( &value, 1, internal::getMpiType< T >(), srcRank, comm );
 #endif
@@ -1271,7 +1295,7 @@ void MpiWrapper::broadcast< string >( string & MPI_PARAM( value ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   int size = LvArray::integerConversion< int >( value.size() );
   broadcast( size, srcRank, comm );
@@ -1290,7 +1314,7 @@ int MpiWrapper::gather( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   return MPI_Gather( sendbuf, sendcount, internal::getMpiType< TS >(),
                      recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1317,7 +1341,7 @@ int MpiWrapper::gather( T const & value,
                           "Receive buffer is not large enough to contain the values to receive." );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   return MPI_Gather( &value, sizeof( T ), internal::getMpiType< uint8_t >(),
                      destValuesBuffer.data(), sizeof( T ), internal::getMpiType< uint8_t >(),
@@ -1339,7 +1363,7 @@ int MpiWrapper::gatherv( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   return MPI_Gatherv( sendbuf, sendcount, internal::getMpiType< TS >(),
                       recvbuf, recvcounts, displs, internal::getMpiType< TR >(),
@@ -1366,7 +1390,7 @@ int MpiWrapper::scatter( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   return MPI_Scatter( sendbuf, sendcount, internal::getMpiType< TS >(),
                       recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1393,7 +1417,7 @@ int MpiWrapper::scatterv( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   return MPI_Scatterv( sendbuf, sendcounts, displs, internal::getMpiType< TS >(),
                        recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1661,7 +1685,7 @@ MpiWrapper::allReduce( PairType< FIRST, SECOND > const & localPair, MPI_Comm com
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  desyncDetection::MpiDesyncGuard const mpiDesyncGuard( comm, desyncDetection::failed, desyncDetection::succeeded );
 #endif
   auto const type = internal::getMpiPairType< FIRST, SECOND >();
   auto const mpiOp = internal::getMpiPairReductionOp< FIRST, SECOND, OP >();

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -26,6 +26,10 @@
 
 #include <numeric>
 
+// TODO move in cpp
+#include <chrono>
+#include <thread>
+
 #if defined(GEOS_USE_MPI)
   #include <mpi.h>
 #define MPI_PARAM( x ) x
@@ -817,9 +821,6 @@ private:
   static int allReduce( T const * sendbuf, T * recvbuf, int count, MPI_Op op, MPI_Comm comm = MPI_COMM_GEOS );
 
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  /// Tag/counter of the latest MPI collective operation to detect MPI desynchronizations
-  inline static int g_collectiveOperationCounter = 0;
-
   /**
    * @struct MpiDesyncGuard
    * @brief RAII helper to detect MPI desynchronizations from MPI collective operations.
@@ -827,30 +828,37 @@ private:
   struct MpiDesyncGuard
   {
     MPI_Comm const & m_comm;
-    int const m_operationId;
+    bool m_collectiveOperationSuccess = false;
 
     explicit MpiDesyncGuard( MPI_Comm const & comm )
       : m_comm( comm )
-      , m_operationId( ++g_collectiveOperationCounter )
     {
-      saveStackTrace();
+      saveStackTrace(); // Here every rank saves a stacktrace TODO modify
     }
 
     ~MpiDesyncGuard()
     {
-      detectMpiDesync( m_comm, m_operationId );
+      detectMpiDesync();
     }
+
+    /**
+     * @brief Detects MPI desynchronizations from MPI collective operations.
+     */
+    void detectMpiDesync();
+
+    /**
+     * TODO
+     */
+    void timeout();
+
+    // TODO rename TODO is it useful?
+    void failed();
+    // TODO rename TODO is it useful?
+    void succeeded();
 
     MpiDesyncGuard( MpiDesyncGuard const & ) = delete;
     MpiDesyncGuard & operator=( MpiDesyncGuard const & ) = delete;
   };
-
-  /**
-   * @brief Detects MPI desynchronizations from MPI collective operations.
-   * @param[in] comm The MPI_Comm over which the gather operates.
-   * @param[in] operationId The current collective operation counter of this rank.
-   */
-  static void detectMpiDesync( MPI_Comm const & MPI_PARAM( comm ), int operationId );
 
   /**
    * @brief Save the stack trace for desync diagnostics for MPI collective calls.

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -968,7 +968,10 @@ struct MpiDesyncGuard
   explicit MpiDesyncGuard( MPI_Comm const & comm, int collectiveOperationTag )
     : m_comm( comm )
     , m_collectiveOperationTag( collectiveOperationTag )
-  { saveStackFrames(); }
+  { 
+    ++m_collectiveOperationTag;
+    saveStackFrames();
+  }
 
   ~MpiDesyncGuard()
   { detectMpiDesync(); }

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -26,9 +26,7 @@
 
 #include <numeric>
 
-// TODO move in cpp
-#include <chrono>
-#include <thread>
+#include <atomic>
 
 #if defined(GEOS_USE_MPI)
   #include <mpi.h>
@@ -828,7 +826,7 @@ private:
   struct MpiDesyncGuard
   {
     MPI_Comm const & m_comm;
-    bool m_collectiveOperationSuccess = false;
+    std::atomic<bool> m_collectiveOperationSuccess{ false };
 
     explicit MpiDesyncGuard( MPI_Comm const & comm )
       : m_comm( comm )
@@ -847,13 +845,14 @@ private:
     void detectMpiDesync();
 
     /**
-     * TODO
+     * @brief Method ran when a desynchronization is detected.
+     * TODO rename TODO is it useful?
      */
-    void timeout();
-
-    // TODO rename TODO is it useful?
     void failed();
-    // TODO rename TODO is it useful?
+    /**
+     * @brief Method ran when no desynchronizations are detected.
+     * TODO rename TODO is it useful?
+     */
     void succeeded();
 
     MpiDesyncGuard( MpiDesyncGuard const & ) = delete;

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -815,6 +815,12 @@ private:
    */
   template< typename T >
   static int allReduce( T const * sendbuf, T * recvbuf, int count, MPI_Op op, MPI_Comm comm = MPI_COMM_GEOS );
+
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  /// Tag/counter of the latest MPI collective operation to detect MPI desynchronizations
+  inline static int g_currentMpiOperationTag = 0;
+#endif
+
 };
 
 namespace internal

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -816,13 +816,6 @@ private:
   template< typename T >
   static int allReduce( T const * sendbuf, T * recvbuf, int count, MPI_Op op, MPI_Comm comm = MPI_COMM_GEOS );
 
-#ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  /**
-   * @brief Tag of the current MPI collective operation
-   * @note Used to detect MPI desynchronized calls on collective operations.
-   */
-  inline static int g_collectiveOperationTag = 0;
-#endif
 };
 
 namespace internal
@@ -958,20 +951,15 @@ MPI_Op getMpiPairReductionOp()
 struct MpiDesyncGuard
 {
   MPI_Comm const & m_comm;
-  int m_collectiveOperationTag;
   bool m_collectiveOperationSuccess{ false };
 
   static constexpr int maxFrames = 30;
   stdArray< void *, maxFrames > m_frames{};
   int m_frameCount = 0;
 
-  explicit MpiDesyncGuard( MPI_Comm const & comm, int collectiveOperationTag )
+  explicit MpiDesyncGuard( MPI_Comm const & comm )
     : m_comm( comm )
-    , m_collectiveOperationTag( collectiveOperationTag )
-  { 
-    ++m_collectiveOperationTag;
-    saveStackFrames();
-  }
+  { saveStackFrames(); }
 
   ~MpiDesyncGuard()
   { detectMpiDesync(); }
@@ -1042,7 +1030,7 @@ int MpiWrapper::allgather( T_SEND const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Allgather( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
                         recvbuf, recvcount, internal::getMpiType< T_RECV >(),
@@ -1066,7 +1054,7 @@ int MpiWrapper::allgatherv( T_SEND const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Allgatherv( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
                          recvbuf, recvcounts, displacements, internal::getMpiType< T_RECV >(),
@@ -1086,7 +1074,7 @@ void MpiWrapper::allGather( T const myValue, array1d< T > & allValues, MPI_Comm 
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   int const mpiSize = commSize( comm );
   allValues.resize( mpiSize );
@@ -1109,7 +1097,7 @@ int MpiWrapper::allGather( arrayView1d< T const > const & sendValues,
   int const sendSize = LvArray::integerConversion< int >( sendValues.size() );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   int const mpiSize = commSize( comm );
   allValues.resize( mpiSize * sendSize );
@@ -1139,7 +1127,7 @@ int MpiWrapper::allGatherv( arrayView1d< T const > const & sendValues,
   int const sendSize = LvArray::integerConversion< int >( sendValues.size() );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   int const mpiSize = commSize( comm );
   array1d< int > counts;
@@ -1175,7 +1163,7 @@ int MpiWrapper::allReduce( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   MPI_Datatype const mpiType = internal::getMpiType< T >();
   return MPI_Allreduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, comm );
@@ -1198,7 +1186,7 @@ int MpiWrapper::reduce( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   MPI_Datatype const mpiType = internal::getMpiType< T >();
   return MPI_Reduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, root, comm );
@@ -1220,7 +1208,7 @@ int MpiWrapper::scan( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Scan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #else
@@ -1238,7 +1226,7 @@ int MpiWrapper::exscan( T const * const MPI_PARAM( sendbuf ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Exscan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #else
@@ -1255,7 +1243,7 @@ int MpiWrapper::bcast( T * const MPI_PARAM( buffer ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Bcast( buffer, count, internal::getMpiType< T >(), root, comm );
 #else
@@ -1269,7 +1257,7 @@ void MpiWrapper::broadcast( T & MPI_PARAM( value ), int MPI_PARAM( srcRank ), MP
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   MPI_Bcast( &value, 1, internal::getMpiType< T >(), srcRank, comm );
 #endif
@@ -1283,7 +1271,7 @@ void MpiWrapper::broadcast< string >( string & MPI_PARAM( value ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   int size = LvArray::integerConversion< int >( value.size() );
   broadcast( size, srcRank, comm );
@@ -1302,7 +1290,7 @@ int MpiWrapper::gather( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Gather( sendbuf, sendcount, internal::getMpiType< TS >(),
                      recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1329,7 +1317,7 @@ int MpiWrapper::gather( T const & value,
                           "Receive buffer is not large enough to contain the values to receive." );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Gather( &value, sizeof( T ), internal::getMpiType< uint8_t >(),
                      destValuesBuffer.data(), sizeof( T ), internal::getMpiType< uint8_t >(),
@@ -1351,7 +1339,7 @@ int MpiWrapper::gatherv( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Gatherv( sendbuf, sendcount, internal::getMpiType< TS >(),
                       recvbuf, recvcounts, displs, internal::getMpiType< TR >(),
@@ -1378,7 +1366,7 @@ int MpiWrapper::scatter( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Scatter( sendbuf, sendcount, internal::getMpiType< TS >(),
                       recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1405,7 +1393,7 @@ int MpiWrapper::scatterv( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Scatterv( sendbuf, sendcounts, displs, internal::getMpiType< TS >(),
                        recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1673,7 +1661,7 @@ MpiWrapper::allReduce( PairType< FIRST, SECOND > const & localPair, MPI_Comm com
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   auto const type = internal::getMpiPairType< FIRST, SECOND >();
   auto const mpiOp = internal::getMpiPairReductionOp< FIRST, SECOND, OP >();

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -821,7 +821,30 @@ private:
   inline static int g_currentMpiOperationTag = 0;
 
   /**
-   * @brief Detects MPI desynchronization from MPI collective operations.
+   * @struct MpiDesyncGuard
+   * @brief RAII helper to detect MPI desynchronizations from MPI collective operations.
+   */
+  struct MpiDesyncGuard
+  {
+    MPI_Comm const & m_comm;
+    int const m_operationId;
+
+    explicit MpiDesyncGuard( MPI_Comm const & comm )
+      : m_comm( comm )
+      , m_operationId( ++g_collectiveOperationCounter )
+    {}
+
+    ~MpiDesyncGuard()
+    {
+      detectMpiDesync( m_comm, m_operationId );
+    }
+
+    MpiDesyncGuard( MpiDesyncGuard const & ) = delete;
+    MpiDesyncGuard & operator=( MpiDesyncGuard const & ) = delete;
+  };
+
+  /**
+   * @brief Detects MPI desynchronizations from MPI collective operations.
    * @param[in] comm The MPI_Comm over which the gather operates.
    * @param[in] operationId The current collective operation counter of this rank.
    */
@@ -1004,13 +1027,12 @@ int MpiWrapper::allgather( T_SEND const * const sendbuf,
                            MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  int ret = MPI_Allgather( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
-                           recvbuf, recvcount, internal::getMpiType< T_RECV >(),
-                           comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  return MPI_Allgather( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
+                        recvbuf, recvcount, internal::getMpiType< T_RECV >(),
+                        comm );
 #else
   static_assert( std::is_same< T_SEND, T_RECV >::value,
                  "MpiWrapper::allgather() for serial run requires send and receive buffers are of the same type" );
@@ -1029,13 +1051,12 @@ int MpiWrapper::allgatherv( T_SEND const * const sendbuf,
                             MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  int ret = MPI_Allgatherv( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
-                            recvbuf, recvcounts, displacements, internal::getMpiType< T_RECV >(),
-                            comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  return MPI_Allgatherv( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
+                         recvbuf, recvcounts, displacements, internal::getMpiType< T_RECV >(),
+                         comm );
 #else
   static_assert( std::is_same< T_SEND, T_RECV >::value,
                  "MpiWrapper::allgatherv() for serial run requires send and receive buffers are of the same type" );
@@ -1050,15 +1071,15 @@ template< typename T >
 void MpiWrapper::allGather( T const myValue, array1d< T > & allValues, MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  MpiDesyncGuard const mpiDesyncGuard( comm );
+#endif
   int const mpiSize = commSize( comm );
   allValues.resize( mpiSize );
 
   MPI_Datatype const MPI_TYPE = internal::getMpiType< T >();
 
   MPI_Allgather( &myValue, 1, MPI_TYPE, allValues.data(), 1, MPI_TYPE, comm );
-#ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
-#endif
 
 #else
   allValues.resize( 1 );
@@ -1073,19 +1094,18 @@ int MpiWrapper::allGather( arrayView1d< T const > const & sendValues,
 {
   int const sendSize = LvArray::integerConversion< int >( sendValues.size() );
 #ifdef GEOS_USE_MPI
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  MpiDesyncGuard const mpiDesyncGuard( comm );
+#endif
   int const mpiSize = commSize( comm );
   allValues.resize( mpiSize * sendSize );
-  int ret = MPI_Allgather( sendValues.data(),
-                           sendSize,
-                           internal::getMpiType< T >(),
-                           allValues.data(),
-                           sendSize,
-                           internal::getMpiType< T >(),
-                           comm );
-#ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
-#endif
-  return ret;
+  return MPI_Allgather( sendValues.data(),
+                        sendSize,
+                        internal::getMpiType< T >(),
+                        allValues.data(),
+                        sendSize,
+                        internal::getMpiType< T >(),
+                        comm );
 
 #else
   allValues.resize( sendSize );
@@ -1104,24 +1124,23 @@ int MpiWrapper::allGatherv( arrayView1d< T const > const & sendValues,
 {
   int const sendSize = LvArray::integerConversion< int >( sendValues.size() );
 #ifdef GEOS_USE_MPI
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  MpiDesyncGuard const mpiDesyncGuard( comm );
+#endif
   int const mpiSize = commSize( comm );
   array1d< int > counts;
   allGather( sendSize, counts, comm );
   array1d< int > displs( mpiSize + 1 );
   std::partial_sum( counts.begin(), counts.end(), displs.begin() + 1 );
   allValues.resize( displs.back() );
-  int ret = MPI_Allgatherv( sendValues.data(),
-                            sendSize,
-                            internal::getMpiType< T >(),
-                            allValues.data(),
-                            counts.data(),
-                            displs.data(),
-                            internal::getMpiType< T >(),
-                            comm );
-#ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
-#endif
-  return ret;
+  return MPI_Allgatherv( sendValues.data(),
+                         sendSize,
+                         internal::getMpiType< T >(),
+                         allValues.data(),
+                         counts.data(),
+                         displs.data(),
+                         internal::getMpiType< T >(),
+                         comm );
 
 #else
   allValues.resize( sendSize );
@@ -1141,12 +1160,11 @@ int MpiWrapper::allReduce( T const * const sendbuf,
                            MPI_Comm const MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  MPI_Datatype const mpiType = internal::getMpiType< T >();
-  int ret = MPI_Allreduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  MPI_Datatype const mpiType = internal::getMpiType< T >();
+  return MPI_Allreduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, comm );
 #else
   if( sendbuf != recvbuf )
   {
@@ -1165,12 +1183,11 @@ int MpiWrapper::reduce( T const * const sendbuf,
                         MPI_Comm const MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  MPI_Datatype const mpiType = internal::getMpiType< T >();
-  int ret = MPI_Reduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  MPI_Datatype const mpiType = internal::getMpiType< T >();
+  return MPI_Reduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, root, comm );
 #else
   if( sendbuf != recvbuf )
   {
@@ -1188,11 +1205,10 @@ int MpiWrapper::scan( T const * const sendbuf,
                       MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  int ret = MPI_Scan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  return MPI_Scan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #else
   memcpy( recvbuf, sendbuf, count*sizeof(T) );
   return 0;
@@ -1207,11 +1223,10 @@ int MpiWrapper::exscan( T const * const MPI_PARAM( sendbuf ),
                         MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  int ret = MPI_Exscan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  return MPI_Exscan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #else
   memset( recvbuf, 0, count*sizeof(T) );
   return 0;
@@ -1225,11 +1240,10 @@ int MpiWrapper::bcast( T * const MPI_PARAM( buffer ),
                        MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  int ret = MPI_Bcast( buffer, count, internal::getMpiType< T >(), root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  return MPI_Bcast( buffer, count, internal::getMpiType< T >(), root, comm );
 #else
   return 0;
 #endif
@@ -1240,10 +1254,10 @@ template< typename T >
 void MpiWrapper::broadcast( T & MPI_PARAM( value ), int MPI_PARAM( srcRank ), MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  MPI_Bcast( &value, 1, internal::getMpiType< T >(), srcRank, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
+  MPI_Bcast( &value, 1, internal::getMpiType< T >(), srcRank, comm );
 #endif
 }
 
@@ -1254,13 +1268,13 @@ void MpiWrapper::broadcast< string >( string & MPI_PARAM( value ),
                                       MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  MpiDesyncGuard const mpiDesyncGuard( comm );
+#endif
   int size = LvArray::integerConversion< int >( value.size() );
   broadcast( size, srcRank, comm );
   value.resize( size );
   MPI_Bcast( const_cast< char * >( value.data() ), size, internal::getMpiType< char >(), srcRank, comm );
-#ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
-#endif
 #endif
 }
 
@@ -1273,13 +1287,12 @@ int MpiWrapper::gather( TS const * const sendbuf,
                         MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  int ret = MPI_Gather( sendbuf, sendcount, internal::getMpiType< TS >(),
-                        recvbuf, recvcount, internal::getMpiType< TR >(),
-                        root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  return MPI_Gather( sendbuf, sendcount, internal::getMpiType< TS >(),
+                     recvbuf, recvcount, internal::getMpiType< TR >(),
+                     root, comm );
 #else
   static_assert( std::is_same< TS, TR >::value,
                  "MpiWrapper::gather() for serial run requires send and receive buffers are of the same type" );
@@ -1301,13 +1314,12 @@ int MpiWrapper::gather( T const & value,
     GEOS_ERROR_IF_LT_MSG( destValuesBuffer.size(), size_t( commSize() ),
                           "Receive buffer is not large enough to contain the values to receive." );
 #ifdef GEOS_USE_MPI
-  int ret = MPI_Gather( &value, sizeof( T ), internal::getMpiType< uint8_t >(),
-                        destValuesBuffer.data(), sizeof( T ), internal::getMpiType< uint8_t >(),
-                        root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  return MPI_Gather( &value, sizeof( T ), internal::getMpiType< uint8_t >(),
+                     destValuesBuffer.data(), sizeof( T ), internal::getMpiType< uint8_t >(),
+                     root, comm );
 #else
   memcpy( destValuesBuffer.data(), &value, sendBufferSize );
   return 0;
@@ -1324,13 +1336,12 @@ int MpiWrapper::gatherv( TS const * const sendbuf,
                          MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  int ret = MPI_Gatherv( sendbuf, sendcount, internal::getMpiType< TS >(),
-                         recvbuf, recvcounts, displs, internal::getMpiType< TR >(),
-                         root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  return MPI_Gatherv( sendbuf, sendcount, internal::getMpiType< TS >(),
+                      recvbuf, recvcounts, displs, internal::getMpiType< TR >(),
+                      root, comm );
 #else
   static_assert( std::is_same< TS, TR >::value,
                  "MpiWrapper::gather() for serial run requires send and receive buffers are of the same type" );
@@ -1352,13 +1363,12 @@ int MpiWrapper::scatter( TS const * const sendbuf,
                          MPI_Comm MPI_PARAM( comm ))
 {
 #ifdef GEOS_USE_MPI
-  int ret = MPI_Scatter( sendbuf, sendcount, internal::getMpiType< TS >(),
-                         recvbuf, recvcount, internal::getMpiType< TR >(),
-                         root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  return MPI_Scatter( sendbuf, sendcount, internal::getMpiType< TS >(),
+                      recvbuf, recvcount, internal::getMpiType< TR >(),
+                      root, comm );
 #else
   static_assert( std::is_same< TS, TR >::value,
                  "MpiWrapper::scatter() for serial run requires send and receive buffers are of the same type" );
@@ -1380,13 +1390,12 @@ int MpiWrapper::scatterv( TS const * const sendbuf,
                           MPI_Comm MPI_PARAM( comm ))
 {
 #ifdef GEOS_USE_MPI
-  int ret = MPI_Scatterv( sendbuf, sendcounts, displs, internal::getMpiType< TS >(),
-                          recvbuf, recvcount, internal::getMpiType< TR >(),
-                          root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
+  MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
-  return ret;
+  return MPI_Scatterv( sendbuf, sendcounts, displs, internal::getMpiType< TS >(),
+                       recvbuf, recvcount, internal::getMpiType< TR >(),
+                       root, comm );
 #else
   static_assert( std::is_same< TS, TR >::value,
                  "MpiWrapper::scatterv() for serial run requires send and receive buffers are of the same type" );
@@ -1649,13 +1658,13 @@ MpiWrapper::PairType< FIRST, SECOND >
 MpiWrapper::allReduce( PairType< FIRST, SECOND > const & localPair, MPI_Comm comm )
 {
 #ifdef GEOS_USE_MPI
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  MpiDesyncGuard const mpiDesyncGuard( comm );
+#endif
   auto const type = internal::getMpiPairType< FIRST, SECOND >();
   auto const mpiOp = internal::getMpiPairReductionOp< FIRST, SECOND, OP >();
   PairType< FIRST, SECOND > pair{ localPair.first, localPair.second };
   MPI_Allreduce( MPI_IN_PLACE, &pair, 1, type, mpiOp, comm );
-#ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_collectiveOperationCounter );
-#endif
   return pair;
 #else
   return localPair;

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -815,6 +815,14 @@ private:
    */
   template< typename T >
   static int allReduce( T const * sendbuf, T * recvbuf, int count, MPI_Op op, MPI_Comm comm = MPI_COMM_GEOS );
+
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  /**
+   * @brief Tag of the current MPI collective operation
+   * @note Used to detect MPI desynchronized calls on collective operations.
+   */
+  inline static int g_collectiveOperationTag = 0;
+#endif
 };
 
 namespace internal
@@ -950,14 +958,16 @@ MPI_Op getMpiPairReductionOp()
 struct MpiDesyncGuard
 {
   MPI_Comm const & m_comm;
+  int m_collectiveOperationTag;
   bool m_collectiveOperationSuccess{ false };
 
   static constexpr int maxFrames = 30;
   stdArray< void *, maxFrames > m_frames{};
   int m_frameCount = 0;
 
-  explicit MpiDesyncGuard( MPI_Comm const & comm )
+  explicit MpiDesyncGuard( MPI_Comm const & comm, int collectiveOperationTag )
     : m_comm( comm )
+    , m_collectiveOperationTag( collectiveOperationTag )
   { saveStackFrames(); }
 
   ~MpiDesyncGuard()
@@ -1029,7 +1039,7 @@ int MpiWrapper::allgather( T_SEND const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   return MPI_Allgather( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
                         recvbuf, recvcount, internal::getMpiType< T_RECV >(),
@@ -1053,7 +1063,7 @@ int MpiWrapper::allgatherv( T_SEND const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   return MPI_Allgatherv( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
                          recvbuf, recvcounts, displacements, internal::getMpiType< T_RECV >(),
@@ -1073,7 +1083,7 @@ void MpiWrapper::allGather( T const myValue, array1d< T > & allValues, MPI_Comm 
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   int const mpiSize = commSize( comm );
   allValues.resize( mpiSize );
@@ -1096,7 +1106,7 @@ int MpiWrapper::allGather( arrayView1d< T const > const & sendValues,
   int const sendSize = LvArray::integerConversion< int >( sendValues.size() );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   int const mpiSize = commSize( comm );
   allValues.resize( mpiSize * sendSize );
@@ -1126,7 +1136,7 @@ int MpiWrapper::allGatherv( arrayView1d< T const > const & sendValues,
   int const sendSize = LvArray::integerConversion< int >( sendValues.size() );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   int const mpiSize = commSize( comm );
   array1d< int > counts;
@@ -1162,7 +1172,7 @@ int MpiWrapper::allReduce( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   MPI_Datatype const mpiType = internal::getMpiType< T >();
   return MPI_Allreduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, comm );
@@ -1185,7 +1195,7 @@ int MpiWrapper::reduce( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   MPI_Datatype const mpiType = internal::getMpiType< T >();
   return MPI_Reduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, root, comm );
@@ -1207,7 +1217,7 @@ int MpiWrapper::scan( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   return MPI_Scan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #else
@@ -1225,7 +1235,7 @@ int MpiWrapper::exscan( T const * const MPI_PARAM( sendbuf ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   return MPI_Exscan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #else
@@ -1242,7 +1252,7 @@ int MpiWrapper::bcast( T * const MPI_PARAM( buffer ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   return MPI_Bcast( buffer, count, internal::getMpiType< T >(), root, comm );
 #else
@@ -1256,7 +1266,7 @@ void MpiWrapper::broadcast( T & MPI_PARAM( value ), int MPI_PARAM( srcRank ), MP
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   MPI_Bcast( &value, 1, internal::getMpiType< T >(), srcRank, comm );
 #endif
@@ -1270,7 +1280,7 @@ void MpiWrapper::broadcast< string >( string & MPI_PARAM( value ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   int size = LvArray::integerConversion< int >( value.size() );
   broadcast( size, srcRank, comm );
@@ -1289,7 +1299,7 @@ int MpiWrapper::gather( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   return MPI_Gather( sendbuf, sendcount, internal::getMpiType< TS >(),
                      recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1316,7 +1326,7 @@ int MpiWrapper::gather( T const & value,
                           "Receive buffer is not large enough to contain the values to receive." );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   return MPI_Gather( &value, sizeof( T ), internal::getMpiType< uint8_t >(),
                      destValuesBuffer.data(), sizeof( T ), internal::getMpiType< uint8_t >(),
@@ -1338,7 +1348,7 @@ int MpiWrapper::gatherv( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   return MPI_Gatherv( sendbuf, sendcount, internal::getMpiType< TS >(),
                       recvbuf, recvcounts, displs, internal::getMpiType< TR >(),
@@ -1365,7 +1375,7 @@ int MpiWrapper::scatter( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   return MPI_Scatter( sendbuf, sendcount, internal::getMpiType< TS >(),
                       recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1392,7 +1402,7 @@ int MpiWrapper::scatterv( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   return MPI_Scatterv( sendbuf, sendcounts, displs, internal::getMpiType< TS >(),
                        recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1660,7 +1670,7 @@ MpiWrapper::allReduce( PairType< FIRST, SECOND > const & localPair, MPI_Comm com
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm, g_collectiveOperationTag );
 #endif
   auto const type = internal::getMpiPairType< FIRST, SECOND >();
   auto const mpiOp = internal::getMpiPairReductionOp< FIRST, SECOND, OP >();

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -26,8 +26,6 @@
 
 #include <numeric>
 
-#include <atomic>
-
 #if defined(GEOS_USE_MPI)
   #include <mpi.h>
 #define MPI_PARAM( x ) x
@@ -957,7 +955,7 @@ void saveStackTrace();
 struct MpiDesyncGuard
 {
   MPI_Comm const & m_comm;
-  std::atomic<bool> m_collectiveOperationSuccess{ false };
+  bool m_collectiveOperationSuccess{ false };
 
   explicit MpiDesyncGuard( MPI_Comm const & comm )
     : m_comm( comm )

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -944,26 +944,25 @@ MPI_Op getMpiPairReductionOp()
 
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
 /**
-  * @brief Save the stack trace for desync diagnostics for MPI collective calls.
-  */
-void saveStackTrace();
-
-/**
-  * @struct MpiDesyncGuard
-  * @brief RAII helper to detect MPI desynchronizations from MPI collective operations.
-  */
+ * @struct MpiDesyncGuard
+ * @brief RAII helper to detect MPI desynchronizations from MPI collective operations.
+ */
 struct MpiDesyncGuard
 {
   MPI_Comm const & m_comm;
   bool m_collectiveOperationSuccess{ false };
 
+  static constexpr int maxFrames = 30;
+  stdArray< void *, maxFrames > m_frames{};
+  int m_frameCount = 0;
+
   explicit MpiDesyncGuard( MPI_Comm const & comm )
     : m_comm( comm )
-  { saveStackTrace(); }
+  { saveStackFrames(); }
 
   ~MpiDesyncGuard()
   { detectMpiDesync(); }
-  
+
   /// @brief Detects MPI desynchronizations from MPI collective operations.
   void detectMpiDesync();
 
@@ -975,6 +974,13 @@ struct MpiDesyncGuard
 
   MpiDesyncGuard( MpiDesyncGuard const & ) = delete;
   MpiDesyncGuard & operator=( MpiDesyncGuard const & ) = delete;
+
+  /// @brief Save the stacktrace frames
+  void saveStackFrames();
+  /// @brief Symbolize and demangle the captured stacktrace frames
+  string symbolizeStackTrace( stdArray< void *, maxFrames > const & frames,
+                              int const frameCount ) const;
+
 };
 #endif
 

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -817,54 +817,6 @@ private:
    */
   template< typename T >
   static int allReduce( T const * sendbuf, T * recvbuf, int count, MPI_Op op, MPI_Comm comm = MPI_COMM_GEOS );
-
-#ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  /**
-   * @struct MpiDesyncGuard
-   * @brief RAII helper to detect MPI desynchronizations from MPI collective operations.
-   */
-  struct MpiDesyncGuard
-  {
-    MPI_Comm const & m_comm;
-    std::atomic<bool> m_collectiveOperationSuccess{ false };
-
-    explicit MpiDesyncGuard( MPI_Comm const & comm )
-      : m_comm( comm )
-    {
-      saveStackTrace(); // Here every rank saves a stacktrace TODO modify
-    }
-
-    ~MpiDesyncGuard()
-    {
-      detectMpiDesync();
-    }
-
-    /**
-     * @brief Detects MPI desynchronizations from MPI collective operations.
-     */
-    void detectMpiDesync();
-
-    /**
-     * @brief Method ran when a desynchronization is detected.
-     * TODO rename TODO is it useful?
-     */
-    void failed();
-    /**
-     * @brief Method ran when no desynchronizations are detected.
-     * TODO rename TODO is it useful?
-     */
-    void succeeded();
-
-    MpiDesyncGuard( MpiDesyncGuard const & ) = delete;
-    MpiDesyncGuard & operator=( MpiDesyncGuard const & ) = delete;
-  };
-
-  /**
-   * @brief Save the stack trace for desync diagnostics for MPI collective calls.
-   */
-  static void saveStackTrace();
-#endif
-
 };
 
 namespace internal
@@ -992,7 +944,43 @@ MPI_Op getMpiPairReductionOp()
   return mpiOp;
 }
 
-}
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+/**
+  * @brief Save the stack trace for desync diagnostics for MPI collective calls.
+  */
+void saveStackTrace();
+
+/**
+  * @struct MpiDesyncGuard
+  * @brief RAII helper to detect MPI desynchronizations from MPI collective operations.
+  */
+struct MpiDesyncGuard
+{
+  MPI_Comm const & m_comm;
+  std::atomic<bool> m_collectiveOperationSuccess{ false };
+
+  explicit MpiDesyncGuard( MPI_Comm const & comm )
+    : m_comm( comm )
+  { saveStackTrace(); }
+
+  ~MpiDesyncGuard()
+  { detectMpiDesync(); }
+  
+  /// @brief Detects MPI desynchronizations from MPI collective operations.
+  void detectMpiDesync();
+
+  /// @brief Method ran when a desynchronization is detected.
+  void failed();
+
+  /// @brief Method ran when no desynchronizations are detected.
+  void succeeded();
+
+  MpiDesyncGuard( MpiDesyncGuard const & ) = delete;
+  MpiDesyncGuard & operator=( MpiDesyncGuard const & ) = delete;
+};
+#endif
+
+} // namespace internal
 
 inline MPI_Op MpiWrapper::getMpiOp( Reduction const op )
 {
@@ -1037,7 +1025,7 @@ int MpiWrapper::allgather( T_SEND const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Allgather( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
                         recvbuf, recvcount, internal::getMpiType< T_RECV >(),
@@ -1061,7 +1049,7 @@ int MpiWrapper::allgatherv( T_SEND const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Allgatherv( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
                          recvbuf, recvcounts, displacements, internal::getMpiType< T_RECV >(),
@@ -1081,7 +1069,7 @@ void MpiWrapper::allGather( T const myValue, array1d< T > & allValues, MPI_Comm 
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   int const mpiSize = commSize( comm );
   allValues.resize( mpiSize );
@@ -1104,7 +1092,7 @@ int MpiWrapper::allGather( arrayView1d< T const > const & sendValues,
   int const sendSize = LvArray::integerConversion< int >( sendValues.size() );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   int const mpiSize = commSize( comm );
   allValues.resize( mpiSize * sendSize );
@@ -1134,7 +1122,7 @@ int MpiWrapper::allGatherv( arrayView1d< T const > const & sendValues,
   int const sendSize = LvArray::integerConversion< int >( sendValues.size() );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   int const mpiSize = commSize( comm );
   array1d< int > counts;
@@ -1170,7 +1158,7 @@ int MpiWrapper::allReduce( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   MPI_Datatype const mpiType = internal::getMpiType< T >();
   return MPI_Allreduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, comm );
@@ -1193,7 +1181,7 @@ int MpiWrapper::reduce( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   MPI_Datatype const mpiType = internal::getMpiType< T >();
   return MPI_Reduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, root, comm );
@@ -1215,7 +1203,7 @@ int MpiWrapper::scan( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Scan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #else
@@ -1233,7 +1221,7 @@ int MpiWrapper::exscan( T const * const MPI_PARAM( sendbuf ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Exscan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #else
@@ -1250,7 +1238,7 @@ int MpiWrapper::bcast( T * const MPI_PARAM( buffer ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Bcast( buffer, count, internal::getMpiType< T >(), root, comm );
 #else
@@ -1264,7 +1252,7 @@ void MpiWrapper::broadcast( T & MPI_PARAM( value ), int MPI_PARAM( srcRank ), MP
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   MPI_Bcast( &value, 1, internal::getMpiType< T >(), srcRank, comm );
 #endif
@@ -1278,7 +1266,7 @@ void MpiWrapper::broadcast< string >( string & MPI_PARAM( value ),
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   int size = LvArray::integerConversion< int >( value.size() );
   broadcast( size, srcRank, comm );
@@ -1297,7 +1285,7 @@ int MpiWrapper::gather( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Gather( sendbuf, sendcount, internal::getMpiType< TS >(),
                      recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1324,7 +1312,7 @@ int MpiWrapper::gather( T const & value,
                           "Receive buffer is not large enough to contain the values to receive." );
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Gather( &value, sizeof( T ), internal::getMpiType< uint8_t >(),
                      destValuesBuffer.data(), sizeof( T ), internal::getMpiType< uint8_t >(),
@@ -1346,7 +1334,7 @@ int MpiWrapper::gatherv( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Gatherv( sendbuf, sendcount, internal::getMpiType< TS >(),
                       recvbuf, recvcounts, displs, internal::getMpiType< TR >(),
@@ -1373,7 +1361,7 @@ int MpiWrapper::scatter( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Scatter( sendbuf, sendcount, internal::getMpiType< TS >(),
                       recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1400,7 +1388,7 @@ int MpiWrapper::scatterv( TS const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   return MPI_Scatterv( sendbuf, sendcounts, displs, internal::getMpiType< TS >(),
                        recvbuf, recvcount, internal::getMpiType< TR >(),
@@ -1668,7 +1656,7 @@ MpiWrapper::allReduce( PairType< FIRST, SECOND > const & localPair, MPI_Comm com
 {
 #ifdef GEOS_USE_MPI
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  MpiDesyncGuard const mpiDesyncGuard( comm );
+  internal::MpiDesyncGuard const mpiDesyncGuard( comm );
 #endif
   auto const type = internal::getMpiPairType< FIRST, SECOND >();
   auto const mpiOp = internal::getMpiPairReductionOp< FIRST, SECOND, OP >();

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -823,12 +823,12 @@ private:
   /**
    * @brief Detects MPI desynchronization from MPI collective operations.
    * @param[in] comm The MPI_Comm over which the gather operates.
-   * @param[in] id The current collective operation counter of this rank.
+   * @param[in] operationId The current collective operation counter of this rank.
    */
-  inline static void detectMpiDesync( MPI_Comm const & MPI_PARAM( comm ), int id )
+  inline static void detectMpiDesync( MPI_Comm const & MPI_PARAM( comm ), int operationId )
   {
-    int minId = id; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MIN, comm );
-    int maxId = id; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MAX, comm );
+    int minId = operationId; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MIN, comm );
+    int maxId = operationId; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MAX, comm );
     if( minId != maxId ) { MPI_Abort( comm, 1 ); }
   }
 #endif
@@ -1008,7 +1008,7 @@ int MpiWrapper::allgather( T_SEND const * const sendbuf,
                            recvbuf, recvcount, internal::getMpiType< T_RECV >(),
                            comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1033,7 +1033,7 @@ int MpiWrapper::allgatherv( T_SEND const * const sendbuf,
                             recvbuf, recvcounts, displacements, internal::getMpiType< T_RECV >(),
                             comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1057,7 +1057,7 @@ void MpiWrapper::allGather( T const myValue, array1d< T > & allValues, MPI_Comm 
 
   MPI_Allgather( &myValue, 1, MPI_TYPE, allValues.data(), 1, MPI_TYPE, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
 
 #else
@@ -1083,7 +1083,7 @@ int MpiWrapper::allGather( arrayView1d< T const > const & sendValues,
                            internal::getMpiType< T >(),
                            comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 
@@ -1119,7 +1119,7 @@ int MpiWrapper::allGatherv( arrayView1d< T const > const & sendValues,
                             internal::getMpiType< T >(),
                             comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 
@@ -1144,7 +1144,7 @@ int MpiWrapper::allReduce( T const * const sendbuf,
   MPI_Datatype const mpiType = internal::getMpiType< T >();
   int ret = MPI_Allreduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1168,7 +1168,7 @@ int MpiWrapper::reduce( T const * const sendbuf,
   MPI_Datatype const mpiType = internal::getMpiType< T >();
   int ret = MPI_Reduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1190,7 +1190,7 @@ int MpiWrapper::scan( T const * const sendbuf,
 #ifdef GEOS_USE_MPI
   int ret = MPI_Scan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1209,7 +1209,7 @@ int MpiWrapper::exscan( T const * const MPI_PARAM( sendbuf ),
 #ifdef GEOS_USE_MPI
   int ret = MPI_Exscan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1227,7 +1227,7 @@ int MpiWrapper::bcast( T * const MPI_PARAM( buffer ),
 #ifdef GEOS_USE_MPI
   int ret = MPI_Bcast( buffer, count, internal::getMpiType< T >(), root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1242,7 +1242,7 @@ void MpiWrapper::broadcast( T & MPI_PARAM( value ), int MPI_PARAM( srcRank ), MP
 #ifdef GEOS_USE_MPI
   MPI_Bcast( &value, 1, internal::getMpiType< T >(), srcRank, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
 #endif
 }
@@ -1259,7 +1259,7 @@ void MpiWrapper::broadcast< string >( string & MPI_PARAM( value ),
   value.resize( size );
   MPI_Bcast( const_cast< char * >( value.data() ), size, internal::getMpiType< char >(), srcRank, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
 #endif
 }
@@ -1277,7 +1277,7 @@ int MpiWrapper::gather( TS const * const sendbuf,
                         recvbuf, recvcount, internal::getMpiType< TR >(),
                         root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1305,7 +1305,7 @@ int MpiWrapper::gather( T const & value,
                         destValuesBuffer.data(), sizeof( T ), internal::getMpiType< uint8_t >(),
                         root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1328,7 +1328,7 @@ int MpiWrapper::gatherv( TS const * const sendbuf,
                          recvbuf, recvcounts, displs, internal::getMpiType< TR >(),
                          root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1356,7 +1356,7 @@ int MpiWrapper::scatter( TS const * const sendbuf,
                          recvbuf, recvcount, internal::getMpiType< TR >(),
                          root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1384,7 +1384,7 @@ int MpiWrapper::scatterv( TS const * const sendbuf,
                           recvbuf, recvcount, internal::getMpiType< TR >(),
                           root, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return ret;
 #else
@@ -1654,7 +1654,7 @@ MpiWrapper::allReduce( PairType< FIRST, SECOND > const & localPair, MPI_Comm com
   PairType< FIRST, SECOND > pair{ localPair.first, localPair.second };
   MPI_Allreduce( MPI_IN_PLACE, &pair, 1, type, mpiOp, comm );
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+  detectMpiDesync( comm, ++g_collectiveOperationCounter );
 #endif
   return pair;
 #else

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -827,9 +827,9 @@ private:
    */
   inline static void detectMpiDesync( MPI_Comm const & MPI_PARAM( comm ), int id )
   {
-    int min_id = MpiWrapper::min( id );
-    int max_id = MpiWrapper::max( id );
-    if( min_id != max_id ) { MPI_Abort( comm, 1 ); }
+    int minId = id; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MIN, comm );
+    int maxId = id; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MAX, comm );
+    if( minId != maxId ) { MPI_Abort( comm, 1 ); }
   }
 #endif
 
@@ -1189,7 +1189,7 @@ int MpiWrapper::scan( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
   int ret = MPI_Scan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
-#ifdef GEOS_USE_MPI
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
   detectMpiDesync( comm, ++g_currentMpiOperationTag );
 #endif
   return ret;
@@ -1241,9 +1241,9 @@ void MpiWrapper::broadcast( T & MPI_PARAM( value ), int MPI_PARAM( srcRank ), MP
 {
 #ifdef GEOS_USE_MPI
   MPI_Bcast( &value, 1, internal::getMpiType< T >(), srcRank, comm );
-// #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-//   detectMpiDesync( comm, ++g_currentMpiOperationTag );
-// #endif
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
 #endif
 }
 
@@ -1258,9 +1258,9 @@ void MpiWrapper::broadcast< string >( string & MPI_PARAM( value ),
   broadcast( size, srcRank, comm );
   value.resize( size );
   MPI_Bcast( const_cast< char * >( value.data() ), size, internal::getMpiType< char >(), srcRank, comm );
-// #ifdef GEOS_USE_MPI_DESYNC_DETECTION
-//   detectMpiDesync( comm, ++g_currentMpiOperationTag );
-// #endif
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
 #endif
 }
 
@@ -1653,6 +1653,9 @@ MpiWrapper::allReduce( PairType< FIRST, SECOND > const & localPair, MPI_Comm com
   auto const mpiOp = internal::getMpiPairReductionOp< FIRST, SECOND, OP >();
   PairType< FIRST, SECOND > pair{ localPair.first, localPair.second };
   MPI_Allreduce( MPI_IN_PLACE, &pair, 1, type, mpiOp, comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
   return pair;
 #else
   return localPair;

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -818,7 +818,7 @@ private:
 
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
   /// Tag/counter of the latest MPI collective operation to detect MPI desynchronizations
-  inline static int g_currentMpiOperationTag = 0;
+  inline static int g_collectiveOperationCounter = 0;
 
   /**
    * @struct MpiDesyncGuard

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -819,6 +819,18 @@ private:
 #ifdef GEOS_USE_MPI_DESYNC_DETECTION
   /// Tag/counter of the latest MPI collective operation to detect MPI desynchronizations
   inline static int g_currentMpiOperationTag = 0;
+
+  /**
+   * @brief Detects MPI desynchronization from MPI collective operations.
+   * @param[in] comm The MPI_Comm over which the gather operates.
+   * @param[in] id The current collective operation counter of this rank.
+   */
+  inline static void detectMpiDesync( MPI_Comm const & MPI_PARAM( comm ), int id )
+  {
+    int min_id = MpiWrapper::min( id );
+    int max_id = MpiWrapper::max( id );
+    if( min_id != max_id ) { MPI_Abort( comm, 1 ); }
+  }
 #endif
 
 };

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -832,7 +832,9 @@ private:
     explicit MpiDesyncGuard( MPI_Comm const & comm )
       : m_comm( comm )
       , m_operationId( ++g_collectiveOperationCounter )
-    {}
+    {
+      saveStackTrace();
+    }
 
     ~MpiDesyncGuard()
     {
@@ -848,12 +850,12 @@ private:
    * @param[in] comm The MPI_Comm over which the gather operates.
    * @param[in] operationId The current collective operation counter of this rank.
    */
-  inline static void detectMpiDesync( MPI_Comm const & MPI_PARAM( comm ), int operationId )
-  {
-    int minId = operationId; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MIN, comm );
-    int maxId = operationId; MPI_Allreduce( MPI_IN_PLACE, &maxId, 1, MPI_INT, MPI_MAX, comm );
-    if( minId != maxId ) { MPI_Abort( comm, 1 ); }
-  }
+  static void detectMpiDesync( MPI_Comm const & MPI_PARAM( comm ), int operationId );
+
+  /**
+   * @brief Save the stack trace for desync diagnostics for MPI collective calls.
+   */
+  static void saveStackTrace();
 #endif
 
 };

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -828,7 +828,7 @@ private:
   inline static void detectMpiDesync( MPI_Comm const & MPI_PARAM( comm ), int operationId )
   {
     int minId = operationId; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MIN, comm );
-    int maxId = operationId; MPI_Allreduce( MPI_IN_PLACE, &minId, 1, MPI_INT, MPI_MAX, comm );
+    int maxId = operationId; MPI_Allreduce( MPI_IN_PLACE, &maxId, 1, MPI_INT, MPI_MAX, comm );
     if( minId != maxId ) { MPI_Abort( comm, 1 ); }
   }
 #endif

--- a/src/coreComponents/common/MpiWrapper.hpp
+++ b/src/coreComponents/common/MpiWrapper.hpp
@@ -1004,9 +1004,13 @@ int MpiWrapper::allgather( T_SEND const * const sendbuf,
                            MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  return MPI_Allgather( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
-                        recvbuf, recvcount, internal::getMpiType< T_RECV >(),
-                        comm );
+  int ret = MPI_Allgather( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
+                           recvbuf, recvcount, internal::getMpiType< T_RECV >(),
+                           comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   static_assert( std::is_same< T_SEND, T_RECV >::value,
                  "MpiWrapper::allgather() for serial run requires send and receive buffers are of the same type" );
@@ -1025,9 +1029,13 @@ int MpiWrapper::allgatherv( T_SEND const * const sendbuf,
                             MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  return MPI_Allgatherv( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
-                         recvbuf, recvcounts, displacements, internal::getMpiType< T_RECV >(),
-                         comm );
+  int ret = MPI_Allgatherv( sendbuf, sendcount, internal::getMpiType< T_SEND >(),
+                            recvbuf, recvcounts, displacements, internal::getMpiType< T_RECV >(),
+                            comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   static_assert( std::is_same< T_SEND, T_RECV >::value,
                  "MpiWrapper::allgatherv() for serial run requires send and receive buffers are of the same type" );
@@ -1048,6 +1056,9 @@ void MpiWrapper::allGather( T const myValue, array1d< T > & allValues, MPI_Comm 
   MPI_Datatype const MPI_TYPE = internal::getMpiType< T >();
 
   MPI_Allgather( &myValue, 1, MPI_TYPE, allValues.data(), 1, MPI_TYPE, comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
 
 #else
   allValues.resize( 1 );
@@ -1064,13 +1075,17 @@ int MpiWrapper::allGather( arrayView1d< T const > const & sendValues,
 #ifdef GEOS_USE_MPI
   int const mpiSize = commSize( comm );
   allValues.resize( mpiSize * sendSize );
-  return MPI_Allgather( sendValues.data(),
-                        sendSize,
-                        internal::getMpiType< T >(),
-                        allValues.data(),
-                        sendSize,
-                        internal::getMpiType< T >(),
-                        comm );
+  int ret = MPI_Allgather( sendValues.data(),
+                           sendSize,
+                           internal::getMpiType< T >(),
+                           allValues.data(),
+                           sendSize,
+                           internal::getMpiType< T >(),
+                           comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 
 #else
   allValues.resize( sendSize );
@@ -1095,14 +1110,18 @@ int MpiWrapper::allGatherv( arrayView1d< T const > const & sendValues,
   array1d< int > displs( mpiSize + 1 );
   std::partial_sum( counts.begin(), counts.end(), displs.begin() + 1 );
   allValues.resize( displs.back() );
-  return MPI_Allgatherv( sendValues.data(),
-                         sendSize,
-                         internal::getMpiType< T >(),
-                         allValues.data(),
-                         counts.data(),
-                         displs.data(),
-                         internal::getMpiType< T >(),
-                         comm );
+  int ret = MPI_Allgatherv( sendValues.data(),
+                            sendSize,
+                            internal::getMpiType< T >(),
+                            allValues.data(),
+                            counts.data(),
+                            displs.data(),
+                            internal::getMpiType< T >(),
+                            comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 
 #else
   allValues.resize( sendSize );
@@ -1123,7 +1142,11 @@ int MpiWrapper::allReduce( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
   MPI_Datatype const mpiType = internal::getMpiType< T >();
-  return MPI_Allreduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, comm );
+  int ret = MPI_Allreduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   if( sendbuf != recvbuf )
   {
@@ -1143,7 +1166,11 @@ int MpiWrapper::reduce( T const * const sendbuf,
 {
 #ifdef GEOS_USE_MPI
   MPI_Datatype const mpiType = internal::getMpiType< T >();
-  return MPI_Reduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, root, comm );
+  int ret = MPI_Reduce( sendbuf == recvbuf ? MPI_IN_PLACE : sendbuf, recvbuf, count, mpiType, op, root, comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   if( sendbuf != recvbuf )
   {
@@ -1161,7 +1188,11 @@ int MpiWrapper::scan( T const * const sendbuf,
                       MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  return MPI_Scan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
+  int ret = MPI_Scan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
+#ifdef GEOS_USE_MPI
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   memcpy( recvbuf, sendbuf, count*sizeof(T) );
   return 0;
@@ -1176,7 +1207,11 @@ int MpiWrapper::exscan( T const * const MPI_PARAM( sendbuf ),
                         MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  return MPI_Exscan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
+  int ret = MPI_Exscan( sendbuf, recvbuf, count, internal::getMpiType< T >(), op, comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   memset( recvbuf, 0, count*sizeof(T) );
   return 0;
@@ -1190,7 +1225,11 @@ int MpiWrapper::bcast( T * const MPI_PARAM( buffer ),
                        MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  return MPI_Bcast( buffer, count, internal::getMpiType< T >(), root, comm );
+  int ret = MPI_Bcast( buffer, count, internal::getMpiType< T >(), root, comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   return 0;
 #endif
@@ -1202,6 +1241,9 @@ void MpiWrapper::broadcast( T & MPI_PARAM( value ), int MPI_PARAM( srcRank ), MP
 {
 #ifdef GEOS_USE_MPI
   MPI_Bcast( &value, 1, internal::getMpiType< T >(), srcRank, comm );
+// #ifdef GEOS_USE_MPI_DESYNC_DETECTION
+//   detectMpiDesync( comm, ++g_currentMpiOperationTag );
+// #endif
 #endif
 }
 
@@ -1216,6 +1258,9 @@ void MpiWrapper::broadcast< string >( string & MPI_PARAM( value ),
   broadcast( size, srcRank, comm );
   value.resize( size );
   MPI_Bcast( const_cast< char * >( value.data() ), size, internal::getMpiType< char >(), srcRank, comm );
+// #ifdef GEOS_USE_MPI_DESYNC_DETECTION
+//   detectMpiDesync( comm, ++g_currentMpiOperationTag );
+// #endif
 #endif
 }
 
@@ -1228,9 +1273,13 @@ int MpiWrapper::gather( TS const * const sendbuf,
                         MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  return MPI_Gather( sendbuf, sendcount, internal::getMpiType< TS >(),
-                     recvbuf, recvcount, internal::getMpiType< TR >(),
-                     root, comm );
+  int ret = MPI_Gather( sendbuf, sendcount, internal::getMpiType< TS >(),
+                        recvbuf, recvcount, internal::getMpiType< TR >(),
+                        root, comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   static_assert( std::is_same< TS, TR >::value,
                  "MpiWrapper::gather() for serial run requires send and receive buffers are of the same type" );
@@ -1252,9 +1301,13 @@ int MpiWrapper::gather( T const & value,
     GEOS_ERROR_IF_LT_MSG( destValuesBuffer.size(), size_t( commSize() ),
                           "Receive buffer is not large enough to contain the values to receive." );
 #ifdef GEOS_USE_MPI
-  return MPI_Gather( &value, sizeof( T ), internal::getMpiType< uint8_t >(),
-                     destValuesBuffer.data(), sizeof( T ), internal::getMpiType< uint8_t >(),
-                     root, comm );
+  int ret = MPI_Gather( &value, sizeof( T ), internal::getMpiType< uint8_t >(),
+                        destValuesBuffer.data(), sizeof( T ), internal::getMpiType< uint8_t >(),
+                        root, comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   memcpy( destValuesBuffer.data(), &value, sendBufferSize );
   return 0;
@@ -1271,9 +1324,13 @@ int MpiWrapper::gatherv( TS const * const sendbuf,
                          MPI_Comm MPI_PARAM( comm ) )
 {
 #ifdef GEOS_USE_MPI
-  return MPI_Gatherv( sendbuf, sendcount, internal::getMpiType< TS >(),
-                      recvbuf, recvcounts, displs, internal::getMpiType< TR >(),
-                      root, comm );
+  int ret = MPI_Gatherv( sendbuf, sendcount, internal::getMpiType< TS >(),
+                         recvbuf, recvcounts, displs, internal::getMpiType< TR >(),
+                         root, comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   static_assert( std::is_same< TS, TR >::value,
                  "MpiWrapper::gather() for serial run requires send and receive buffers are of the same type" );
@@ -1295,9 +1352,13 @@ int MpiWrapper::scatter( TS const * const sendbuf,
                          MPI_Comm MPI_PARAM( comm ))
 {
 #ifdef GEOS_USE_MPI
-  return MPI_Scatter( sendbuf, sendcount, internal::getMpiType< TS >(),
-                      recvbuf, recvcount, internal::getMpiType< TR >(),
-                      root, comm );
+  int ret = MPI_Scatter( sendbuf, sendcount, internal::getMpiType< TS >(),
+                         recvbuf, recvcount, internal::getMpiType< TR >(),
+                         root, comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   static_assert( std::is_same< TS, TR >::value,
                  "MpiWrapper::scatter() for serial run requires send and receive buffers are of the same type" );
@@ -1319,9 +1380,13 @@ int MpiWrapper::scatterv( TS const * const sendbuf,
                           MPI_Comm MPI_PARAM( comm ))
 {
 #ifdef GEOS_USE_MPI
-  return MPI_Scatterv( sendbuf, sendcounts, displs, internal::getMpiType< TS >(),
-                       recvbuf, recvcount, internal::getMpiType< TR >(),
-                       root, comm );
+  int ret = MPI_Scatterv( sendbuf, sendcounts, displs, internal::getMpiType< TS >(),
+                          recvbuf, recvcount, internal::getMpiType< TR >(),
+                          root, comm );
+#ifdef GEOS_USE_MPI_DESYNC_DETECTION
+  detectMpiDesync( comm, ++g_currentMpiOperationTag );
+#endif
+  return ret;
 #else
   static_assert( std::is_same< TS, TR >::value,
                  "MpiWrapper::scatterv() for serial run requires send and receive buffers are of the same type" );

--- a/src/coreComponents/common/logger/Logger.cpp
+++ b/src/coreComponents/common/logger/Logger.cpp
@@ -19,6 +19,7 @@
 
 // Source includes
 #include "Logger.hpp"
+#include "common/MpiWrapper.hpp"
 #include "common/Path.hpp"
 
 namespace geos
@@ -53,7 +54,7 @@ void InitializeLogger( MPI_Comm mpi_comm, const std::string & rankOutputDir )
       makeDirsForPath( rankOutputDir );
     }
 
-    MPI_Barrier( mpi_comm );
+    MpiWrapper::barrier( mpi_comm );
     std::string outputFilePath = rankOutputDir + "/rank_" + internal::g_rankString + ".out";
     internal::g_rankStream = new std::ofstream( outputFilePath );
   }

--- a/src/coreComponents/events/EventManager.cpp
+++ b/src/coreComponents/events/EventManager.cpp
@@ -169,10 +169,8 @@ bool EventManager::run( DomainPartition & domain )
       }
       m_currentSubEvent = 0;
 
-#ifdef GEOS_USE_MPI
       // Find the min dt across processes
       m_dt = MpiWrapper::min( m_dt, MPI_COMM_GEOS );
-#endif
     }
     LogPart logPart( "TIMESTEP", MpiWrapper::commRank() == 0 );
 

--- a/src/coreComponents/events/EventManager.cpp
+++ b/src/coreComponents/events/EventManager.cpp
@@ -171,9 +171,7 @@ bool EventManager::run( DomainPartition & domain )
 
 #ifdef GEOS_USE_MPI
       // Find the min dt across processes
-      real64 dt_global;
-      MPI_Allreduce( &m_dt, &dt_global, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_GEOS );
-      m_dt = dt_global;
+      m_dt = MpiWrapper::min( m_dt, MPI_COMM_GEOS );
 #endif
     }
     LogPart logPart( "TIMESTEP", MpiWrapper::commRank() == 0 );

--- a/src/coreComponents/events/HaltEvent.cpp
+++ b/src/coreComponents/events/HaltEvent.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "HaltEvent.hpp"
+#include "common/MpiWrapper.hpp"
 #include <sys/time.h>
 
 /**
@@ -67,9 +68,7 @@ void HaltEvent::estimateEventTiming( real64 const GEOS_UNUSED_PARAM( time ),
   // The timing for the ranks may differ slightly, so synchronize
   // TODO: Only do the communication when you are close to the end?
 #ifdef GEOS_USE_MPI
-  integer forecast_global;
-  MPI_Allreduce( &forecast, &forecast_global, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD );
-  forecast = forecast_global;
+  forecast = MpiWrapper::min( forecast, MPI_COMM_WORLD );
 #endif
 
   setForecast( forecast );

--- a/src/coreComponents/events/HaltEvent.cpp
+++ b/src/coreComponents/events/HaltEvent.cpp
@@ -67,9 +67,7 @@ void HaltEvent::estimateEventTiming( real64 const GEOS_UNUSED_PARAM( time ),
 
   // The timing for the ranks may differ slightly, so synchronize
   // TODO: Only do the communication when you are close to the end?
-#ifdef GEOS_USE_MPI
   forecast = MpiWrapper::min( forecast, MPI_COMM_WORLD );
-#endif
 
   setForecast( forecast );
 

--- a/src/coreComponents/events/PeriodicEvent.cpp
+++ b/src/coreComponents/events/PeriodicEvent.cpp
@@ -183,7 +183,7 @@ void PeriodicEvent::checkOptionalFunctionThreshold( real64 const time,
       }
       case 1:
       {
-        result = MpiWrapper::sum( result, MPI_COMM_WORLD ) / MPI_Comm_size( MPI_COMM_WORLD );
+        result = MpiWrapper::sum( result, MPI_COMM_WORLD ) / MpiWrapper::commSize( MPI_COMM_WORLD );
         break;
       }
       case 2:

--- a/src/coreComponents/events/PeriodicEvent.cpp
+++ b/src/coreComponents/events/PeriodicEvent.cpp
@@ -20,6 +20,7 @@
 #include "PeriodicEvent.hpp"
 
 #include "common/format/Format.hpp"
+#include "common/MpiWrapper.hpp"
 #include "functions/FunctionManager.hpp"
 
 namespace geos
@@ -173,27 +174,21 @@ void PeriodicEvent::checkOptionalFunctionThreshold( real64 const time,
     // Because the function applied to an object may differ by rank, synchronize
     // (Note: this shouldn't occur very often, since it is only called if the base forecast <= 0)
 #ifdef GEOS_USE_MPI
-    real64 result_global;
     switch( m_functionStatOption )
     {
       case 0:
       {
-        MPI_Allreduce( &result, &result_global, 1, MPI_DOUBLE, MPI_MIN, MPI_COMM_WORLD );
-        result = result_global;
+        result = MpiWrapper::min( result, MPI_COMM_WORLD );
         break;
       }
       case 1:
       {
-        int nprocs;
-        MPI_Comm_size( MPI_COMM_WORLD, &nprocs );
-        MPI_Allreduce( &result, &result_global, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD );
-        result = result_global / nprocs;
+        result = MpiWrapper::sum( result, MPI_COMM_WORLD ) / MPI_Comm_size( MPI_COMM_WORLD );
         break;
       }
       case 2:
       {
-        MPI_Allreduce( &result, &result_global, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD );
-        result = result_global;
+        result = MpiWrapper::max( result, MPI_COMM_WORLD );
       }
     }
 #endif

--- a/src/coreComponents/events/PeriodicEvent.cpp
+++ b/src/coreComponents/events/PeriodicEvent.cpp
@@ -173,7 +173,6 @@ void PeriodicEvent::checkOptionalFunctionThreshold( real64 const time,
 
     // Because the function applied to an object may differ by rank, synchronize
     // (Note: this shouldn't occur very often, since it is only called if the base forecast <= 0)
-#ifdef GEOS_USE_MPI
     switch( m_functionStatOption )
     {
       case 0:
@@ -191,7 +190,6 @@ void PeriodicEvent::checkOptionalFunctionThreshold( real64 const time,
         result = MpiWrapper::max( result, MPI_COMM_WORLD );
       }
     }
-#endif
   }
 
   // Forcast event

--- a/src/coreComponents/fileIO/silo/SiloFile.cpp
+++ b/src/coreComponents/fileIO/silo/SiloFile.cpp
@@ -277,13 +277,7 @@ SiloFile::~SiloFile()
 
 void SiloFile::makeSiloDirectories()
 {
-
-  int rank=0;
-#ifdef GEOS_USE_MPI
-  MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-#endif
-
-  if( rank==0 )
+  if( MpiWrapper::commRank( MPI_COMM_GEOS ) == 0 )
   {
     makeDirsForPath( joinPath( m_siloDirectory, m_siloDataSubDirectory ) );
   }
@@ -342,11 +336,7 @@ void SiloFile::waitForBatonWrite( int const domainNumber,
                                   integer const eventCounter,
                                   bool const isRestart )
 {
-
-  int rank = 0;
-#ifdef GEOS_USE_MPI
-  MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-#endif
+  int const rank = MpiWrapper::commRank( MPI_COMM_GEOS );
   int const groupRank = PMPIO_GroupRank( m_baton, rank );
 
   if( isRestart )
@@ -376,11 +366,7 @@ void SiloFile::waitForBatonWrite( int const domainNumber,
 
 void SiloFile::waitForBaton( int const domainNumber, string const & restartFileName )
 {
-
-  int rank = 0;
-#ifdef GEOS_USE_MPI
-  MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-#endif
+  int const rank = MpiWrapper::commRank( MPI_COMM_GEOS );
   int const groupRank = PMPIO_GroupRank( m_baton, rank );
 
   m_baseFileName = restartFileName;
@@ -411,11 +397,7 @@ void SiloFile::handOffBaton()
 {
   PMPIO_HandOffBaton( m_baton, m_dbFilePtr );
 
-  int rank = 0;
-#ifdef GEOS_USE_MPI
-  MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-#endif
-  if( rank==0 )
+  if( MpiWrapper::commRank( MPI_COMM_GEOS ) == 0 )
   {
     DBClose( m_dbBaseFilePtr );
   }
@@ -573,11 +555,7 @@ void SiloFile::writeMeshObject( string const & meshName,
   }
 
   // write multimesh object
-  int rank = 0;
-#ifdef GEOS_USE_MPI
-  MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-#endif
-  if( rank == 0 )
+  if( MpiWrapper::commRank( MPI_COMM_GEOS ) == 0 )
   {
     DBAddOption( optlist, DBOPT_CYCLE, const_cast< int * >(&cycleNumber));
     DBAddOption( optlist, DBOPT_DTIME, const_cast< real64 * >(&problemTime));
@@ -648,11 +626,7 @@ void SiloFile::writeBeamMesh( string const & meshName,
 
   //----write multimesh object
   {
-    int rank = 0;
-  #ifdef GEOS_USE_MPI
-    MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-  #endif
-    if( rank == 0 )
+    if( MpiWrapper::commRank( MPI_COMM_GEOS ) == 0 )
     {
       DBAddOption( optlist, DBOPT_CYCLE, const_cast< int * >(&cycleNumber));
       DBAddOption( optlist, DBOPT_DTIME, const_cast< real64 * >(&problemTime));
@@ -681,11 +655,7 @@ void SiloFile::writePointMesh( string const & meshName,
 
   //----write multimesh object
   {
-    int rank = 0;
-  #ifdef GEOS_USE_MPI
-    MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-  #endif
-    if( rank == 0 )
+    if( MpiWrapper::commRank( MPI_COMM_GEOS ) == 0 )
     {
       writeMultiXXXX( DB_POINTMESH, DBPutMultimesh, 0, meshName.c_str(), cycleNumber, "/", optlist );
     }
@@ -809,10 +779,7 @@ void SiloFile::writeMaterialMapsFullStorage( ElementRegionBase const & elemRegio
       DBFreeOptlist( optlist );
     }
     // write multimesh object
-    int rank = 0;
-  #ifdef GEOS_USE_MPI
-    MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-  #endif
+    int const rank = MpiWrapper::commRank( MPI_COMM_GEOS );
     if( rank == 0 )
     {
 
@@ -1966,11 +1933,7 @@ void SiloFile::writePolygonMeshObject( const string & meshName,
   }
 
   // write multimesh object
-  int rank = 0;
-#ifdef GEOS_USE_MPI
-  MPI_Comm_rank( MPI_COMM_WORLD, &rank );
-#endif
-  if( rank == 0 )
+  if( MpiWrapper::commRank( MPI_COMM_WORLD ) == 0 )
   {
     DBAddOption( optlist, DBOPT_CYCLE, const_cast< int * >(&cycleNumber));
     DBAddOption( optlist, DBOPT_DTIME, const_cast< real64 * >(&problemTime));
@@ -2107,10 +2070,7 @@ void SiloFile::writeMultiXXXX( const DBObjectType type,
 {
   (void)centering;
 
-  int size = 1;
-#ifdef GEOS_USE_MPI
-  MPI_Comm_size( MPI_COMM_GEOS, &size );
-#endif
+  int const size = MpiWrapper::commSize( MPI_COMM_GEOS );
 
   string_array vBlockNames( size );
   array1d< char * > BlockNames( size );
@@ -2255,11 +2215,7 @@ void SiloFile::writeDataField( string const & meshName,
   }
 
   // write multimesh object
-  int rank = 0;
-#ifdef GEOS_USE_MPI
-  MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-#endif
-  if( rank == 0 )
+  if( MpiWrapper::commRank( MPI_COMM_GEOS ) == 0 )
   {
     int tensorRank = siloFileUtilities::GetTensorRank< TYPE >();
     DBAddOption( optlist, DBOPT_TENSOR_RANK, const_cast< int * >(&tensorRank));
@@ -2524,11 +2480,7 @@ void SiloFile::writeDataField( string const & meshName,
   }
 
   // write multimesh object
-  int rank = 0;
-#ifdef GEOS_USE_MPI
-  MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-#endif
-  if( rank == 0 )
+  if( MpiWrapper::commRank( MPI_COMM_GEOS ) == 0 )
   {
 //    int tensorRank = siloTensorRank;
 //    DBAddOption(optlist, DBOPT_TENSOR_RANK, const_cast<int*> (&tensorRank));
@@ -2812,11 +2764,7 @@ void SiloFile::writeMaterialDataField( string const & meshName,
   }
 
   // write multimesh object
-  int rank = 0;
-#ifdef GEOS_USE_MPI
-  MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-#endif
-  if( rank == 0 )
+  if( MpiWrapper::commRank( MPI_COMM_GEOS ) == 0 )
   {
     int tensorRank = siloFileUtilities::GetTensorRank< TYPE >();
     DBAddOption( optlist, DBOPT_TENSOR_RANK, const_cast< int * >(&tensorRank));

--- a/src/coreComponents/physicsSolvers/FieldStatisticsBase.hpp
+++ b/src/coreComponents/physicsSolvers/FieldStatisticsBase.hpp
@@ -99,7 +99,7 @@ protected:
         makeDirsForPath( m_outputDir );
       }
       // wait till the dir is created by rank 0
-      MPI_Barrier( MPI_COMM_WORLD );
+      MpiWrapper::barrier( MPI_COMM_WORLD );
     }
   }
 

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/WellSolverBase.cpp
@@ -111,7 +111,7 @@ void WellSolverBase::postInputInitialization()
       makeDirsForPath( m_ratesOutputDir );
     }
     // wait till the dir is created by rank 0
-    MPI_Barrier( MPI_COMM_WORLD );
+    MpiWrapper::barrier( MPI_COMM_WORLD );
   }
 }
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsMPM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsMPM.cpp
@@ -577,12 +577,12 @@ void SolidMechanicsMPM::initialize( NodeManager & nodeManager,
       BCTableSize = BCTable1D.size();
     }
 
-    MPI_Bcast( &BCTableSize, 1, MPI_INT, 0, MPI_COMM_GEOS ); // Broadcast the size of BCTable1D to other processes
+    MpiWrapper::bcast( &BCTableSize, 1, 0, MPI_COMM_GEOS ); // Broadcast the size of BCTable1D to other processes
     if( rank != 0 ) // All processes except for root resize their versions of BCTable1D
     {
       BCTable1D.resize( BCTableSize );
     }
-    MPI_Bcast( BCTable1D.data(), BCTableSize, MPI_DOUBLE, 0, MPI_COMM_GEOS ); // Broadcast BCTable1D to other processes
+    MpiWrapper::bcast( BCTable1D.data(), BCTableSize, 0, MPI_COMM_GEOS ); // Broadcast BCTable1D to other processes
 
     // Technically don't need to reshape BCTable1D into a 2D array, but it makes things more readable and should have little runtime penalty
     m_bcTable.resize( BCTableSize / 7, 7 ); // Initialize size of m_BCTable
@@ -618,12 +618,12 @@ void SolidMechanicsMPM::initialize( NodeManager & nodeManager,
       FTableSize = FTable1D.size();
     }
 
-    MPI_Bcast( &FTableSize, 1, MPI_INT, 0, MPI_COMM_GEOS ); // Broadcast the size of FTable1D to other processes
+    MpiWrapper::bcast( &FTableSize, 1, 0, MPI_COMM_GEOS ); // Broadcast the size of FTable1D to other processes
     if( rank != 0 ) // All processes except for root resize their versions of FTable1D
     {
       FTable1D.resize( FTableSize );
     }
-    MPI_Bcast( FTable1D.data(), FTableSize, MPI_DOUBLE, 0, MPI_COMM_GEOS ); // Broadcast FTable1D to other processes
+    MpiWrapper::bcast( FTable1D.data(), FTableSize, 0, MPI_COMM_GEOS ); // Broadcast FTable1D to other processes
 
     // Techinically don't need to reshape FTable1D into a 2D array, but it makes things more readable and should have little runtime penalty
     m_fTable.resize( FTableSize / 4, 4 ); // Initialize size of m_fTable
@@ -823,12 +823,7 @@ void SolidMechanicsMPM::initialize( NodeManager & nodeManager,
     {
       localMinMass = DBL_MAX;
     }
-    MPI_Allreduce( &localMinMass,
-                   &globalMinMass,
-                   1,
-                   MPI_DOUBLE,
-                   MPI_MIN,
-                   MPI_COMM_GEOS );
+    globalMinMass = MpiWrapper::min( localMinMass, MPI_COMM_GEOS );
     m_smallMass = fmin( globalMinMass * 1.0e-12, m_smallMass );
 
     // Initialize deformation gradient and velocity gradient
@@ -884,12 +879,7 @@ void SolidMechanicsMPM::initialize( NodeManager & nodeManager,
       }
     }
   } );
-  MPI_Allreduce( &maxLocalGroupNumber,
-                 &maxGlobalGroupNumber,
-                 1,
-                 MPI_INT,
-                 MPI_MAX,
-                 MPI_COMM_GEOS );
+  maxGlobalGroupNumber = MpiWrapper::max( maxLocalGroupNumber, MPI_COMM_GEOS );
 
   // Number of contact groups
   m_numContactGroups = maxGlobalGroupNumber + 1;
@@ -1465,12 +1455,7 @@ void SolidMechanicsMPM::applyEssentialBCs( const real64 dt,
   real64 globalFaceReactions[6];
   for( int face = 0; face < 6; face++ )
   {
-    MPI_Allreduce( &localFaceReactions[face],
-                   &globalFaceReactions[face],
-                   1,
-                   MPI_DOUBLE,
-                   MPI_SUM,
-                   MPI_COMM_GEOS );
+    globalFaceReactions[face] = MpiWrapper::sum( localFaceReactions[face], MPI_COMM_GEOS );
   }
 
   // Get end-of-step domain dimensions - note that m_domainExtent is updated later
@@ -1956,7 +1941,7 @@ void SolidMechanicsMPM::solverProfiling( std::string label )
 {
   if( m_solverProfiling >= 1 )
   {
-    MPI_Barrier( MPI_COMM_GEOS );
+    MpiWrapper::barrier( MPI_COMM_GEOS );
     GEOS_LOG_RANK_IF( m_solverProfiling == 2, label );
     m_profilingTimes.push_back( MPI_Wtime() );
     m_profilingLabels.push_back( label );
@@ -2195,18 +2180,8 @@ void SolidMechanicsMPM::optimizeBinSort( ParticleManager & particleManager )
   real64 globalWeightedMultiplier;
   int localNumberOfParticles = particleManager.getNumberOfParticles();
   real64 localWeightedMultiplier = optimalMultiplier * localNumberOfParticles;
-  MPI_Allreduce( &localWeightedMultiplier,
-                 &globalWeightedMultiplier,
-                 1,
-                 MPI_DOUBLE,
-                 MPI_SUM,
-                 MPI_COMM_GEOS );
-  MPI_Allreduce( &localNumberOfParticles,
-                 &globalNumberOfParticles,
-                 1,
-                 MPI_INT,
-                 MPI_SUM,
-                 MPI_COMM_GEOS );
+  globalWeightedMultiplier = MpiWrapper::sum( localWeightedMultiplier, MPI_COMM_GEOS );
+  globalNumberOfParticles = MpiWrapper::sum( localNumberOfParticles, MPI_COMM_GEOS );
 
   // Set bin size multiplier
   m_binSizeMultiplier = std::max( (int) std::round( globalWeightedMultiplier / globalNumberOfParticles ), 1 );
@@ -2752,15 +2727,7 @@ void SolidMechanicsMPM::computeAndWriteBoxAverage( const real64 dt,
   // so file is directly plottable in excel as CSV or something.
   for( localIndex i = 0; i < 9; i++ )
   {
-    real64 localSum = boxSums[i];
-    real64 globalSum;
-    MPI_Allreduce( &localSum,
-                   &globalSum,
-                   1,
-                   MPI_DOUBLE,
-                   MPI_SUM,
-                   MPI_COMM_GEOS );
-    boxSums[i] = globalSum;
+    boxSums[i] = MpiWrapper::sum( boxSums[i], MPI_COMM_GEOS );
   }
 
   int rank;
@@ -3332,7 +3299,7 @@ void SolidMechanicsMPM::printProfilingResults()
   }
 
   // Print out solver profiling
-  MPI_Barrier( MPI_COMM_GEOS );
+  MpiWrapper::barrier( MPI_COMM_GEOS );
   if( rank == 0 )
   {
     std::cout << "---------------------------------------------" << std::endl;

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsMPM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsMPM.cpp
@@ -2730,9 +2730,7 @@ void SolidMechanicsMPM::computeAndWriteBoxAverage( const real64 dt,
     boxSums[i] = MpiWrapper::sum( boxSums[i], MPI_COMM_GEOS );
   }
 
-  int rank;
-  MPI_Comm_rank( MPI_COMM_GEOS, &rank );
-  if( rank == 0 )
+  if( MpiWrapper::commRank( MPI_COMM_GEOS ) == 0 )
   {
     // Calculate the box volume
     real64 boxVolume = m_domainExtent[0] * m_domainExtent[1] * m_domainExtent[2];

--- a/src/coreComponents/schema/schema.xsd.other
+++ b/src/coreComponents/schema/schema.xsd.other
@@ -526,7 +526,7 @@ A field can represent a physical variable. (pressure, temperature, global compos
 		<!--fractureStencil => (no description available)-->
 		<xsd:attribute name="fractureStencil" type="geos_SurfaceElementStencil" />
 		<!--targetRegions => List of regions to build the stencil for-->
-		<xsd:attribute name="targetRegions" type="geos_mapBase_lt_string_cm_-geos_internal_StdVectorWrapper_lt_string_cm_-std_allocator_lt_string-_gt__cm_-false_gt__cm_-std_integral_constant_lt_bool_cm_-true_gt_-_gt_" />
+		<xsd:attribute name="targetRegions" type="geos_mapBase_lt_string_cm_-geos_internal_StdVectorWrapper_lt_string_cm_-std_allocator_lt_string-_gt__cm_-true_gt__cm_-std_integral_constant_lt_bool_cm_-true_gt_-_gt_" />
 	</xsd:complexType>
 	<xsd:complexType name="OutputsType">
 		<xsd:choice minOccurs="0" maxOccurs="unbounded">
@@ -1603,7 +1603,7 @@ A field can represent a physical variable. (pressure, temperature, global compos
 			<xsd:element name="MeshBodies" type="MeshBodiesType" />
 		</xsd:choice>
 		<!--Neighbors => (no description available)-->
-		<xsd:attribute name="Neighbors" type="geos_internal_StdVectorWrapper_lt_geos_NeighborCommunicator_cm_-std_allocator_lt_geos_NeighborCommunicator_gt__cm_-false_gt_" />
+		<xsd:attribute name="Neighbors" type="geos_internal_StdVectorWrapper_lt_geos_NeighborCommunicator_cm_-std_allocator_lt_geos_NeighborCommunicator_gt__cm_-true_gt_" />
 		<!--partitionManager => (no description available)-->
 		<xsd:attribute name="partitionManager" type="geos_PartitionBase" />
 	</xsd:complexType>
@@ -2437,11 +2437,11 @@ A field can represent a physical variable. (pressure, temperature, global compos
 		<xsd:attribute name="permeability" type="real64_array3d" />
 	</xsd:complexType>
 	<xsd:complexType name="CoulombType">
-		<!--cohesion => Cohesion for each cell => Coulomb-->
+		<!--cohesion => Cohesion for each element-->
 		<xsd:attribute name="cohesion" type="real64_array" />
 		<!--elasticSlip => Elastic Slip-->
 		<xsd:attribute name="elasticSlip" type="real64_array2d" />
-		<!--frictionCoefficient => Friction coefficient for each cell => Coulomb-->
+		<!--frictionCoefficient => Friction coefficient for each element-->
 		<xsd:attribute name="frictionCoefficient" type="real64_array" />
 	</xsd:complexType>
 	<xsd:complexType name="DamageElasticIsotropicType">

--- a/src/docs/doxygen/GeosxConfig.hpp
+++ b/src/docs/doxygen/GeosxConfig.hpp
@@ -44,6 +44,9 @@
 /// Enables use of MPI (CMake option ENABLE_MPI)
 #define GEOS_USE_MPI
 
+/// Enables detection of MPI desynchronization (CMake option ENABLE_MPI_DESYNC_DETECTION)
+#define GEOS_USE_MPI_DESYNC_DETECTION
+
 /// Enables use of OpenMP (CMake option ENABLE_OPENMP)
 #define GEOS_USE_OPENMP
 


### PR DESCRIPTION
The goal of this PR is to add a way to detect MPI desynchronizations.

MPI desynchronizations occur when an MPI operation is not called on all ranks (for example, due to an `if` condition or a `for` loop). When this happens, subsequent MPI operations may become non-blocking, potentially leading to incorrect results.

Identifying whether a desynchronization has occurred, and locating it, can be long.

This PR proposes mechanism to detect such desynchronizations. It also outputs the current stack trace when such desynchronization occurs.

---

### Implementation

The current approach adds an `Ibarrier` after every collective MPI call, combined with a `timeout()`. Ranks are trapped in a `while` loop until all ranks in the communicator have reached the `Ibarrier`. If the timeout expires before all ranks participated in the current collective MPI operation, we consider this a desynchronization.

---

### Compile option

This feature is currently behind a compile option (`-DGEOS_ENABLE_MPI_DESYNC_DETECTION=ON`).
All code related to the detection is behind guards, and doesn't get compiled if GEOS is not built with the compile option.

I am not anchored on this choice, neither for the implementation. I'm open to any proposition.

---

### Other solutions

Some external tools have already solved this problem, in a more optimized and elegant way. [PARCOACH](https://gitlab.inria.fr/parcoach/parcoach) and its [comprehensive paper of the solution](https://hal.science/hal-01078762/file/PARCOACH.pdf) combine static analysis to detect some desynchronizations + dynamic checks for the rest that couldn't be detected in the static analysis. This is a "heavier" approach as it requires to extract the intermediate representation (IR) of the code, but it could reasonably be integrated in a CI machine.