### PR TITLE
Moving to C++23

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ cmake_policy(SET CMP0056 NEW) # use CMAKE_EXE_LINKER_FLAGS in try_compile() in a
 ################################
 project( geosx LANGUAGES C CXX )
 include(GNUInstallDirs)
-set( BLT_CXX_STD "c++17" CACHE STRING "Version of C++ standard" )
+set( BLT_CXX_STD "c++23" CACHE STRING "Version of C++ standard" )
 if(CMAKE_BUILD_TYPE EQUAL "Debug")
   set( ENABLE_WARNINGS_AS_ERRORS "OFF" CACHE PATH "")
 else()

--- a/src/cmake/GeosxOptions.cmake
+++ b/src/cmake/GeosxOptions.cmake
@@ -143,9 +143,9 @@ option( GEOS_ENABLE_WAVEPROPAGATION "Enables wave propagation physics package" O
 #message( "SPHINX_FOUND = ${SPHINX_FOUND}" )
 #message( "SPHINX_EXECUTABLE = ${SPHINX_EXECUTABLE}" )
 
-if( NOT BLT_CXX_STD STREQUAL c++17 )
-    MESSAGE( FATAL_ERROR "c++17 is NOT enabled. GEOSX requires c++17" )
-endif( NOT BLT_CXX_STD STREQUAL c++17 )
+if( NOT BLT_CXX_STD STREQUAL c++23 )
+    MESSAGE( FATAL_ERROR "c++23 is NOT enabled. GEOSX requires c++23" )
+endif( NOT BLT_CXX_STD STREQUAL c++23 )
 
 message( "CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}" )
 

--- a/src/coreComponents/functions/FunctionBase.hpp
+++ b/src/coreComponents/functions/FunctionBase.hpp
@@ -225,7 +225,7 @@ void FunctionBase::evaluateT( dataRepository::Group const & group,
                                   getDataContext() ) );
 
   arrayView1d< real64 const > const scale = m_inputVarScale.toViewConst();
