### PR TITLE
feature: speed up unit tests

### DIFF
--- a/scripts/test_submodule_updated.sh
+++ b/scripts/test_submodule_updated.sh
@@ -22,9 +22,6 @@ declare -ar pr_hashes_array=( $(git submodule status | awk '{print $1}') )
 # Initialize submodule paths
 declare -ar paths_array=( $(git submodule status | awk '{print $2}') )
 
-# Initialize differences between PR and origin/develop branches
-declare -ar diff_array=( $(git diff --name-only origin/develop) )
-
 # Initialize main branches for submodules
 declare -Ar main_branches=(
   ["blt"]="origin/develop"

--- a/src/coreComponents/constitutive/dispersion/DispersionBase.hpp
+++ b/src/coreComponents/constitutive/dispersion/DispersionBase.hpp
@@ -85,6 +85,9 @@ class DispersionBase : public ConstitutiveBase
 {
 public:
 
+  struct viewKeyStruct : public ConstitutiveBase::viewKeyStruct
+  {};
+
   /**
    * @brief Constructor for the abstract base class
    * @param[in] name the name of the class

--- a/src/coreComponents/constitutive/permeability/PermeabilityBase.hpp
+++ b/src/coreComponents/constitutive/permeability/PermeabilityBase.hpp
@@ -107,6 +107,9 @@ class PermeabilityBase : public ConstitutiveBase
 {
 public:
 
+  struct viewKeyStruct : public ConstitutiveBase::viewKeyStruct
+  {};
+
   PermeabilityBase( string const & name, dataRepository::Group * const parent );
 
   virtual void allocateConstitutiveData( dataRepository::Group & parent,

--- a/src/coreComponents/constitutive/thermalConductivity/SinglePhaseThermalConductivityBase.hpp
+++ b/src/coreComponents/constitutive/thermalConductivity/SinglePhaseThermalConductivityBase.hpp
@@ -96,6 +96,9 @@ class SinglePhaseThermalConductivityBase : public ConstitutiveBase
 {
 public:
 
+  struct viewKeyStruct : public ConstitutiveBase::viewKeyStruct
+  {};
+
   /**
    * @brief Constructor for the abstract base class
    * @param[in] name the name of the class

--- a/src/coreComponents/constitutive/unitTests/FluidModelTest.hpp
+++ b/src/coreComponents/constitutive/unitTests/FluidModelTest.hpp
@@ -132,6 +132,17 @@ public:
                                  real64 const relTol = relTolerance,
                                  real64 const absTol = absTolerance );
 
+  /**
+   * @brief Tests numerical derivatives for several independent test points in one update pass.
+   * @details This preserves the same finite-difference checks as the single-point overload while
+   *          avoiding repeated fluid allocation and cloning for each point.
+   */
+  void testNumericalDerivatives( FluidModel * fluid,
+                                 stdVector< TestPoint > const & data,
+                                 real64 const perturbationLevel = 1.0e-4,
+                                 real64 const relTol = relTolerance,
+                                 real64 const absTol = absTolerance );
+
 protected:
   /**
    * @brief Writes content to a file
@@ -251,6 +262,20 @@ protected:
                                real64 const relTol,
                                real64 const absTol,
                                INDICES const ... indices );
+
+  template< integer NDIM, typename ... INDICES, integer USD1, integer USD2, integer USD3,
+            typename=std::enable_if_t< sizeof ... ( INDICES ) == NDIM-2 > >
+  static void testDerivativesAtOffset( string const propName,
+                                       string const testValues,
+                                       ArrayView< real64 const, NDIM, USD1 > const & valueArray,
+                                       ArrayView< real64 const, NDIM+1, USD2 > const & derivArray,
+                                       ArraySlice< real64 const, 1, USD3 > const & displacements,
+                                       real64 const valueScale,
+                                       string_array const & dofNames,
+                                       real64 const relTol,
+                                       real64 const absTol,
+                                       integer const offset,
+                                       INDICES const ... indices );
 
 private:
   void createFunctionManager();

--- a/src/coreComponents/constitutive/unitTests/FluidModelTest_impl.hpp
+++ b/src/coreComponents/constitutive/unitTests/FluidModelTest_impl.hpp
@@ -172,20 +172,47 @@ void FluidModelTest< FLUID_TYPE, NUM_COMP, NUM_PHASE >::testDerivatives( string 
                                                                          real64 const absTol,
                                                                          INDICES const ... indices )
 {
+  testDerivativesAtOffset( propName,
+                           testPoint,
+                           valueArray,
+                           derivArray,
+                           displacements,
+                           valueScale,
+                           dofNames,
+                           relTol,
+                           absTol,
+                           0,
+                           indices ... );
+}
+
+template< typename FLUID_TYPE, integer NUM_COMP, integer NUM_PHASE >
+template< integer NDIM, typename ... INDICES, integer USD1, integer USD2, integer USD3, typename >
+void FluidModelTest< FLUID_TYPE, NUM_COMP, NUM_PHASE >::testDerivativesAtOffset( string const propName,
+                                                                                  string const testPoint,
+                                                                                  ArrayView< real64 const, NDIM, USD1 > const & valueArray,
+                                                                                  ArrayView< real64 const, NDIM+1, USD2 > const & derivArray,
+                                                                                  ArraySlice< real64 const, 1, USD3 > const & displacements,
+                                                                                  real64 const valueScale,
+                                                                                  string_array const & dofNames,
+                                                                                  real64 const relTol,
+                                                                                  real64 const absTol,
+                                                                                  integer const offset,
+                                                                                  INDICES const ... indices )
+{
   integer const numberOfDof = dofNames.size();
   real64 const invScale = 1.0 / valueScale;
 
   for( integer idof = 0; idof < numberOfDof; idof++ )
   {
-    real64 const analyticalDerivative = derivArray( 0, 0, indices ..., idof ) * invScale;
+    real64 const analyticalDerivative = derivArray( offset, 0, indices ..., idof ) * invScale;
     real64 numericalDerivative = 0.0;
 
-    real64 centreValue = valueArray( 0, 0, indices ... ) * invScale;
-    real64 rightValue = valueArray( 2*idof+1, 0, indices ... ) * invScale;
-    real64 leftValue = valueArray( 2*idof+2, 0, indices ... ) * invScale;
+    real64 centreValue = valueArray( offset, 0, indices ... ) * invScale;
+    real64 rightValue = valueArray( offset+2*idof+1, 0, indices ... ) * invScale;
+    real64 leftValue = valueArray( offset+2*idof+2, 0, indices ... ) * invScale;
 
-    real64 const dVr = displacements[2*idof+1];
-    real64 const dVl = displacements[2*idof+2];
+    real64 const dVr = displacements[offset+2*idof+1];
+    real64 const dVl = displacements[offset+2*idof+2];
 
     // Calculate the left, central and right derivative.
     // The selected numerical derivative will be the one nearest the analytical derivative
@@ -226,10 +253,25 @@ void FluidModelTest< FLUID_TYPE, NUM_COMP, NUM_PHASE >::testNumericalDerivatives
                                                                                   real64 const relTol,
                                                                                   real64 const absTol )
 {
+  stdVector< TestPoint > dataBatch;
+  dataBatch.emplace_back( data );
+  testNumericalDerivatives( fluid, dataBatch, perturbationLevel, relTol, absTol );
+}
+
+template< typename FLUID_TYPE, integer NUM_COMP, integer NUM_PHASE >
+void FluidModelTest< FLUID_TYPE, NUM_COMP, NUM_PHASE >::testNumericalDerivatives( FluidModel * fluid,
+                                                                                  stdVector< TestPoint > const & data,
+                                                                                  real64 const perturbationLevel,
+                                                                                  real64 const relTol,
+                                                                                  real64 const absTol )
+{
   using Deriv = constitutive::multifluid::DerivativeOffset;
 
-  // Number of execution points actual value plus left and right pertubations for each variable
-  integer constexpr size = 2*numDof + 1;
+  // Number of execution points for one test point: actual value plus left and right
+  // perturbations for each variable.
+  integer constexpr pointsSize = 2*numDof + 1;
+  integer const numberOfPoints = data.size();
+  integer const size = numberOfPoints * pointsSize;
   m_parent.resize( size );
   fluid->allocateConstitutiveData( m_parent, 1 );
 
@@ -245,46 +287,51 @@ void FluidModelTest< FLUID_TYPE, NUM_COMP, NUM_PHASE >::testNumericalDerivatives
   string_array const & phaseNames = fluid->phaseNames();
   string_array const & componentNames = fluid->componentNames();
 
-  auto const & [pressure, temperature, composition] = data;
-  for( integer i = 0; i < size; ++i )
+  for( integer pointIndex = 0; pointIndex < numberOfPoints; ++pointIndex )
   {
-    pressureArray[i] = pressure;
-    temperatureArray[i] = temperature;
+    integer const offset = pointIndex * pointsSize;
+    auto const & [pressure, temperature, composition] = data[pointIndex];
+
+    for( integer i = 0; i < pointsSize; ++i )
+    {
+      pressureArray[offset+i] = pressure;
+      temperatureArray[offset+i] = temperature;
+      for( integer ic = 0; ic < numComp; ++ic )
+      {
+        compositionArray( offset+i, ic ) = composition[ic];
+      }
+    }
+
+    real64 const dP = perturbationLevel * (pressure + perturbationLevel);
+    deltaArray[offset+2*Deriv::dP+1] = dP;
+    deltaArray[offset+2*Deriv::dP+2] = -dP;
+    pressureArray[offset+2*Deriv::dP+1] += deltaArray[offset+2*Deriv::dP+1];
+    pressureArray[offset+2*Deriv::dP+2] += deltaArray[offset+2*Deriv::dP+2];
+
+    real64 const dT = perturbationLevel * (temperature + perturbationLevel);
+    deltaArray[offset+2*Deriv::dT+1] = dT;
+    deltaArray[offset+2*Deriv::dT+2] = -dT;
+    temperatureArray[offset+2*Deriv::dT+1] += deltaArray[offset+2*Deriv::dT+1];
+    temperatureArray[offset+2*Deriv::dT+2] += deltaArray[offset+2*Deriv::dT+2];
+
     for( integer ic = 0; ic < numComp; ++ic )
     {
-      compositionArray( i, ic ) = composition[ic];
+      integer const idof = Deriv::dC+ic;
+      real64 const dz = LvArray::math::max( 1.0e-7, perturbationLevel * ( composition[ic] + perturbationLevel ) );
+      deltaArray[offset+2*idof+1] = dz;
+      deltaArray[offset+2*idof+2] = -dz;
+      compositionArray( offset+2*idof+1, ic ) += deltaArray[offset+2*idof+1];
+      compositionArray( offset+2*idof+2, ic ) += deltaArray[offset+2*idof+2];
+      compositionArray( offset+2*idof+1, ic ) = LvArray::math::min( compositionArray( offset+2*idof+1, ic ), 1.0 );
+      compositionArray( offset+2*idof+2, ic ) = LvArray::math::max( compositionArray( offset+2*idof+2, ic ), 0.0 );
     }
   }
 
-  string const testValues = GEOS_FMT( "Pressure: {}, Temperature: {}, Composition: {}",
-                                      pressureArray[0],
-                                      temperatureArray[0],
-                                      toString( compositionArray[0].toSliceConst() ) );
-
-  real64 const dP = perturbationLevel * (pressure + perturbationLevel);
-  deltaArray[2*Deriv::dP+1] = dP;
-  deltaArray[2*Deriv::dP+2] = -dP;
-  pressureArray[2*Deriv::dP+1] += deltaArray[2*Deriv::dP+1];
-  pressureArray[2*Deriv::dP+2] += deltaArray[2*Deriv::dP+2];
   dofNames[Deriv::dP] = "pressure";
-
-  real64 const dT = perturbationLevel * (temperature + perturbationLevel);
-  deltaArray[2*Deriv::dT+1] = dT;
-  deltaArray[2*Deriv::dT+2] = -dT;
-  temperatureArray[2*Deriv::dT+1] += deltaArray[2*Deriv::dT+1];
-  temperatureArray[2*Deriv::dT+2] += deltaArray[2*Deriv::dT+2];
   dofNames[Deriv::dT] = "temperature";
-
   for( integer ic = 0; ic < numComp; ++ic )
   {
     integer const idof = Deriv::dC+ic;
-    real64 const dz = LvArray::math::max( 1.0e-7, perturbationLevel * ( composition[ic] + perturbationLevel ) );
-    deltaArray[2*idof+1] = dz;
-    deltaArray[2*idof+2] = -dz;
-    compositionArray( 2*idof+1, ic ) += deltaArray[2*idof+1];
-    compositionArray( 2*idof+2, ic ) += deltaArray[2*idof+2];
-    compositionArray( 2*idof+1, ic ) = LvArray::math::min( compositionArray( 2*idof+1, ic ), 1.0 );
-    compositionArray( 2*idof+2, ic ) = LvArray::math::max( compositionArray( 2*idof+2, ic ), 0.0 );
     dofNames[idof] = GEOS_FMT( "z({})", componentNames[ic] );
   }
 
@@ -320,95 +367,112 @@ void FluidModelTest< FLUID_TYPE, NUM_COMP, NUM_PHASE >::testNumericalDerivatives
   // reference enthalpy value to bring them to a more manageable scale.
   real64 constexpr referenceEnthalpy = 5.0584e5;
 
-  for( integer phaseIndex = 0; phaseIndex < numPhase; phaseIndex++ )
+  for( integer pointIndex = 0; pointIndex < numberOfPoints; ++pointIndex )
   {
-    testDerivatives( GEOS_FMT( "Phase fraction ({})", phaseNames[phaseIndex] ),
-                     testValues,
-                     fluidCopy->phaseFraction().toViewConst(),
-                     fluidCopy->dPhaseFraction().toViewConst(),
-                     deltaArray.toSliceConst(),
-                     1.0,
-                     dofNames,
-                     relTol,
-                     absTol,
-                     phaseIndex );
-    testDerivatives( GEOS_FMT( "Phase density ({})", phaseNames[phaseIndex] ),
-                     testValues,
-                     fluidCopy->phaseDensity().toViewConst(),
-                     fluidCopy->dPhaseDensity().toViewConst(),
-                     deltaArray.toSliceConst(),
-                     1.0,
-                     dofNames,
-                     relTol,
-                     absTol,
-                     phaseIndex );
-    testDerivatives( GEOS_FMT( "Phase mass density ({})", phaseNames[phaseIndex] ),
-                     testValues,
-                     fluidCopy->phaseMassDensity().toViewConst(),
-                     fluidCopy->dPhaseMassDensity().toViewConst(),
-                     deltaArray.toSliceConst(),
-                     1.0,
-                     dofNames,
-                     relTol,
-                     absTol,
-                     phaseIndex );
-    testDerivatives( GEOS_FMT( "Phase viscosity ({})", phaseNames[phaseIndex] ),
-                     testValues,
-                     fluidCopy->phaseViscosity().toViewConst(),
-                     fluidCopy->dPhaseViscosity().toViewConst(),
-                     deltaArray.toSliceConst(),
-                     1.0,
-                     dofNames,
-                     relTol,
-                     absTol,
-                     phaseIndex );
-    if( isThermal )
+    integer const offset = pointIndex * pointsSize;
+    string const testValues = GEOS_FMT( "Pressure: {}, Temperature: {}, Composition: {}",
+                                        pressureArray[offset],
+                                        temperatureArray[offset],
+                                        toString( compositionArray[offset].toSliceConst() ) );
+
+    for( integer phaseIndex = 0; phaseIndex < numPhase; phaseIndex++ )
     {
-      testDerivatives( GEOS_FMT( "Phase enthalpy ({})", phaseNames[phaseIndex] ),
-                       testValues,
-                       fluidCopy->phaseEnthalpy().toViewConst(),
-                       fluidCopy->dPhaseEnthalpy().toViewConst(),
-                       deltaArray.toSliceConst(),
-                       referenceEnthalpy,
-                       dofNames,
-                       relTol,
-                       absTol,
-                       phaseIndex );
-      testDerivatives( GEOS_FMT( "Phase internal energy ({})", phaseNames[phaseIndex] ),
-                       testValues,
-                       fluidCopy->phaseInternalEnergy().toViewConst(),
-                       fluidCopy->dPhaseInternalEnergy().toViewConst(),
-                       deltaArray.toSliceConst(),
-                       referenceEnthalpy,
-                       dofNames,
-                       relTol,
-                       absTol,
-                       phaseIndex );
+      testDerivativesAtOffset( GEOS_FMT( "Phase fraction ({})", phaseNames[phaseIndex] ),
+                               testValues,
+                               fluidCopy->phaseFraction().toViewConst(),
+                               fluidCopy->dPhaseFraction().toViewConst(),
+                               deltaArray.toSliceConst(),
+                               1.0,
+                               dofNames,
+                               relTol,
+                               absTol,
+                               offset,
+                               phaseIndex );
+      testDerivativesAtOffset( GEOS_FMT( "Phase density ({})", phaseNames[phaseIndex] ),
+                               testValues,
+                               fluidCopy->phaseDensity().toViewConst(),
+                               fluidCopy->dPhaseDensity().toViewConst(),
+                               deltaArray.toSliceConst(),
+                               1.0,
+                               dofNames,
+                               relTol,
+                               absTol,
+                               offset,
+                               phaseIndex );
+      testDerivativesAtOffset( GEOS_FMT( "Phase mass density ({})", phaseNames[phaseIndex] ),
+                               testValues,
+                               fluidCopy->phaseMassDensity().toViewConst(),
+                               fluidCopy->dPhaseMassDensity().toViewConst(),
+                               deltaArray.toSliceConst(),
+                               1.0,
+                               dofNames,
+                               relTol,
+                               absTol,
+                               offset,
+                               phaseIndex );
+      testDerivativesAtOffset( GEOS_FMT( "Phase viscosity ({})", phaseNames[phaseIndex] ),
+                               testValues,
+                               fluidCopy->phaseViscosity().toViewConst(),
+                               fluidCopy->dPhaseViscosity().toViewConst(),
+                               deltaArray.toSliceConst(),
+                               1.0,
+                               dofNames,
+                               relTol,
+                               absTol,
+                               offset,
+                               phaseIndex );
+      if( isThermal )
+      {
+        testDerivativesAtOffset( GEOS_FMT( "Phase enthalpy ({})", phaseNames[phaseIndex] ),
+                                 testValues,
+                                 fluidCopy->phaseEnthalpy().toViewConst(),
+                                 fluidCopy->dPhaseEnthalpy().toViewConst(),
+                                 deltaArray.toSliceConst(),
+                                 referenceEnthalpy,
+                                 dofNames,
+                                 relTol,
+                                 absTol,
+                                 offset,
+                                 phaseIndex );
+        testDerivativesAtOffset( GEOS_FMT( "Phase internal energy ({})", phaseNames[phaseIndex] ),
+                                 testValues,
+                                 fluidCopy->phaseInternalEnergy().toViewConst(),
+                                 fluidCopy->dPhaseInternalEnergy().toViewConst(),
+                                 deltaArray.toSliceConst(),
+                                 referenceEnthalpy,
+                                 dofNames,
+                                 relTol,
+                                 absTol,
+                                 offset,
+                                 phaseIndex );
+      }
+      for( integer compIndex = 0; compIndex < numComp; compIndex++ )
+      {
+        testDerivativesAtOffset( GEOS_FMT( "Phase composition ({} {})", phaseNames[phaseIndex], componentNames[compIndex] ),
+                                 testValues,
+                                 fluidCopy->phaseCompFraction().toViewConst(),
+                                 fluidCopy->dPhaseCompFraction().toViewConst(),
+                                 deltaArray.toSliceConst(),
+                                 1.0,
+                                 dofNames,
+                                 relTol,
+                                 absTol,
+                                 offset,
+                                 phaseIndex,
+                                 compIndex );
+      }
     }
-    for( integer compIndex = 0; compIndex < numComp; compIndex++ )
-    {
-      testDerivatives( GEOS_FMT( "Phase composition ({} {})", phaseNames[phaseIndex], componentNames[compIndex] ),
-                       testValues,
-                       fluidCopy->phaseCompFraction().toViewConst(),
-                       fluidCopy->dPhaseCompFraction().toViewConst(),
-                       deltaArray.toSliceConst(),
-                       1.0,
-                       dofNames,
-                       relTol,
-                       absTol,
-                       phaseIndex,
-                       compIndex );
-    }
+    testDerivativesAtOffset( "Total density",
+                             testValues,
+                             fluidCopy->totalDensity().toViewConst(),
+                             fluidCopy->dTotalDensity().toViewConst(),
+                             deltaArray.toSliceConst(),
+                             1.0,
+                             dofNames,
+                             relTolerance,
+                             absTolerance,
+                             offset );
   }
-  testDerivatives( "Total density",
-                   testValues,
-                   fluidCopy->totalDensity().toViewConst(),
-                   fluidCopy->dTotalDensity().toViewConst(),
-                   deltaArray.toSliceConst(),
-                   1.0,
-                   dofNames,
-                   relTolerance,
-                   absTolerance );
 }
 
 template< typename FLUID_TYPE, integer NUM_COMP, integer NUM_PHASE >

--- a/src/coreComponents/constitutive/unitTests/FluidModelTest_impl.hpp
+++ b/src/coreComponents/constitutive/unitTests/FluidModelTest_impl.hpp
@@ -188,16 +188,16 @@ void FluidModelTest< FLUID_TYPE, NUM_COMP, NUM_PHASE >::testDerivatives( string 
 template< typename FLUID_TYPE, integer NUM_COMP, integer NUM_PHASE >
 template< integer NDIM, typename ... INDICES, integer USD1, integer USD2, integer USD3, typename >
 void FluidModelTest< FLUID_TYPE, NUM_COMP, NUM_PHASE >::testDerivativesAtOffset( string const propName,
-                                                                                  string const testPoint,
-                                                                                  ArrayView< real64 const, NDIM, USD1 > const & valueArray,
-                                                                                  ArrayView< real64 const, NDIM+1, USD2 > const & derivArray,
-                                                                                  ArraySlice< real64 const, 1, USD3 > const & displacements,
-                                                                                  real64 const valueScale,
-                                                                                  string_array const & dofNames,
-                                                                                  real64 const relTol,
-                                                                                  real64 const absTol,
-                                                                                  integer const offset,
-                                                                                  INDICES const ... indices )
+                                                                                 string const testPoint,
+                                                                                 ArrayView< real64 const, NDIM, USD1 > const & valueArray,
+                                                                                 ArrayView< real64 const, NDIM+1, USD2 > const & derivArray,
+                                                                                 ArraySlice< real64 const, 1, USD3 > const & displacements,
+                                                                                 real64 const valueScale,
+                                                                                 string_array const & dofNames,
+                                                                                 real64 const relTol,
+                                                                                 real64 const absTol,
+                                                                                 integer const offset,
+                                                                                 INDICES const ... indices )
 {
   integer const numberOfDof = dofNames.size();
   real64 const invScale = 1.0 / valueScale;

--- a/src/coreComponents/constitutive/unitTests/testDruckerPrager.cpp
+++ b/src/coreComponents/constitutive/unitTests/testDruckerPrager.cpp
@@ -110,16 +110,16 @@ void testDruckerPragerDriver()
   data.strainIncrement[0] = -1e-4;
   real64 timeIncrement = 0;
 
-  for( localIndex loadstep=0; loadstep < 50; ++loadstep )
+  forAll< POLICY >( 1, [=] GEOS_HOST_DEVICE ( localIndex const k )
   {
-    forAll< POLICY >( 1, [=] GEOS_HOST_DEVICE ( localIndex const k )
+    for( localIndex loadstep=0; loadstep < 50; ++loadstep )
     {
       real64 stress[6] = {0};
       real64 stiffness[6][6] = {{0}};
       cmw.smallStrainUpdate( k, 0, timeIncrement, data.strainIncrement, stress, stiffness );
-    } );
-    cm.saveConvergedState();
-  }
+      cmw.saveConvergedState( k, 0 );
+    }
+  } );
 
   real64 stress[6] = {0};
   getStress( cmw, stress );
@@ -225,31 +225,27 @@ void testDruckerPragerExtendedDriver()
   StrainData data;
   real64 timeIncrement = 0;
   data.strainIncrement[0] = -1e-3;
-  real64 invariantP, invariantQ;
-  real64 deviator[6] = {0};
-
-  //FILE* fp = fopen("pq.txt","w");
-  for( localIndex loadstep=0; loadstep < 300; ++loadstep )
+  forAll< POLICY >( 1, [=] GEOS_HOST_DEVICE ( localIndex const k )
   {
-    forAll< POLICY >( 1, [=] GEOS_HOST_DEVICE ( localIndex const k )
+    for( localIndex loadstep=0; loadstep < 300; ++loadstep )
     {
       real64 stress[6] = {0};
       real64 stiffness[6][6] = {{0}};
       cmw.smallStrainUpdate( k, 0, timeIncrement, data.strainIncrement, stress, stiffness );
-    } );
+      cmw.saveConvergedState( k, 0 );
+    }
+  } );
 
-    cm.saveConvergedState();
+  real64 stress[6] = {0};
+  getStress( cmw, stress );
 
-    real64 stress[6] = {0};
-    getStress( cmw, stress );
+  real64 invariantP, invariantQ;
+  real64 deviator[6] = {0};
 
-    twoInvariant::stressDecomposition( stress,
-                                       invariantP,
-                                       invariantQ,
-                                       deviator );
-    //fprintf(fp,"%.4e %.4e %.4e\n",invariantP,invariantQ,total);
-  }
-  //fclose(fp);
+  twoInvariant::stressDecomposition( stress,
+                                     invariantP,
+                                     invariantQ,
+                                     deviator );
 
   // loading was set up to drive to residual strength, at which
   // point the Q/(P-P0) ratio should equal the slope of residual yield surface:

--- a/src/coreComponents/constitutive/unitTests/testInverseCapillaryPressure.cpp
+++ b/src/coreComponents/constitutive/unitTests/testInverseCapillaryPressure.cpp
@@ -48,6 +48,22 @@ using TestData = std::tuple<
   real64 const                             // Permeability (mD) (if required)
   >;
 
+struct InverseCapillaryPressureTestState
+{
+  conduit::Node m_node;
+  std::unique_ptr< Group > m_parent{};
+  std::unique_ptr< FunctionManager > m_functionManager{};
+  std::unique_ptr< ConstitutiveManager > m_constitutiveManager{};
+
+  InverseCapillaryPressureTestState();
+};
+
+static InverseCapillaryPressureTestState & getInverseCapillaryPressureTestState()
+{
+  static InverseCapillaryPressureTestState state;
+  return state;
+}
+
 template< typename CAP_PRESSURE, integer NUM_PHASE=2 >
 class InverseCapillaryPressureTestFixture : public ::testing::TestWithParam< TestData< NUM_PHASE > >
 {
@@ -61,14 +77,19 @@ public:
   void testInversion( TestData< NUM_PHASE > const & testData );
 
 private:
-  conduit::Node m_node;
-  std::unique_ptr< Group > m_parent{};
-  std::unique_ptr< FunctionManager > m_functionManager{};
-  std::unique_ptr< ConstitutiveManager > m_constitutiveManager{};
+  static InverseCapillaryPressureTestState & getState()
+  {
+    return getInverseCapillaryPressureTestState();
+  }
 };
 
 template< typename CAP_PRESSURE, integer NUM_PHASE >
 InverseCapillaryPressureTestFixture< CAP_PRESSURE, NUM_PHASE >::InverseCapillaryPressureTestFixture()
+{
+  getState();
+}
+
+InverseCapillaryPressureTestState::InverseCapillaryPressureTestState()
   : m_parent( std::make_unique< Group >( "parent", m_node )),
   m_functionManager( std::make_unique< FunctionManager >( FunctionManager::catalogName(), m_parent.get() )),
   m_constitutiveManager( std::make_unique< ConstitutiveManager >( ConstitutiveManager::groupKeyStruct::constitutiveModelsString(), m_parent.get() ))
@@ -143,6 +164,7 @@ template< typename CAP_PRESSURE, integer NUM_PHASE >
 void
 InverseCapillaryPressureTestFixture< CAP_PRESSURE, NUM_PHASE >::testInversion( TestData< NUM_PHASE > const & testData )
 {
+  InverseCapillaryPressureTestState & state = getState();
   StackArray< real64, 2, NUM_PHASE, compflow::LAYOUT_PHASE > phaseVolumeFraction( 1, NUM_PHASE );
   StackArray< real64, 3, NUM_PHASE, constitutive::cappres::LAYOUT_CAPPRES > capillaryPressure( 1, 1, NUM_PHASE );
   StackArray< real64, 1, NUM_PHASE > jFunctionMultiplier( NUM_PHASE-1 );
@@ -157,11 +179,11 @@ InverseCapillaryPressureTestFixture< CAP_PRESSURE, NUM_PHASE >::testInversion( T
   }
 
   string const modelName = GEOS_FMT( "{}{}", CapPressureModel::catalogName(), NUM_PHASE );
-  CapPressureModel & model = m_constitutiveManager->getConstitutiveRelation< CapPressureModel >( modelName );
+  CapPressureModel & model = state.m_constitutiveManager->template getConstitutiveRelation< CapPressureModel >( modelName );
 
   if constexpr (std::is_same_v< CapPressureModel, JFunctionCapillaryPressure >)
   {
-    model.allocateConstitutiveData( *m_constitutiveManager, 2 );
+    model.allocateConstitutiveData( *state.m_constitutiveManager, 2 );
     array3d< real64 > perm( 1, 1, 3 );
     array2d< real64 > poro( 1, 2 );
     perm( 0, 0, 0 ) = permeability;

--- a/src/coreComponents/constitutive/unitTests/testModifiedCamClay.cpp
+++ b/src/coreComponents/constitutive/unitTests/testModifiedCamClay.cpp
@@ -135,16 +135,16 @@ void testModifiedCamClayDriver()
 
   // run loading
 
-  for( localIndex loadstep=0; loadstep < 500; ++loadstep )
+  forAll< POLICY >( 1, [=] GEOS_HOST_DEVICE ( localIndex const k )
   {
-    forAll< POLICY >( 1, [=] GEOS_HOST_DEVICE ( localIndex const k )
+    for( localIndex loadstep=0; loadstep < 500; ++loadstep )
     {
       real64 stressLocal[6] = {0};
       real64 stiffnessLocal[6][6] = {{0}};
       cmw.smallStrainUpdate( k, 0, timeIncrement, data.strainIncrement, stressLocal, stiffnessLocal );
-    } );
-    cm.saveConvergedState();
-  }
+      cmw.saveConvergedState( k, 0 );
+    }
+  } );
 
   // get final stress state in p-q space
 
@@ -162,8 +162,6 @@ void testModifiedCamClayDriver()
 
   // we now use a finite-difference check of tangent stiffness to confirm
   // the analytical form is working properly.
-
-  SolidUtilities::checkSmallStrainStiffness( cmw, 0, 0, timeIncrement, data.strainIncrement, true );
 
   EXPECT_TRUE( SolidUtilities::checkSmallStrainStiffness( cmw, 0, 0, timeIncrement, data.strainIncrement ) );
 }

--- a/src/coreComponents/constitutive/unitTests/testMultiFluidBlackOil.cpp
+++ b/src/coreComponents/constitutive/unitTests/testMultiFluidBlackOil.cpp
@@ -154,10 +154,7 @@ TEST_F( MultiFluidBlackOilTestMass, numericalDerivatives )
 
   real64 constexpr eps = 1.0e-6;
 
-  for( auto const & data : getTestData< MultiFluidBlackOilTestMass >())
-  {
-    Base::testNumericalDerivatives( fluid, data, eps );
-  }
+  Base::testNumericalDerivatives( fluid, getTestData< MultiFluidBlackOilTestMass >(), eps );
 }
 
 TEST_F( MultiFluidBlackOilTestMolar, numericalDerivatives )
@@ -166,10 +163,7 @@ TEST_F( MultiFluidBlackOilTestMolar, numericalDerivatives )
 
   real64 constexpr eps = 1.0e-6;
 
-  for( auto const & data : getTestData< MultiFluidBlackOilTestMolar >())
-  {
-    Base::testNumericalDerivatives( fluid, data, eps );
-  }
+  Base::testNumericalDerivatives( fluid, getTestData< MultiFluidBlackOilTestMolar >(), eps );
 }
 
 TEST_P( MultiFluidBlackOilTestMolar, testFluidValues )

--- a/src/coreComponents/constitutive/unitTests/testMultiFluidCO2Brine.cpp
+++ b/src/coreComponents/constitutive/unitTests/testMultiFluidCO2Brine.cpp
@@ -137,6 +137,8 @@ public:
     constexpr real64 temperatures[] = { 367.65, 368.00, 368.75 };
     constexpr real64 pressures[] = { 20.01e5, 75.01e5, 120.1e5 };
     auto const samples = { Feed< 2 >{0.7, 0.3}, Feed< 2 >{0.01, 0.99}, Feed< 2 >{0.99, 0.01} };
+    stdVector< typename Base::TestPoint > testData;
+    testData.reserve( 27 );
 
     for( auto const & sample : samples )
     {
@@ -144,11 +146,11 @@ public:
       {
         for( real64 const temperature : temperatures )
         {
-          typename Base::TestPoint const data ( pressure, temperature, sample );
-          Base::testNumericalDerivatives( fluid, data, eps );
+          testData.emplace_back( pressure, temperature, sample );
         }
       }
     }
+    Base::testNumericalDerivatives( fluid, testData, eps );
   }
 
   static string getFluidName();

--- a/src/coreComponents/constitutive/unitTests/testMultiFluidDeadOil.cpp
+++ b/src/coreComponents/constitutive/unitTests/testMultiFluidDeadOil.cpp
@@ -226,12 +226,14 @@ TYPED_TEST_SUITE( MultiFluidDeadOilTestFixture, TestTypes, NameGenerator );
 TYPED_TEST( MultiFluidDeadOilTestFixture, numericalDerivatives )
 {
   DeadOilFluid * fluid = this->getFluid( this->getFluidName() );
+  stdVector< typename TestFixture::Base::TestPoint > testData;
+  testData.reserve( 3 );
 
   for( real64 const pressure : { 1.24e7, 3.21e7, 5.01e7 } )
   {
-    typename TestFixture::Base::TestPoint const data ( pressure, 297.15, { 0.1, 0.3, 0.6 } );
-    TestFixture::Base::testNumericalDerivatives( fluid, data );
+    testData.emplace_back( pressure, 297.15, Feed< 3 >{ 0.1, 0.3, 0.6 } );
   }
+  TestFixture::Base::testNumericalDerivatives( fluid, testData );
 }
 
 } // testing

--- a/src/coreComponents/constitutive/unitTests/testMultiFluidThreePhaseCompositionalMultiphase.cpp
+++ b/src/coreComponents/constitutive/unitTests/testMultiFluidThreePhaseCompositionalMultiphase.cpp
@@ -68,6 +68,8 @@ public:
 
     constexpr real64 pressures[] = { 10.0e5, 50.0e5, 100.0e5, 600.0e5 };
     constexpr real64 temperatures[] = { 15.5, 24.0, 40.0, 80.0 };
+    stdVector< typename Base::TestPoint > testData;
+    testData.reserve( sampleCount * 16 );
 
     for( integer sampleIndex = 0; sampleIndex < sampleCount; ++sampleIndex )
     {
@@ -79,11 +81,11 @@ public:
       {
         for( real64 const temperature : temperatures )
         {
-          typename Base::TestPoint const data ( pressure, units::convertCToK( temperature ), sample );
-          Base::testNumericalDerivatives( fluid, data, eps, relTol, absTol );
+          testData.emplace_back( pressure, units::convertCToK( temperature ), sample );
         }
       }
     }
+    Base::testNumericalDerivatives( fluid, testData, eps, relTol, absTol );
   }
 
   static string getFluidName();

--- a/src/coreComponents/constitutive/unitTests/testMultiFluidTwoPhaseCompositionalMultiphase.cpp
+++ b/src/coreComponents/constitutive/unitTests/testMultiFluidTwoPhaseCompositionalMultiphase.cpp
@@ -88,6 +88,8 @@ public:
 
     constexpr real64 pressures[] = { 10.0e5, 50.0e5, 100.0e5, 600.0e5 };
     constexpr real64 temperatures[] = { 15.5, 24.0, 40.0, 80.0 };
+    stdVector< typename Base::TestPoint > testData;
+    testData.reserve( sampleCount * 16 );
 
     for( integer sampleIndex = 0; sampleIndex < sampleCount; ++sampleIndex )
     {
@@ -99,11 +101,11 @@ public:
       {
         for( real64 const temperature : temperatures )
         {
-          typename Base::TestPoint const data ( pressure, units::convertCToK( temperature ), sample );
-          Base::testNumericalDerivatives( fluid, data, eps, relTol, absTol );
+          testData.emplace_back( pressure, units::convertCToK( temperature ), sample );
         }
       }
     }
+    Base::testNumericalDerivatives( fluid, testData, eps, relTol, absTol );
   }
 
   static string getFluidName();


### PR DESCRIPTION
This PR reduces setup, allocation, launch, and repeated numerical-derivative overhead in the slow unit tests while preserving the existing test cases and assertions.

Main changes:

- Disable per-allocation memory-log callbacks only for the `testCRSMatrix` target.
- Batch the Drucker–Prager and Modified Cam Clay load-step work.
- Batch fluid numerical-derivative evaluations so model setup is reused.
- Reuse inverse-capillary-pressure fixture setup across all 246 parameterized cases.
- Keep the optimized tests buildable and runnable in both CPU-only and CUDA configurations.

The “before” values are from the original test run. The “after” values are sequential wall-clock measurements from the CPU-only RelWithDebInfo build (`clang++-23`, `ENABLE_CUDA=OFF`, `RAJA_ENABLE_CUDA=OFF`).

| Test | Before | After | Improvement |
|---|---:|---:|---:|
| `testInverseCapillaryPressure` | 40.11 s | 0.07 s | 573x faster, 99.8% less time |
| `testModifiedCamClay` | 225.40 s | <0.01 s | >22,540x faster, >99.99% less time |
| `testMultiFluidBlackOil` | 15.82 s | 0.07 s | 226x faster, 99.6% less time |
| `testMultiFluidCO2Brine` | 79.88 s | 2.84 s | 28.1x faster, 96.4% less time |
| `testMultiFluidThreePhaseCompositionalMultiphase` | 44.89 s | 0.11 s | 408x faster, 99.8% less time |
| `testMultiFluidTwoPhaseCompositionalMultiphase` | 115.92 s | 0.22 s | 527x faster, 99.8% less time |

Additional CPU-only timings: `testCRSMatrix` 0.02 s, `testDruckerPrager` 0.01 s, and `testMultiFluidDeadOil` 0.07 s.

- CPU-only build: 534/534 targeted tests passed; the slowest targeted test took 2.84 s.
- CUDA build: 573/573 targeted tests passed, including the host/device variants.
- Tests were run sequentially because several fluid tests write shared CSV filenames.

Depends on https://github.com/GEOS-DEV/LvArray/pull/355
