### PR TITLE
fix: Global well residual norm calc

### DIFF
--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr3836-17046-2e89f64
+  baseline: integratedTests/baseline_integratedTests-pr4100-17125-aafd40
 
 allow_fail:
   all: ''

--- a/.integrated_tests.yaml
+++ b/.integrated_tests.yaml
@@ -1,6 +1,6 @@
 baselines:
   bucket: geosx
-  baseline: integratedTests/baseline_integratedTests-pr4100-17125-aafd40
+  baseline: integratedTests/baseline_integratedTests-pr4100-17125-aafd403
 
 allow_fail:
   all: ''

--- a/BASELINE_NOTES.md
+++ b/BASELINE_NOTES.md
@@ -5,8 +5,10 @@ This file is designed to track changes to the integrated test baselines.
 Any developer who updates the baseline ID in the .integrated_tests.yaml file is expected to create an entry in this file with the pull request number, date, and their justification for rebaselining.
 These notes should be in reverse-chronological order, and use the following time format: (YYYY-MM-DD).
 
+PR #4100 (2026-07-22) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr4100-17125-aafd403.tar.gz>
+Fix to include all well residuals in convergence check.
+
 PR #3836 (2026-05-20) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr3836-17046-2e89f64.tar.gz>
-=====================
 Added statistics `Group` objects for each statistics `Task` instance
 
 PR #4040 (2026-06-16) <https://storage.googleapis.com/geosx/integratedTests/baseline_integratedTests-pr4040-16993-1393f80.tar.gz>

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -1498,16 +1498,16 @@ CompositionalMultiphaseWell::calculateLocalWellResidualNorm( real64 const & time
 
   // step 1: compute the norm in the subRegion
 
-      if( !isWellOpen() )
-      {
-        for( integer i = 0; i < numNorm; ++i )
-        {
-          localResidualNormalizer[i] = m_nonlinearSolverParameters.m_minNormalizer;
-        }
-      }
-      else if( isThermal() )
-      {
-        real64 subRegionResidualNorm[2]{};
+  if( !isWellOpen() )
+  {
+    for( integer i = 0; i < numNorm; ++i )
+    {
+      localResidualNormalizer[i] = m_nonlinearSolverParameters.m_minNormalizer;
+    }
+  }
+  else if( isThermal() )
+  {
+    real64 subRegionResidualNorm[2]{};
 
     thermalCompositionalMultiphaseWellKernels::ResidualNormKernelFactory::
       createAndLaunch< parallelDevicePolicy<> >( m_numComponents,

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -1502,7 +1502,7 @@ CompositionalMultiphaseWell::calculateLocalWellResidualNorm( real64 const & time
   {
     for( integer i = 0; i < numNorm; ++i )
     {
-      localResidualNormalizer[i] = m_nonlinearSolverParameters.m_minNormalizer;
+      localResidualNormalizer[i] =  nonlinearSolverParameters.m_minNormalizer;
     }
   }
   else if( isThermal() )

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -1443,7 +1443,6 @@ CompositionalMultiphaseWell::calculateResidualNorm( real64 const & time_n,
       {
         for( integer i = 0; i < numNorm; ++i )
         {
-          localResidualNorm[i] = 0.0;
           localResidualNormalizer[i] = m_nonlinearSolverParameters.m_minNormalizer;
         }
       }


### PR DESCRIPTION
 If an open well had non converged residual followed by a shut well, the max well residual was set to zero, allowing global convergence with a non converged well, this is only an issue for compositional models.   The non convergence would be in the well segment flows.   Checks on material balance for reservoir cells with well perforations is not impacted by this bug.