-  forAll< POLICY >( set.size(), [=]( localIndex const i )
+  forAll< POLICY >( set.size(), [=, this]( localIndex const i )
   {
     localIndex const index = set[i];
     real64 input[MAX_VARS]{};

--- a/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraMatrix.cpp
+++ b/src/coreComponents/linearAlgebra/interfaces/trilinos/EpetraMatrix.cpp
@@ -1223,7 +1223,7 @@ real64 EpetraMatrix::normMax( arrayView1d< globalIndex const > const & rowIndice
   GEOS_LAI_ASSERT( ready() );
   globalIndex const firstLocalRow = ilower();
   RAJA::ReduceMax< parallelHostReduce, real64 > maxAbsValue( 0.0 );
-  forAll< parallelHostPolicy >( rowIndices.size(), [=]( int const i )
+  forAll< parallelHostPolicy >( rowIndices.size(), [=, this]( int const i )
   {
     int const localRow = LvArray::integerConversion< int >( rowIndices[i] - firstLocalRow );
     GEOS_ASSERT( 0 <= localRow && localRow < numLocalRows() );

--- a/src/coreComponents/mesh/CellElementSubRegion.cpp
+++ b/src/coreComponents/mesh/CellElementSubRegion.cpp
@@ -409,7 +409,7 @@ void CellElementSubRegion::calculateElementGeometricQuantities( NodeManager cons
 
   arrayView2d< real64 const, nodes::REFERENCE_POSITION_USD > const X = nodeManager.referencePosition();
 
-  forAll< parallelHostPolicy >( this->size(), [=] ( localIndex const k )
+  forAll< parallelHostPolicy >( this->size(), [=, this] ( localIndex const k )
   {
     calculateElementCenterAndVolume( k, X );
   } );

--- a/src/coreComponents/mesh/ElementSubRegionBase.hpp
+++ b/src/coreComponents/mesh/ElementSubRegionBase.hpp
@@ -277,7 +277,7 @@ protected:
     arrayView2d< real64 > const & elementCenters = m_elementCenter;
     auto const e2n = toNodesRelation.toViewConst();
 
-    forAll< parallelHostPolicy >( size(), [=]( localIndex const k )
+    forAll< parallelHostPolicy >( size(), [=, this]( localIndex const k )
     {
       // collect node coordinates for element k
       localIndex const numNodes = this->numNodesPerElement( k );

--- a/src/coreComponents/mesh/EmbeddedSurfaceSubRegion.cpp
+++ b/src/coreComponents/mesh/EmbeddedSurfaceSubRegion.cpp
@@ -81,7 +81,7 @@ void EmbeddedSurfaceSubRegion::calculateElementGeometricQuantities( NodeManager 
                                                                     FaceManager const & GEOS_UNUSED_PARAM( facemanager ) )
 {
   // loop over the elements
-  forAll< parallelHostPolicy >( this->size(), [=] ( localIndex const k )
+  forAll< parallelHostPolicy >( this->size(), [=, this] ( localIndex const k )
   {
     m_elementVolume[k] = m_elementAperture[k] * m_elementArea[k];
   } );

--- a/src/coreComponents/mesh/FaceElementSubRegion.cpp
+++ b/src/coreComponents/mesh/FaceElementSubRegion.cpp
@@ -236,7 +236,7 @@ void FaceElementSubRegion::calculateElementGeometricQuantities( NodeManager cons
 {
   arrayView1d< real64 const > const & faceArea = faceManager.faceArea();
 
-  forAll< parallelHostPolicy >( this->size(), [=] ( localIndex const k )
+  forAll< parallelHostPolicy >( this->size(), [=, this] ( localIndex const k )
   {
     calculateSingleElementGeometricQuantities( k, faceArea );
   } );

--- a/src/coreComponents/mesh/FaceManager.cpp
+++ b/src/coreComponents/mesh/FaceManager.cpp
@@ -285,7 +285,7 @@ void FaceManager::sortAllFaceNodes( NodeManager const & nodeManager,
   ElementRegionManager::ElementViewAccessor< arrayView2d< real64 const > > elemCenter =
     elemManager.constructArrayViewAccessor< real64, 2 >( ElementSubRegionBase::viewKeyStruct::elementCenterString() );
 
-  forAll< parallelHostPolicy >( size(), [=, elemCenter = elemCenter.toNestedViewConst()]( localIndex const faceIndex )
+  forAll< parallelHostPolicy >( size(), [=, this, elemCenter = elemCenter.toNestedViewConst()]( localIndex const faceIndex )
   {
     // The face should be connected to at least one element.
     if( facesToElements( faceIndex, 0 ) < 0 && facesToElements( faceIndex, 1 ) < 0 )

--- a/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/FlowSolverBase.cpp
@@ -654,7 +654,7 @@ void FlowSolverBase::updatePorosityAndPermeability( CellElementSubRegion & subRe
   string const & solidName = subRegion.getReference< string >( viewKeyStruct::solidNamesString() );
   CoupledSolidBase & porousSolid = subRegion.template getConstitutiveModel< CoupledSolidBase >( solidName );
 
-  constitutive::ConstitutivePassThru< CoupledSolidBase >::execute( porousSolid, [=, &subRegion] ( auto & castedPorousSolid )
+  constitutive::ConstitutivePassThru< CoupledSolidBase >::execute( porousSolid, [=, this, &subRegion] ( auto & castedPorousSolid )
   {
     typename TYPEOFREF( castedPorousSolid ) ::KernelWrapper porousWrapper = castedPorousSolid.createKernelUpdates();
     if( m_isFixedStressPoromechanicsUpdate )

--- a/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/SinglePhaseBase.cpp
@@ -601,7 +601,7 @@ void SinglePhaseBase::computeHydrostaticEquilibrium( DomainPartition & domain )
 
     RAJA::ReduceMin< parallelHostReduce, real64 > minPressure( LvArray::NumericLimits< real64 >::max );
 
-    forAll< parallelHostPolicy >( targetSet.size(), [=] GEOS_HOST_DEVICE ( localIndex const i )
+    forAll< parallelHostPolicy >( targetSet.size(), [=, this] GEOS_HOST_DEVICE ( localIndex const i )
     {
       localIndex const k = targetSet[i];
       real64 const elevation = elemCenter[k][2];

--- a/src/coreComponents/physicsSolvers/fluidFlow/proppantTransport/ProppantTransport.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/proppantTransport/ProppantTransport.cpp
@@ -362,7 +362,7 @@ void ProppantTransport::preStepUpdate( real64 const & time,
       arrayView1d< real64 > const excessPackVolume = subRegion.getField< proppant::proppantExcessPackVolume >();
       arrayView2d< real64 > const cellBasedFlux = subRegion.getField< proppant::cellBasedFlux >();
 
-      forAll< parallelDevicePolicy<> >( subRegion.size(), [=] GEOS_HOST_DEVICE ( localIndex const ei )
+      forAll< parallelDevicePolicy<> >( subRegion.size(), [=, this] GEOS_HOST_DEVICE ( localIndex const ei )
       {
         for( localIndex c = 0; c < m_numComponents; ++c )
         {
@@ -778,7 +778,7 @@ void ProppantTransport::applyBoundaryConditions( real64 const time_n,
         arrayView2d< real64 const > const bcCompConc =
           subRegion.getReference< array2d< real64 > >( proppant::bcComponentConcentration::key() );
 
-        forAll< parallelDevicePolicy<> >( targetSet.size(), [=] GEOS_HOST_DEVICE ( localIndex const a )
+        forAll< parallelDevicePolicy<> >( targetSet.size(), [=, this] GEOS_HOST_DEVICE ( localIndex const a )
         {
           localIndex const ei = targetSet[a];
           if( ghostRank[ei] >= 0 )

--- a/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
+++ b/src/coreComponents/physicsSolvers/fluidFlow/wells/CompositionalMultiphaseWell.cpp
@@ -1298,7 +1298,7 @@ void CompositionalMultiphaseWell::assembleAccumulationTerms( real64 const & time
         arrayView1d< integer const > const elemStatus = subRegion.getLocalWellElementStatus();
         arrayView1d< real64 > const mixConnRate = subRegion.getField< fields::well::mixtureConnectionRate >();
         localIndex rank_offset = dofManager.rankOffset();
-        forAll< parallelDevicePolicy<> >( subRegion.size(), [=] GEOS_HOST_DEVICE ( localIndex const ei )
+        forAll< parallelDevicePolicy<> >( subRegion.size(), [=, this] GEOS_HOST_DEVICE ( localIndex const ei )
         {
           if( wellElemGhostRank[ei] < 0 )
           {
@@ -1330,7 +1330,7 @@ void CompositionalMultiphaseWell::assembleAccumulationTerms( real64 const & time
           subRegion.getReference< array1d< globalIndex > >( wellDofKey );
         arrayView1d< integer const > const & wellElemGhostRank = subRegion.ghostRank();
         localIndex rank_offset = dofManager.rankOffset();
-        forAll< parallelDevicePolicy<> >( subRegion.size(), [=] GEOS_HOST_DEVICE ( localIndex const ei )
+        forAll< parallelDevicePolicy<> >( subRegion.size(), [=, this] GEOS_HOST_DEVICE ( localIndex const ei )
         {
           if( wellElemGhostRank[ei] < 0 )
           {

--- a/src/coreComponents/physicsSolvers/inducedSeismicity/ExplicitQDRateAndState.cpp
+++ b/src/coreComponents/physicsSolvers/inducedSeismicity/ExplicitQDRateAndState.cpp
@@ -220,7 +220,7 @@ void ExplicitQDRateAndState::updateSlipVelocity( real64 const & time_n,
     {
       string const & frictionLawName = subRegion.getReference< string >( viewKeyStruct::frictionLawNameString() );
       constitutive::ConstitutiveBase & frictionLaw = subRegion.getConstitutiveModel< constitutive::ConstitutiveBase >( frictionLawName );
-      constitutive::ConstitutivePassThru< constitutive::RateAndStateFrictionBase >::execute( frictionLaw, [=, &subRegion] ( auto & castedFrictionLaw )
+      constitutive::ConstitutivePassThru< constitutive::RateAndStateFrictionBase >::execute( frictionLaw, [=, this, &subRegion] ( auto & castedFrictionLaw )
       {
         // solve rate and state equations.
         rateAndStateKernels::createAndLaunch< rateAndStateKernels::ExplicitRateAndStateKernel,

--- a/src/coreComponents/physicsSolvers/inducedSeismicity/ImplicitQDRateAndState.cpp
+++ b/src/coreComponents/physicsSolvers/inducedSeismicity/ImplicitQDRateAndState.cpp
@@ -68,7 +68,7 @@ void ImplicitQDRateAndState::solveRateAndStateEquations( real64 const time_n,
     {
       string const & frictionLawName = subRegion.getReference< string >( viewKeyStruct::frictionLawNameString() );
       constitutive::ConstitutiveBase & frictionLaw = subRegion.getConstitutiveModel< constitutive::ConstitutiveBase >( frictionLawName );
-      constitutive::ConstitutivePassThru< constitutive::RateAndStateFrictionBase >::execute( frictionLaw, [=, &subRegion] ( auto & castedFrictionLaw )
+      constitutive::ConstitutivePassThru< constitutive::RateAndStateFrictionBase >::execute( frictionLaw, [=, this, &subRegion] ( auto & castedFrictionLaw )
       {
 
         // solve rate and state equations.

--- a/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/CoupledReservoirAndWellsBase.hpp
@@ -357,7 +357,7 @@ private:
           GEOS_UNUSED_VAR( resElemSubRegion ); // unused if geos_error_if is nulld
           GEOS_UNUSED_VAR( resElemIndex ); // unused if geos_error_if is nulld
 
-          forAll< serialPolicy >( perforationData.size(), [=] ( localIndex const iperf )
+          forAll< serialPolicy >( perforationData.size(), [=, this] ( localIndex const iperf )
           {
             GEOS_UNUSED_VAR( iperf ); // unused if geos_error_if is nulld
             GEOS_LOG_RANK( GEOS_FMT( "{}: perforation at ({},{},{}), perforated element center = ({},{},{}), transmissibility = {} [{}]",

--- a/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/HydrofractureSolver.cpp
@@ -1141,11 +1141,11 @@ void HydrofractureSolver< POROMECHANICS_SOLVER >::initializeNewFractureFields( r
       nodeManager.getField< solidMechanics::totalDisplacement >();
 
     elemManager.forElementRegions< SurfaceElementRegion >( regionNames,
-                                                           [=] ( localIndex const,
-                                                                 SurfaceElementRegion & region )
+                                                           [=, this] ( localIndex const,
+                                                                       SurfaceElementRegion & region )
     {
       real64 const defaultAperture = region.getDefaultAperture();
-      region.forElementSubRegions< FaceElementSubRegion >( [=]( FaceElementSubRegion & subRegion )
+      region.forElementSubRegions< FaceElementSubRegion >( [=, this]( FaceElementSubRegion & subRegion )
       {
         ArrayOfArraysView< localIndex const > const facesToEdges = subRegion.edgeList().toViewConst();
         ArrayOfArraysView< localIndex const > const & fractureConnectorsToFaceElements = subRegion.m_2dFaceTo2dElems.toViewConst();

--- a/src/coreComponents/physicsSolvers/multiphysics/PoromechanicsConformingFractures.hpp
+++ b/src/coreComponents/physicsSolvers/multiphysics/PoromechanicsConformingFractures.hpp
@@ -492,7 +492,7 @@ protected:
       arrayView1d< real64 const > const & pressure = subRegion.getReference< array1d< real64 > >( fields::flow::pressure::key() );
       arrayView2d< localIndex const > const & elemsToFaces = subRegion.faceList().toViewConst();
 
-      forAll< serialPolicy >( subRegion.size(), [=]( localIndex const kfe )
+      forAll< serialPolicy >( subRegion.size(), [=, this]( localIndex const kfe )
       {
         localIndex const kf0 = elemsToFaces[kfe][0];
         localIndex const numNodesPerFace = faceToNodeMap.sizeOfArray( kf0 );

--- a/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsMPM.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/SolidMechanicsMPM.cpp
@@ -2459,8 +2459,9 @@ void SolidMechanicsMPM::computeDamageFieldGradient( ParticleManager & particleMa
 
     // Loop over neighbors
     SortedArrayView< localIndex const > const activeParticleIndices = subRegion.activeParticleIndices();
-    forAll< serialPolicy >( activeParticleIndices.size(), [=] GEOS_HOST ( localIndex const pp ) // Must be on host since we call a 'this'
-                                                                                                // method which uses class variables
+    forAll< serialPolicy >( activeParticleIndices.size(), [=, this] GEOS_HOST ( localIndex const pp ) // Must be on host since we call a
+                                                                                                      // 'this' method which uses class
+                                                                                                      // variables
     {
       localIndex const p = activeParticleIndices[pp];
 
@@ -2819,7 +2820,7 @@ void SolidMechanicsMPM::initializeGridFields( NodeManager & nodeManager )
   arrayView3d< real64 > const gridSurfaceNormal = nodeManager.getReference< array3d< real64 > >( viewKeyStruct::surfaceNormalString() );
   arrayView3d< real64 > const gridMaterialPosition = nodeManager.getReference< array3d< real64 > >( viewKeyStruct::materialPositionString() );
 
-  forAll< serialPolicy >( numNodes, [=] GEOS_HOST ( localIndex const g ) // Switch to .zero()?
+  forAll< serialPolicy >( numNodes, [=, this] GEOS_HOST ( localIndex const g ) // Switch to .zero()?
   {
     for( int i = 0; i < 3; i++ )
     {
@@ -2903,10 +2904,12 @@ void SolidMechanicsMPM::particleToGrid( ParticleManager & particleManager,
     int const numDims = m_numDims;
     int voigtMap[3][3] = { {0, 5, 4}, {5, 1, 3}, {4, 3, 2} };
     int const damageFieldPartitioning = m_damageFieldPartitioning;
-    forAll< serialPolicy >( activeParticleIndices.size(), [=] GEOS_HOST ( localIndex const pp ) // Can be parallized using atomics -
-                                                                                                // remember to pass copies of class
-                                                                                                // variables
-    {                                                                                            // Grid max damage will require reduction
+    forAll< serialPolicy >( activeParticleIndices.size(), [=, this] GEOS_HOST ( localIndex const pp ) // Can be parallized using atomics -
+                                                                                                      // remember to pass copies of class
+                                                                                                      // variables
+                                                                                                      // Grid max damage will require
+                                                                                                      // reduction
+    {
       localIndex const p = activeParticleIndices[pp];
 
       for( int g = 0; g < 8 * numberOfVerticesPerParticle; g++ )
@@ -3376,8 +3379,9 @@ void SolidMechanicsMPM::computeSurfaceFlags( ParticleManager & particleManager )
 
     // Loop over neighbors
     SortedArrayView< localIndex const > const activeParticleIndices = subRegion.activeParticleIndices();
-    forAll< serialPolicy >( activeParticleIndices.size(), [=] GEOS_HOST ( localIndex const pp ) // Must be on host since we call a 'this'
-                                                                                                // method which uses class variables
+    forAll< serialPolicy >( activeParticleIndices.size(), [=, this] GEOS_HOST ( localIndex const pp ) // Must be on host since we call a
+                                                                                                      // 'this' method which uses class
+                                                                                                      // variables
     {
       localIndex const p = activeParticleIndices[pp];
 
@@ -3452,9 +3456,9 @@ void SolidMechanicsMPM::computeSphF( ParticleManager & particleManager )
 
     // Loop over neighbors
     SortedArrayView< localIndex const > const activeParticleIndices = subRegion.activeParticleIndices();
-    forAll< serialPolicy >( activeParticleIndices.size(), [=] GEOS_HOST ( localIndex const pp ) // I think this must be on host since we
-                                                                                                // call a 'this' method which uses class
-                                                                                                // variables
+    forAll< serialPolicy >( activeParticleIndices.size(), [=, this] GEOS_HOST ( localIndex const pp ) // I think this must be on host since
+                                                                                                      // we call a 'this' method which uses
+                                                                                                      // class variables
     {
       localIndex const p = activeParticleIndices[pp];
 

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsAugmentedLagrangianContact.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsAugmentedLagrangianContact.cpp
@@ -1454,7 +1454,7 @@ void SolidMechanicsAugmentedLagrangianContact::createFaceTypeList( DomainPartiti
     // Determine the size of the lists and generate the vector keys and vals for parallel indexing into lists.
     // (With RAJA, parallelizing this operation seems the most viable approach.)
     forAll< parallelHostPolicy >( subRegion.size(),
-                                  [ = ] GEOS_HOST ( localIndex const kfe )
+                                  [=, this] GEOS_HOST ( localIndex const kfe )
     {
       localIndex const kf0 = elemsToFaces[kfe][0];
       localIndex const numNodesPerFace = faceToNodeMap.sizeOfArray( kf0 );
@@ -1975,7 +1975,7 @@ void SolidMechanicsAugmentedLagrangianContact::computeTolerances( DomainPartitio
 
         arrayView1d< integer const > const ghostRank = subRegion.ghostRank();
 
-        forAll< parallelHostPolicy >( subRegion.size(), [=] ( localIndex const kfe )
+        forAll< parallelHostPolicy >( subRegion.size(), [=, this] ( localIndex const kfe )
         {
 
           if( ghostRank[kfe] < 0 )

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsLagrangeContact.cpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/SolidMechanicsLagrangeContact.cpp
@@ -533,7 +533,7 @@ void SolidMechanicsLagrangeContact::computeFaceDisplacementJump( DomainPartition
         arrayView1d< real64 > const slip = subRegion.getField< contact::slip >();
         arrayView1d< real64 > const aperture = subRegion.getField< elementAperture >();
 
-        forAll< parallelHostPolicy >( subRegion.size(), [=] ( localIndex const kfe )
+        forAll< parallelHostPolicy >( subRegion.size(), [=, this] ( localIndex const kfe )
         {
 
           // Contact constraints
@@ -713,7 +713,7 @@ void SolidMechanicsLagrangeContact::
     arrayView1d< real64 const > const & pressure = subRegion.getReference< array1d< real64 > >( flow::pressure::key() );
     arrayView2d< localIndex const > const & elemsToFaces = subRegion.faceList().toViewConst();
 
-    forAll< serialPolicy >( subRegion.size(), [=]( localIndex const kfe )
+    forAll< serialPolicy >( subRegion.size(), [=, this]( localIndex const kfe )
     {
       localIndex const kf0 = elemsToFaces[kfe][0];
       localIndex const numNodesPerFace = faceToNodeMap.sizeOfArray( kf0 );
@@ -1363,7 +1363,7 @@ void SolidMechanicsLagrangeContact::
     arrayView3d< real64 const > const & rotationMatrix = subRegion.getReference< array3d< real64 > >( viewKeyStruct::rotationMatrixString() );
     arrayView2d< localIndex const > const & elemsToFaces = subRegion.faceList().toViewConst();
 
-    forAll< parallelHostPolicy >( subRegion.size(), [=] ( localIndex const kfe )
+    forAll< parallelHostPolicy >( subRegion.size(), [=, this] ( localIndex const kfe )
     {
 
       localIndex const numNodesPerFace = faceToNodeMap.sizeOfArray( elemsToFaces[kfe][0] );
@@ -1491,7 +1491,7 @@ void SolidMechanicsLagrangeContact::
       using FrictionType = TYPEOFREF( castedFrictionLaw );
       typename FrictionType::KernelWrapper frictionWrapper = castedFrictionLaw.createKernelUpdates();
 
-      forAll< parallelHostPolicy >( subRegion.size(), [=] ( localIndex const kfe )
+      forAll< parallelHostPolicy >( subRegion.size(), [=, this] ( localIndex const kfe )
       {
 
 
@@ -1782,7 +1782,7 @@ void SolidMechanicsLagrangeContact::assembleStabilization( MeshLevel const & mes
   {
     typename SurfaceElementStencil::IndexContainerViewConstType const & sei = stencil.getElementIndices();
 
-    forAll< serialPolicy >( stencil.size(), [=] ( localIndex const iconn )
+    forAll< serialPolicy >( stencil.size(), [=, this] ( localIndex const iconn )
     {
       localIndex const numFluxElems = sei.sizeOfArray( iconn );
 
@@ -2264,7 +2264,7 @@ bool SolidMechanicsLagrangeContact::updateConfiguration( DomainPartition & domai
         using FrictionType = TYPEOFREF( castedFrictionLaw );
         typename FrictionType::KernelWrapper frictionWrapper = castedFrictionLaw.createKernelUpdates();
 
-        forAll< parallelHostPolicy >( subRegion.size(), [=, &subRegion] ( localIndex const kfe )
+        forAll< parallelHostPolicy >( subRegion.size(), [=, this, &subRegion] ( localIndex const kfe )
         {
           if( ghostRank[kfe] < 0 )
           {

--- a/src/coreComponents/physicsSolvers/solidMechanics/contact/kernels/SolidMechanicsLagrangeContactKernels.hpp
+++ b/src/coreComponents/physicsSolvers/solidMechanics/contact/kernels/SolidMechanicsLagrangeContactKernels.hpp
@@ -263,7 +263,7 @@ public:
                               localIndex const q,
                               StackVariables & stack ) const
   {
-    Base::quadraturePointKernel( k, q, stack, [ =, &stack ] ( real64 const detJ )
+    Base::quadraturePointKernel( k, q, stack, [=, this, &stack ] ( real64 const detJ )
     {
       stack.localRt[0] -= detJ * ( m_dispJump[k][0] - m_targetIncrementalJump[k][0] );
       stack.localRt[1] -= detJ * ( ( m_dispJump[k][1] - m_oldDispJump[k][1] ) - m_targetIncrementalJump[k][1] );

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/firstOrderEqn/isotropic/AcousticFirstOrderWaveEquationSEMKernel.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/firstOrderEqn/isotropic/AcousticFirstOrderWaveEquationSEMKernel.hpp
@@ -63,7 +63,7 @@ struct VelocityComputation
           arrayView2d< real32 > const velocity_y,
           arrayView2d< real32 > const velocity_z )
   {
-    forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const k )
+    forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const k )
     {
       // only the eight corners of the mesh cell are needed to compute the Jacobian
       real64 xLocal[8][3];
@@ -205,7 +205,7 @@ struct PressureComputation
 
     real64 const rickerValue = useSourceWaveletTables ? 0 : WaveSolverUtils::evaluateRicker( time_n, timeSourceFrequency, timeSourceDelay, rickerOrder );
 
-    forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const k )
+    forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const k )
     {
       // only the eight corners of the mesh cell are needed to compute the Jacobian
       real64 xLocal[8][3];

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/anisotropic/AcousticVTIWaveEquationSEMKernel.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/secondOrderEqn/anisotropic/AcousticVTIWaveEquationSEMKernel.hpp
@@ -210,7 +210,7 @@ struct MassMatrixKernel
           arrayView1d< real32 > const mass )
 
   {
-    forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const e )
+    forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const e )
     {
 
 
@@ -288,7 +288,7 @@ struct DampingMatrixKernel
           arrayView1d< real32 > const damping_pq,
           arrayView1d< real32 > const damping_qp )
   {
-    forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const e )
+    forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const e )
     {
       for( localIndex i = 0; i < elemsToFaces.size( 1 ); ++i )
       {

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/shared/AcousticMatricesSEMKernel.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/acoustic/shared/AcousticMatricesSEMKernel.hpp
@@ -57,7 +57,7 @@ struct AcousticMatricesSEM
                        arrayView1d< real32 > const mass )
 
     {
-      forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const e )
+      forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const e )
       {
 
         real32 const invC2 = 1.0 / ( density[e] * pow( velocity[e], 2 ) );
@@ -117,7 +117,7 @@ struct AcousticMatricesSEM
                           arrayView1d< real32 const > const density,
                           arrayView1d< real32 > const damping )
     {
-      forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const e )
+      forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const e )
       {
         for( localIndex i = 0; i < elemsToFaces.size( 1 ); ++i )
         {
@@ -186,7 +186,7 @@ struct AcousticMatricesSEM
                      arrayView1d< real32 > const grad2 )
 
     {
-      forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const e )
+      forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const e )
       {
         if( elemGhostRank[e]<0 )
         {
@@ -247,7 +247,7 @@ struct AcousticMatricesSEM
                              arrayView1d< real32 > const imag )
 
     {
-      forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const e )
+      forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const e )
       {
         if( elemGhostRank[e]<0 )
         {

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEMKernel.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/firstOrderEqn/isotropic/ElasticFirstOrderWaveEquationSEMKernel.hpp
@@ -105,7 +105,7 @@ struct StressComputation
 
   {
     real64 const rickerValue = useSourceWaveletTables ? 0 : WaveSolverUtils::evaluateRicker( time_n, timeSourceFrequency, timeSourceDelay, rickerOrder );
-    forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const k )
+    forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const k )
     {
       // only the eight corners of the mesh cell are needed to compute the Jacobian
       real64 xLocal[8][3];
@@ -305,7 +305,7 @@ struct VelocityComputation
       uz_np1[a] *= 1.0-((dt/2)*(dampingz[a]/mass[a]));
     } );
 
-    forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const k )
+    forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const k )
     {
       // only the eight corners of the mesh cell are needed to compute the Jacobian
       real64 xLocal[8][3];

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/secondOrderEqn/anisotropic/ElasticVTIWaveEquationSEMKernel.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/secondOrderEqn/anisotropic/ElasticVTIWaveEquationSEMKernel.hpp
@@ -109,7 +109,7 @@ struct ComputeTimeStep
     uxAuxView.zero();
     uyAuxView.zero();
     uzAuxView.zero();
-    forAll< EXEC_POLICY >( sizeElem, [=] GEOS_HOST_DEVICE ( localIndex const k )
+    forAll< EXEC_POLICY >( sizeElem, [=, this] GEOS_HOST_DEVICE ( localIndex const k )
     {
 
       real64 mu = density[k]*Vs[k]*Vs[k];
@@ -204,7 +204,7 @@ struct ComputeTimeStep
       uxAuxView.zero();
       uyAuxView.zero();
       uzAuxView.zero();
-      forAll< EXEC_POLICY >( sizeElem, [=] GEOS_HOST_DEVICE ( localIndex const k )
+      forAll< EXEC_POLICY >( sizeElem, [=, this] GEOS_HOST_DEVICE ( localIndex const k )
       {
 
         real64 mu = density[k]*Vs[k]*Vs[k];

--- a/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/shared/ElasticMatricesSEMKernel.hpp
+++ b/src/coreComponents/physicsSolvers/wavePropagation/sem/elastic/shared/ElasticMatricesSEMKernel.hpp
@@ -53,7 +53,7 @@ struct ElasticMatricesSEM
                        arrayView1d< real32 > const mass )
 
     {
-      forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const e )
+      forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const e )
       {
 
         // only the eight corners of the mesh cell are needed to compute the Jacobian
@@ -123,7 +123,7 @@ struct ElasticMatricesSEM
                           arrayView1d< real32 > const dampingy,
                           arrayView1d< real32 > const dampingz )
     {
-      forAll< EXEC_POLICY >( size, [=] GEOS_HOST_DEVICE ( localIndex const e )
+      forAll< EXEC_POLICY >( size, [=, this] GEOS_HOST_DEVICE ( localIndex const e )
       {
         for( localIndex i = 0; i < elemsToFaces.size( 1 ); ++i )
         {


### PR DESCRIPTION
A TPL branch would be needed:
- remove {fmt} (in favor of `std::format`)
- change the BLT and CXX_STANDARD flags to version 23 and modify compilers versions to ones that supports C++23