### PR TITLE
Fix AOCC shadow warning and VTK global ID SIGFPE

### DIFF
--- a/src/coreComponents/mesh/generators/VTKUtilities.cpp
+++ b/src/coreComponents/mesh/generators/VTKUtilities.cpp
@@ -199,6 +199,10 @@ generateGlobalIDs( vtkSmartPointer< vtkDataSet > mesh )
 {
   GEOS_MARK_FUNCTION;
 
+  // vtkGenerateGlobalIds may trigger floating-point exceptions internally
+  // Temporarily disable FPE trapping while invoking VTK.
+  LvArray::system::FloatingPointExceptionGuard guard;
+
   vtkNew< vtkGenerateGlobalIds > generator;
   generator->SetInputDataObject( mesh );
   generator->Update();

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsAugmentedLagrangianContact.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsAugmentedLagrangianContact.cpp
@@ -1257,7 +1257,7 @@ bool SolidMechanicsAugmentedLagrangianContact::updateConfiguration( DomainPartit
     {
       ElementRegionManager & elemManager = mesh.getElemManager();
 
-      elemManager.forElementSubRegions< FaceElementSubRegion >( regionNames, [m_symmetric=m_symmetric]( localIndex const,
+      elemManager.forElementSubRegions< FaceElementSubRegion >( regionNames, [symmetric = m_symmetric]( localIndex const,
                                                                                                         FaceElementSubRegion & subRegion )
       {
 
@@ -1293,7 +1293,7 @@ bool SolidMechanicsAugmentedLagrangianContact::updateConfiguration( DomainPartit
                                               oldDispJump,
                                               dispJump,
                                               iterativePenalty,
-                                              m_symmetric,
+                                              symmetric,
                                               normalTractionTolerance,
                                               traction,
                                               fractureState );


### PR DESCRIPTION
Pushed some changes that were needed to succesfully compile and pass unit tests in our environment (AOCC Compiler, AOCL). 

1. `src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsAugmentedLagrangianContact.cpp` - No functional behavior changes, only the capture variable name is updated to avoid shadowing the class member `m_symmetric`. AOCC treats the warning as an error due to `-Werror=shadow`
2. `src/coreComponents/mesh/generators/VTKUtilities.cpp` - `testSinglePhaseMFDPolyhedral` failed intermittently during mesh initialization. The failures occurred before solver setup and consistently originated from VTK while generating GlobalIds. Hence, Wrapping the call to `vtkGenerateGlobalIds::Update()` with `LvArray::system::FloatingPointExceptionGuard` to temporarily disable FPE trapping