### PR TITLE
ci: Backport earthflowAI solution to unbind ATS launches and run CTest in parallel

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -195,9 +195,6 @@ jobs:
             ENABLE_TRILINOS: OFF
             BUILD_SHARED_LIBS: ON
             GEOS_ENABLE_BOUNDS_CHECK: OFF
-            RUNS_ON: streak2
-            NPROC: 8
-            DOCKER_RUN_ARGS: "--cpus=8 --memory=192g -v /etc/pki/tls/certs/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:ro -v /etc/pki/tls/certs/ca-bundle.crt:/certs/ca-bundle.crt:ro"
             HOST_CONFIG: /spack-generated.cmake
 
           - name: Rocky Linux 8 - gcc 12
@@ -226,9 +223,6 @@ jobs:
             ENABLE_TRILINOS: OFF
             BUILD_SHARED_LIBS: ON
             GEOS_ENABLE_BOUNDS_CHECK: ON
-            RUNS_ON: streak2
-            NPROC: 8
-            DOCKER_RUN_ARGS: "--cpus=8 --memory=192g -v /etc/pki/tls/certs/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:ro -v /etc/pki/tls/certs/ca-bundle.crt:/certs/ca-bundle.crt:ro"
             HOST_CONFIG: /spack-generated.cmake
 
           - name: Rocky Linux 9 - clang 22
@@ -239,9 +233,6 @@ jobs:
             ENABLE_TRILINOS: OFF
             BUILD_SHARED_LIBS: ON
             GEOS_ENABLE_BOUNDS_CHECK: ON
-            RUNS_ON: streak2
-            NPROC: 8
-            DOCKER_RUN_ARGS: "--cpus=8 --memory=192g -v /etc/pki/tls/certs/ca-bundle.crt:/etc/pki/tls/certs/ca-bundle.crt:ro -v /etc/pki/tls/certs/ca-bundle.crt:/certs/ca-bundle.crt:ro"
             HOST_CONFIG: /spack-generated.cmake
 
     uses: ./.github/workflows/build_and_test.yml

--- a/inputFiles/compositionalMultiphaseFlow/benchmarks/thermalLeakyWell/thermalLeakyWell.ats
+++ b/inputFiles/compositionalMultiphaseFlow/benchmarks/thermalLeakyWell/thermalLeakyWell.ats
@@ -9,10 +9,7 @@ decks = [
         name="thermalLeakyWell_smoke_3d",
         description=
         "Smoke test for thermalLeakyWell (3D displacement, 2-phase co2-brine, hydrostatic initial condition)",
-        partitions=(# Temporarily disabled: thermalLeakyWell_smoke_3d_01
-                    # (1, 1, 1),
-                    (2, 2, 1),
-                    ),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=60,
         check_step=104,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),

--- a/inputFiles/compositionalMultiphaseFlow/compositionalMultiphaseFlow.ats
+++ b/inputFiles/compositionalMultiphaseFlow/compositionalMultiphaseFlow.ats
@@ -81,10 +81,7 @@ decks = [
         name="deadoil_3ph_staircase_hybrid_3d",
         description=
         "Compositional multiphase flow test (3D staircase, hybrid FVM, 3-phase dead-oil, Brooks-Corey-Baker 3-phase relperm curves)",
-        partitions=(# Temporarily disabled: deadoil_3ph_staircase_hybrid_3d_01
-                    # (1, 1, 1),
-                    (2, 2, 2),
-                    ),
+        partitions=((1, 1, 1), (2, 2, 2)),
         restart_step=28,
         check_step=38,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),

--- a/inputFiles/compositionalMultiphaseWell/compositionalMultiphaseWell.ats
+++ b/inputFiles/compositionalMultiphaseWell/compositionalMultiphaseWell.ats
@@ -41,9 +41,7 @@ decks = [
         name="dead_oil_wells_hybrid_2d",
         description=
         "Dead oil well test (2D displacement, hybrid FVM, 3-phase dead-oil, 3 wells)",
-        partitions=[# Temporarily disabled: dead_oil_wells_hybrid_2d_01
-                    # (1, 1, 1),
-                    (2, 2, 1)],
+        partitions=[(1, 1, 1), (2, 2, 1)],
         restart_step=50,
         check_step=100,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
@@ -75,9 +73,7 @@ decks = [
         name="staircase_co2_wells_hybrid_3d",
         description=
         "CO2 well test (3D staircase, unstructured mesh, hybrid FVM, 2-phase 2-component, 2 wells)",
-        partitions=[# Temporarily disabled: staircase_co2_wells_hybrid_3d_01
-                    # (1, 1, 1),
-                    (2, 2, 2)],
+        partitions=[(1, 1, 1), (2, 2, 2)],
         restart_step=0,
         check_step=17,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
@@ -89,15 +85,14 @@ decks = [
         restart_step=13,
         check_step=26,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
-    # Temporarily disabled; this problematic test will be fixed in a separate PR.
-    # TestDeck(
-    #     name="isothm_mass_inj_table",
-    #     description=
-    #     "Isothermal mass injection constraint testing control switching",
-    #     partitions=[(1, 1, 1), (1, 2, 1)],
-    #     restart_step=24,
-    #     check_step=28,
-    #     restartcheck_params=RestartcheckParameters(**restartcheck_params)),
+    TestDeck(
+        name="isothm_mass_inj_table",
+        description=
+        "Isothermal mass injection constraint testing control switching",
+        partitions=[(1, 1, 1), (1, 2, 1)],
+        restart_step=24,
+        check_step=28,
+        restartcheck_params=RestartcheckParameters(**restartcheck_params)),
     TestDeck(
         name="isothm_vol_inj_table",
         description=

--- a/inputFiles/hydraulicFracturing/Hydrofracturing.ats
+++ b/inputFiles/hydraulicFracturing/Hydrofracturing.ats
@@ -119,10 +119,7 @@ penny_shaped_viscosity_dominated_poroelastic = {
 pkn_viscosity_dominated = {
     "name": "pknViscosityDominated_smoke",
     "description": "PKN fracture in Viscosity-dominated regime",
-    "partitions": (# Temporarily disabled: pknViscosityDominated_smoke_01
-                   # (1, 1, 1),
-                   (1, 2, 2),
-                   ),
+    "partitions": ((1, 1, 1), (1, 2, 2)),
     "restart_step": 5,
     "check_step": 10,
     "tolerance": [1.8e-5, 2e5],

--- a/inputFiles/lagrangianContactMechanics/contactMechanics.ats
+++ b/inputFiles/lagrangianContactMechanics/contactMechanics.ats
@@ -97,10 +97,7 @@ decks = [
         name="ALM_TFrac_smoke",
         description=
         "Two fractures intersecting at a right angle (structured grid)",
-        partitions=(# Temporarily disabled: ALM_TFrac_smoke_01
-                    # (1, 1, 1),
-                    (2, 2, 1),
-                    ),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=1,
         check_step=2,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
@@ -124,10 +121,7 @@ decks = [
         name="LagrangeContactBubbleStab_FixedSlip_smoke",
         description="Lagrange multiplier with bubble stab and fixed jump on the fault. "
         "Fault with imposed slip",
-        partitions=(# Temporarily disabled: LagrangeContactBubbleStab_FixedSlip_smoke_01
-                    # (1, 1, 1),
-                    (2, 2, 1),
-                    ),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=1,
         check_step=2,
         restartcheck_params=RestartcheckParameters(**restartcheck_params))

--- a/inputFiles/multiphaseFlowFractures/multiphaseFlowFractures.ats
+++ b/inputFiles/multiphaseFlowFractures/multiphaseFlowFractures.ats
@@ -14,10 +14,7 @@ decks = [
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
     TestDeck(name="deadOil_fractureMatrixFlow_edfm_inclinedFrac_smoke",
         description='Multiphase flow EDFM inclined frac.',
-        partitions=(# Temporarily disabled: deadOil_fractureMatrixFlow_edfm_inclinedFrac_smoke_01
-                    # (1, 1, 1),
-                    (2, 2, 1),
-                    ),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=0,
         check_step=42,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),

--- a/inputFiles/poromechanics/poroElasticCoupling.ats
+++ b/inputFiles/poromechanics/poroElasticCoupling.ats
@@ -367,10 +367,7 @@ def _build_PoroElasticPEBICO2FIM_cases():
     restartcheck_params = {"atol": 1.0e-5, "rtol": 2.0e-7}
     return _build_poro_elastic_coupling_case(
         "PoroElastic_hybridHexPrism_co2_fim_3d.xml", (5, 10),
-        (# Temporarily disabled: PoroElastic_hybridHexPrism_co2_fim_3d_01
-         # (1, 1, 1),
-         (2, 2, 1),
-         ), description, restartcheck_params)
+        ((1, 1, 1), (2, 2, 1)), description, restartcheck_params)
 
 
 def _build_PoroElasticPEBICO2Sequential_cases():
@@ -380,10 +377,7 @@ def _build_PoroElasticPEBICO2Sequential_cases():
     restartcheck_params = {"atol": 1.0e-5, "rtol": 2.0e-7}
     return _build_poro_elastic_coupling_case(
         "PoroElastic_hybridHexPrism_co2_sequential_3d.xml", (5, 10),
-        (# Temporarily disabled: PoroElastic_hybridHexPrism_co2_sequential_3d_01
-         # (1, 1, 1),
-         (2, 2, 1),
-         ), description, restartcheck_params)
+        ((1, 1, 1), (2, 2, 1)), description, restartcheck_params)
 
 
 def _build_PoroElasticGravity_cases():

--- a/inputFiles/poromechanicsFractures/Contact/AugmentedLagrangianMultipliers/AugmentedLagrangianMultipliers.ats
+++ b/inputFiles/poromechanicsFractures/Contact/AugmentedLagrangianMultipliers/AugmentedLagrangianMultipliers.ats
@@ -36,44 +36,31 @@ decks = [
     TestDeck(
         name="ALM_inclinedFault_ISG_smoke",
         description='PoroElastic ALM inclined fault with internal surface generator (elastic)',
-        partitions=(# Temporarily disabled: ALM_inclinedFault_ISG_smoke_01
-                    # (1, 1, 1),
-                    (2, 2, 1),
-                    ),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=0,
         check_step=1,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
     TestDeck(
         name="ALM_inclinedFault_ESG_smoke",
         description='PoroElastic ALM inclined fault with external surface generator (elastic)',
-        partitions=(# Temporarily disabled: ALM_inclinedFault_ESG_smoke_01
-                    # (1, 1, 1),
-                    (2, 2, 1),
-                    ),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=0,
         check_step=1,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
     TestDeck(
         name="ALM_inclinedFault_ISG_DruckerPrager_smoke",
         description='PoroElastic ALM inclined fault with internal surface generator (DruckerPrager plastic)',
-        partitions=(# Temporarily disabled: ALM_inclinedFault_ISG_DruckerPrager_smoke_01
-                    # (1, 1, 1),
-                    (2, 2, 1),
-                    ),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=0,
         check_step=1,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
     TestDeck(
         name="ALM_inclinedFault_ESG_friction_cohesion_smoke",
         description='PoroElastic ALM inclined fault with cohesion/frictionCoeff provided in mesh (per cell variation)',
-        partitions=(# Temporarily disabled: ALM_inclinedFault_ESG_friction_cohesion_smoke_01
-                    # (1, 1, 1),
-                    (2, 2, 1),
-                    ),
+        partitions=((1, 1, 1), (2,2,1)),
         restart_step=0,
         check_step=1,
         restartcheck_params=RestartcheckParameters(**restartcheck_params)),
-
 ]
 
 generate_geos_tests(decks)

--- a/inputFiles/poromechanicsFractures/Contact/LagrangianMultipliers/LagrangianMultipliers.ats
+++ b/inputFiles/poromechanicsFractures/Contact/LagrangianMultipliers/LagrangianMultipliers.ats
@@ -57,20 +57,14 @@ decks = [
     TestDeck(
         name="multiphasePoromechanics_FaultModel_smoke",
         description='PoroElastic conformingFracture with external mesh (multiphase)',
-        partitions=(# Temporarily disabled: multiphasePoromechanics_FaultModel_smoke_01
-                    # (1, 1, 1),
-                    (2, 2, 1),
-                    ),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=0,
         check_step=1,
         restartcheck_params=RestartcheckParameters(atol=1e-05, rtol=1e-04)),
     TestDeck(
         name="multiphasePoromechanics_FaultModel_well_fim_smoke",
         description='PoroElastic conformingFracture fully implicit (multiphase with wells)',
-        partitions=(# Temporarily disabled: multiphasePoromechanics_FaultModel_well_fim_smoke_01
-                    # (1, 1, 1),
-                    (2, 2, 1),
-                    ),
+        partitions=((1, 1, 1), (2, 2, 1)),
         restart_step=0,
         check_step=1,
         restartcheck_params=RestartcheckParameters(atol=1e-05, rtol=1e-04)),

--- a/scripts/ci_build_and_test_in_container.sh
+++ b/scripts/ci_build_and_test_in_container.sh
@@ -370,6 +370,10 @@ if [ -z "${NPROC}" ]; then
   NPROC=$(nproc)
   echo "NPROC unset, setting to ${NPROC}..."
 fi
+if ! [[ "${NPROC}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "NPROC must be a positive integer, got '${NPROC}'."
+  exit 1
+fi
 echo "Using ${NPROC} cores."
 
 if [[ -n "${CTEST_PARALLEL_LEVEL_ARG}" ]]; then
@@ -401,7 +405,12 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   ATS_WORKING_DIR=$tempdir/GEOS_integratedTests_working
 
   export ATS_FILTER="np<=32"
-  ATS_ARGUMENTS="--machine openmpi --ats openmpi_mpirun=/usr/bin/mpirun --ats openmpi_args=--allow-run-as-root --ats openmpi_procspernode=32 --ats openmpi_maxprocs=32 --ats cutoff=45m"
+  # Open MPI refuses root launches in CI containers unless both guard variables are set.
+  # Keep this separate from openmpi_args because repeated geos-ats overrides replace values.
+  export OMPI_ALLOW_RUN_AS_ROOT=1
+  export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+  ATS_ARGUMENTS="--machine openmpi --ats openmpi_mpirun=/usr/bin/mpirun --ats openmpi_procspernode=${NPROC} --ats openmpi_maxprocs=${NPROC} --ats cutoff=45m"
+  echo "Integrated test ATS arguments: ${ATS_ARGUMENTS}"
   ATS_CMAKE_ARGS=("-DATS_ARGUMENTS:STRING=\"${ATS_ARGUMENTS}\""
                   "-DPython3_ROOT_DIR=${ATS_PYTHON_HOME}"
                   "-DPython3_EXECUTABLE=${ATS_PYTHON_HOME}/bin/python3"
@@ -535,10 +544,12 @@ fi
 
 # Run the unit tests (excluding previously ran checks).
 if [[ "${RUN_UNIT_TESTS}" = true ]]; then
+  export OMP_NUM_THREADS=1
+  echo "Running unit tests with OMP_NUM_THREADS=${OMP_NUM_THREADS}."
   if [ ${HOSTNAME} == 'streak.llnl.gov' ] || [ ${HOSTNAME} == 'streak2.llnl.gov' ]; then
-    or_die ctest --output-on-failure -E "testUncrustifyCheck|testDoxygenCheck|testExternalSolvers"
+    or_die ctest --output-on-failure --parallel -E "testUncrustifyCheck|testDoxygenCheck|testExternalSolvers"
   else
-    or_die ctest --output-on-failure -E "testUncrustifyCheck|testDoxygenCheck"
+    or_die ctest --output-on-failure --parallel -E "testUncrustifyCheck|testDoxygenCheck"
   fi
 fi
 
@@ -563,6 +574,36 @@ if [[ "${RUN_INTEGRATED_TESTS}" = true ]]; then
   # We directly use the script instead...
   echo "Available baselines:"
   ls -lR /tmp/geos/baselines
+
+  # This CI route configures geos-ats' Open MPI machine explicitly. Capture the
+  # selected launcher's identity once, and fail before tests if an image change
+  # would make the Open MPI placement environment below ineffective.
+  echo "Diagnostic: mpirun --version"
+  MPIRUN_VERSION_OUTPUT="$(/usr/bin/mpirun --version 2>&1)"
+  MPIRUN_VERSION_STATUS=$?
+  printf '%s\n' "${MPIRUN_VERSION_OUTPUT}"
+  echo "Diagnostic 'mpirun --version' exit status: ${MPIRUN_VERSION_STATUS}"
+  if [[ "${MPIRUN_VERSION_STATUS}" -ne 0 ]]; then
+    echo "Open MPI integrated tests require /usr/bin/mpirun --version to succeed."
+    exit "${MPIRUN_VERSION_STATUS}"
+  fi
+  if [[ "${MPIRUN_VERSION_OUTPUT}" != *"Open MPI"* ]]; then
+    echo "Open MPI integrated tests require /usr/bin/mpirun to identify itself as Open MPI."
+    exit 1
+  fi
+
+  # ATS accounts for the rank capacity of concurrent tests but does not assign
+  # disjoint CPU affinities to their independent mpirun processes. Disable each
+  # launcher's local rank binding so Linux can schedule ranks across the
+  # container's allowed CPU set; this policy does not guarantee exclusive cores.
+  export OMPI_MCA_hwloc_base_binding_policy=none
+  echo "Open MPI rank binding disabled with OMPI_MCA_hwloc_base_binding_policy=${OMPI_MCA_hwloc_base_binding_policy}."
+
+  # Report the resulting Open MPI placement policy. Each report is written to
+  # the individual launch's stderr, which ATS retains in TestResults for the
+  # packed diagnostic artifact.
+  export OMPI_MCA_hwloc_base_report_bindings=1
+  echo "Open MPI binding reports enabled with OMPI_MCA_hwloc_base_report_bindings=${OMPI_MCA_hwloc_base_report_bindings}."
 
   echo "Running integrated tests..."
   integratedTests/geos_ats.sh --baselineCacheDirectory /tmp/geos/baselines

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,26 @@ else()
 endif()
 set( CMAKE_ENABLE_EXPORTS ON )
 
+# Configure the arguments used by generated build-system test targets before
+# BLT enables CTest. Users who need full control can still define
+# CMAKE_CTEST_ARGUMENTS directly from their host-config or CMake command line.
+set( GEOS_CTEST_PARALLEL_LEVEL "AUTO" CACHE STRING
+     "CTest parallel level for generated test targets. Use AUTO for CTest's default level, OFF for serial execution, or a nonnegative integer." )
+set_property( CACHE GEOS_CTEST_PARALLEL_LEVEL PROPERTY STRINGS AUTO OFF 0 1 2 4 8 16 )
+if( NOT DEFINED CMAKE_CTEST_ARGUMENTS )
+  string( TOUPPER "${GEOS_CTEST_PARALLEL_LEVEL}" _geos_ctest_parallel_level )
+  if( _geos_ctest_parallel_level STREQUAL "AUTO" )
+    set( CMAKE_CTEST_ARGUMENTS "--parallel" )
+  elseif( _geos_ctest_parallel_level STREQUAL "OFF" )
+    set( CMAKE_CTEST_ARGUMENTS "" )
+  elseif( GEOS_CTEST_PARALLEL_LEVEL MATCHES "^[0-9]+$" )
+    set( CMAKE_CTEST_ARGUMENTS "--parallel" "${GEOS_CTEST_PARALLEL_LEVEL}" )
+  else()
+    message( FATAL_ERROR "GEOS_CTEST_PARALLEL_LEVEL must be AUTO, OFF, or a nonnegative integer." )
+  endif()
+  unset( _geos_ctest_parallel_level )
+endif()
+
 # populated by `geos_add_test` (private list of all geos tests, keep in sync with the macro definition)
 set_property( GLOBAL PROPERTY geos_tests_exe_list )
 
@@ -372,6 +392,6 @@ endif()
 # the following adds a `build_test` CMake target such that running `$ make build_test test`
 # builds the unit tests before running them
 get_property( tmp GLOBAL PROPERTY geos_tests_exe_list )
-add_custom_target( build_test COMMAND ${CMAKE_CTEST_COMMAND} DEPENDS ${tmp} )
+add_custom_target( build_test COMMAND ${CMAKE_CTEST_COMMAND} ${CMAKE_CTEST_ARGUMENTS} DEPENDS ${tmp} )
 
 message( DEBUG "geos_tests: ${tmp} " )

--- a/src/cmake/GeosxMacros.cmake
+++ b/src/cmake/GeosxMacros.cmake
@@ -329,6 +329,10 @@ endfunction()
 ## Adds a test to the project, remaining arguments are forwarded to `blt_add_test`
 ## As a side effect, uses and populates a global property named `geos_tests_exe_list`
 ## initialized in `src/CMakeLists.txt`.
+## MPI tests keep using BLT's NUM_MPI_TASKS command wrapping, and GEOS mirrors
+## that rank count into CTest's PROCESSORS property so parallel CTest runs can
+## schedule multi-rank tests against the same processor-slot budget as serial
+## tests.
 ##------------------------------------------------------------------------------
 macro( geos_add_test )
 
@@ -351,8 +355,27 @@ macro( geos_add_test )
 
     message( DEBUG "arg_NAME=${arg_NAME} arg_EXECUTABLE=${arg_EXECUTABLE} arg_COMMAND=${arg_COMMAND} ARGN=${ARGN}" )  # debug
 
+    set( _geos_test_processors )
+    set( _geos_read_num_mpi_tasks OFF )
+    foreach( _geos_test_arg ${ARGN} )
+      if( _geos_read_num_mpi_tasks )
+        set( _geos_test_processors ${_geos_test_arg} )
+        set( _geos_read_num_mpi_tasks OFF )
+      elseif( _geos_test_arg STREQUAL "NUM_MPI_TASKS" )
+        set( _geos_read_num_mpi_tasks ON )
+      endif()
+    endforeach()
+
     blt_add_test( NAME ${arg_NAME}
                   COMMAND ${arg_COMMAND} ${ARGN} )
+
+    if( _geos_test_processors )
+      set_tests_properties( ${arg_NAME} PROPERTIES PROCESSORS ${_geos_test_processors} )
+    endif()
+
+    unset( _geos_read_num_mpi_tasks )
+    unset( _geos_test_processors )
+    unset( _geos_test_arg )
 
 endmacro( geos_add_test )
 

--- a/src/coreComponents/constitutive/unitTests/testMultiFluidBlackOil.cpp
+++ b/src/coreComponents/constitutive/unitTests/testMultiFluidBlackOil.cpp
@@ -21,6 +21,10 @@
  #include "constitutive/fluid/multifluid/blackOil/BlackOilFluid.hpp"
  #include "common/initializeEnvironment.hpp"
 
+ #include <chrono>
+ #include <cstdint>
+ #include <filesystem>
+
 using namespace geos::constitutive;
 
 namespace geos
@@ -72,11 +76,20 @@ public:
 public:
   MultiFluidBlackOilTestFixture()
   {
-    writeTableToFile( pvtoFileName, pvtoTableContent );
-    writeTableToFile( pvdgFileName, pvdgTableContent );
-    writeTableToFile( pvtwFileName, pvtwTableContent );
+    // Use a unique directory per fixture instance so parallel CTest runs do not race on shared filenames.
+    auto const uniqueSuffix = GEOS_FMT( "{}_{}",
+                                        std::chrono::steady_clock::now().time_since_epoch().count(),
+                                        static_cast< uint64_t >( reinterpret_cast< uintptr_t >( this ) ) );
+    m_tableDir = ( std::filesystem::temp_directory_path() / GEOS_FMT( "geos_blackoil_tables_{}", uniqueSuffix ) ).string();
+    std::error_code ec;
+    std::filesystem::create_directories( m_tableDir, ec );
+    EXPECT_FALSE( ec );
 
-    Base::createFluid( getFluidName(), []( BlackOilFluid & fluid ){
+    writeTableToFile( getTableFilePath( pvtoFileName ), pvtoTableContent );
+    writeTableToFile( getTableFilePath( pvdgFileName ), pvdgTableContent );
+    writeTableToFile( getTableFilePath( pvtwFileName ), pvtwTableContent );
+
+    Base::createFluid( getFluidName(), [this]( BlackOilFluid & fluid ){
       fillPhysicalProperties( fluid );
       fluid.setMassFlag( USE_MASS );
     } );
@@ -84,18 +97,26 @@ public:
 
   ~MultiFluidBlackOilTestFixture() override
   {
-    removeFile( pvtoFileName );
-    removeFile( pvdgFileName );
-    removeFile( pvtwFileName );
+    removeFile( getTableFilePath( pvtoFileName ) );
+    removeFile( getTableFilePath( pvdgFileName ) );
+    removeFile( getTableFilePath( pvtwFileName ) );
+    std::error_code ec;
+    std::filesystem::remove( m_tableDir, ec );
   }
 
   static string getFluidName();
 
 private:
-  static void fillPhysicalProperties( BlackOilFluid & fluid );
+  string getTableFilePath( char const * fileName ) const
+  {
+    return ( std::filesystem::path( m_tableDir ) / fileName ).string();
+  }
+
+  void fillPhysicalProperties( BlackOilFluid & fluid ) const;
   static constexpr const char * pvtoFileName = "pvto.txt";
   static constexpr const char * pvdgFileName = "pvdg.txt";
   static constexpr const char * pvtwFileName = "pvtw.txt";
+  string m_tableDir;
 };
 
 template< bool USE_MASS >
@@ -105,7 +126,7 @@ string MultiFluidBlackOilTestFixture< USE_MASS >::getFluidName()
 }
 
 template< bool USE_MASS >
-void MultiFluidBlackOilTestFixture< USE_MASS >::fillPhysicalProperties( BlackOilFluid & fluid )
+void MultiFluidBlackOilTestFixture< USE_MASS >::fillPhysicalProperties( BlackOilFluid & fluid ) const
 {
   string_array & phaseNames = fluid.getReference< string_array >( MultiFluidBase::viewKeyStruct::phaseNamesString() );
   phaseNames = {"oil", "water", "gas"};
@@ -120,9 +141,9 @@ void MultiFluidBlackOilTestFixture< USE_MASS >::fillPhysicalProperties( BlackOil
   fill( surfaceDens, Feed< 3 >{800.0, 1022.0, 0.9907} );
 
   path_array & tableNames = fluid.getReference< path_array >( BlackOilFluidBase::viewKeyStruct::tableFilesString() );
-  tableNames.emplace_back( Path( pvtoFileName ));
-  tableNames.emplace_back( Path( pvtwFileName ));
-  tableNames.emplace_back( Path( pvdgFileName ));
+  tableNames.emplace_back( Path( getTableFilePath( pvtoFileName ).c_str() ) );
+  tableNames.emplace_back( Path( getTableFilePath( pvtwFileName ).c_str() ) );
+  tableNames.emplace_back( Path( getTableFilePath( pvdgFileName ).c_str() ) );
 }
 
 using MultiFluidBlackOilTestMass = MultiFluidBlackOilTestFixture< true >;

--- a/src/coreComponents/constitutive/unitTests/testMultiFluidCO2Brine.cpp
+++ b/src/coreComponents/constitutive/unitTests/testMultiFluidCO2Brine.cpp
@@ -155,9 +155,12 @@ public:
 
 private:
   static void fillPhysicalProperties( CO2BrineFluid & fluid );
-  static constexpr const char * pvtGasFileName = "pvtgas.txt";
-  static constexpr const char * pvtLiquidFileName = "pvtliquid.txt";
-  static constexpr const char * pvtFlashFileName = "co2flash.txt";
+  // This fixture writes model tables into the CTest working directory before
+  // constructing the fluid. The file names stay specific to this executable so
+  // parallel CTest runs cannot overwrite tables owned by other CO2-brine tests.
+  static constexpr const char * pvtGasFileName = "testMultiFluidCO2Brine_pvtgas.txt";
+  static constexpr const char * pvtLiquidFileName = "testMultiFluidCO2Brine_pvtliquid.txt";
+  static constexpr const char * pvtFlashFileName = "testMultiFluidCO2Brine_co2flash.txt";
 };
 
 template< BrineModelType BRINE, FlashType FLASH, bool THERMAL >

--- a/src/coreComponents/integrationTests/wellsTests/testIsothermalReservoirCompositionalMultiphaseMSWells.cpp
+++ b/src/coreComponents/integrationTests/wellsTests/testIsothermalReservoirCompositionalMultiphaseMSWells.cpp
@@ -219,8 +219,8 @@ char const * xmlInput =
       phaseNames="{ gas, water }"
       componentNames="{ co2, water }"
       componentMolarWeight="{ 44e-3, 18e-3 }"
-      phasePVTParaFiles="{ pvtgas.txt, pvtliquid.txt }"
-      flashModelParaFile="co2flash.txt"/>
+      phasePVTParaFiles="{ testIsothermalReservoirCompositionalMultiphaseMSWells_pvtgas.txt, testIsothermalReservoirCompositionalMultiphaseMSWells_pvtliquid.txt }"
+      flashModelParaFile="testIsothermalReservoirCompositionalMultiphaseMSWells_co2flash.txt"/>
 
     <BrooksCoreyRelativePermeability
       name="relperm"
@@ -702,15 +702,15 @@ TEST_F( CompositionalMultiphaseReservoirSolverTest, jacobianNumericalCheck_Press
 
 int main( int argc, char * * argv )
 {
-  writeTableToFile( "co2flash.txt", co2flash );
-  writeTableToFile( "pvtliquid.txt", pvtLiquid );
-  writeTableToFile( "pvtgas.txt", pvtGas );
+  writeTableToFile( "testIsothermalReservoirCompositionalMultiphaseMSWells_co2flash.txt", co2flash );
+  writeTableToFile( "testIsothermalReservoirCompositionalMultiphaseMSWells_pvtliquid.txt", pvtLiquid );
+  writeTableToFile( "testIsothermalReservoirCompositionalMultiphaseMSWells_pvtgas.txt", pvtGas );
   ::testing::InitGoogleTest( &argc, argv );
   g_commandLineOptions = *geos::basicSetup( argc, argv );
   int const result = RUN_ALL_TESTS();
   geos::basicCleanup();
-  removeFile( "co2flash.txt" );
-  removeFile( "pvtliquid.txt" );
-  removeFile( "pvtgas.txt" );
+  removeFile( "testIsothermalReservoirCompositionalMultiphaseMSWells_co2flash.txt" );
+  removeFile( "testIsothermalReservoirCompositionalMultiphaseMSWells_pvtliquid.txt" );
+  removeFile( "testIsothermalReservoirCompositionalMultiphaseMSWells_pvtgas.txt" );
   return result;
 }

--- a/src/coreComponents/integrationTests/wellsTests/testIsothermalReservoirCompositionalMultiphaseSSWells.cpp
+++ b/src/coreComponents/integrationTests/wellsTests/testIsothermalReservoirCompositionalMultiphaseSSWells.cpp
@@ -219,8 +219,8 @@ char const * xmlInput =
       phaseNames="{ gas, water }"
       componentNames="{ co2, water }"
       componentMolarWeight="{ 44e-3, 18e-3 }"
-      phasePVTParaFiles="{ pvtgas.txt, pvtliquid.txt }"
-      flashModelParaFile="co2flash.txt"/>
+      phasePVTParaFiles="{ testIsothermalReservoirCompositionalMultiphaseSSWells_pvtgas.txt, testIsothermalReservoirCompositionalMultiphaseSSWells_pvtliquid.txt }"
+      flashModelParaFile="testIsothermalReservoirCompositionalMultiphaseSSWells_co2flash.txt"/>
 
     <BrooksCoreyRelativePermeability
       name="relperm"
@@ -793,15 +793,15 @@ TEST_F( CompositionalMultiphaseReservoirSolverTest, jacobianNumericalCheck_Press
 #endif
 int main( int argc, char * * argv )
 {
-  writeTableToFile( "co2flash.txt", co2flash );
-  writeTableToFile( "pvtliquid.txt", pvtLiquid );
-  writeTableToFile( "pvtgas.txt", pvtGas );
+  writeTableToFile( "testIsothermalReservoirCompositionalMultiphaseSSWells_co2flash.txt", co2flash );
+  writeTableToFile( "testIsothermalReservoirCompositionalMultiphaseSSWells_pvtliquid.txt", pvtLiquid );
+  writeTableToFile( "testIsothermalReservoirCompositionalMultiphaseSSWells_pvtgas.txt", pvtGas );
   ::testing::InitGoogleTest( &argc, argv );
   g_commandLineOptions = *geos::basicSetup( argc, argv );
   int const result = RUN_ALL_TESTS();
   geos::basicCleanup();
-  removeFile( "co2flash.txt" );
-  removeFile( "pvtliquid.txt" );
-  removeFile( "pvtgas.txt" );
+  removeFile( "testIsothermalReservoirCompositionalMultiphaseSSWells_co2flash.txt" );
+  removeFile( "testIsothermalReservoirCompositionalMultiphaseSSWells_pvtliquid.txt" );
+  removeFile( "testIsothermalReservoirCompositionalMultiphaseSSWells_pvtgas.txt" );
   return result;
 }

--- a/src/coreComponents/integrationTests/wellsTests/testThermalEstimatorInjWell.cpp
+++ b/src/coreComponents/integrationTests/wellsTests/testThermalEstimatorInjWell.cpp
@@ -227,8 +227,8 @@ char const * xmlInput =
       phaseNames="{ gas, water }"
       componentNames="{ co2, water }"
       componentMolarWeight="{ 44e-3, 18e-3 }"
-      phasePVTParaFiles="{  pvtgas.txt,  pvtliquid.txt }"
-      flashModelParaFile="co2flash.txt">
+      phasePVTParaFiles="{  testThermalEstimatorInjWell_pvtgas.txt,  testThermalEstimatorInjWell_pvtliquid.txt }"
+      flashModelParaFile="testThermalEstimatorInjWell_co2flash.txt">
     </CO2BrinePhillipsThermalFluid>
     <BrooksCoreyRelativePermeability
       name="relperm"
@@ -940,16 +940,16 @@ TEST_F( CompositionalMultiphaseReservoirSolverTest, jacobianNumericalCheck_Flux 
 #endif
 int main( int argc, char * * argv )
 {
-  writeTableToFile( "co2flash.txt", co2flash );
-  writeTableToFile( "pvtliquid.txt", pvtLiquid );
-  writeTableToFile( "pvtgas.txt", pvtGas );
+  writeTableToFile( "testThermalEstimatorInjWell_co2flash.txt", co2flash );
+  writeTableToFile( "testThermalEstimatorInjWell_pvtliquid.txt", pvtLiquid );
+  writeTableToFile( "testThermalEstimatorInjWell_pvtgas.txt", pvtGas );
   ::testing::InitGoogleTest( &argc, argv );
   g_commandLineOptions = *geos::basicSetup( argc, argv );
   int const result = RUN_ALL_TESTS();
   geos::basicCleanup();
-  removeFile( "co2flash.txt" );
-  removeFile( "pvtliquid.txt" );
-  removeFile( "pvtgas.txt" );
+  removeFile( "testThermalEstimatorInjWell_co2flash.txt" );
+  removeFile( "testThermalEstimatorInjWell_pvtliquid.txt" );
+  removeFile( "testThermalEstimatorInjWell_pvtgas.txt" );
 
   return result;
 }

--- a/src/coreComponents/integrationTests/wellsTests/testThermalEstimatorProdWell.cpp
+++ b/src/coreComponents/integrationTests/wellsTests/testThermalEstimatorProdWell.cpp
@@ -229,8 +229,8 @@ char const * xmlInput =
       phaseNames="{ gas, water }"
       componentNames="{ co2, water }"
       componentMolarWeight="{ 44e-3, 18e-3 }"
-      phasePVTParaFiles="{  pvtgas.txt,  pvtliquid.txt }"
-      flashModelParaFile="co2flash.txt">
+      phasePVTParaFiles="{  testThermalEstimatorProdWell_pvtgas.txt,  testThermalEstimatorProdWell_pvtliquid.txt }"
+      flashModelParaFile="testThermalEstimatorProdWell_co2flash.txt">
     </CO2BrinePhillipsThermalFluid>
     <BrooksCoreyRelativePermeability
       name="relperm"
@@ -954,16 +954,16 @@ TEST_F( CompositionalMultiphaseReservoirSolverTest, jacobianNumericalCheck_Flux 
 #endif
 int main( int argc, char * * argv )
 {
-  writeTableToFile( "co2flash.txt", co2flash );
-  writeTableToFile( "pvtliquid.txt", pvtLiquid );
-  writeTableToFile( "pvtgas.txt", pvtGas );
+  writeTableToFile( "testThermalEstimatorProdWell_co2flash.txt", co2flash );
+  writeTableToFile( "testThermalEstimatorProdWell_pvtliquid.txt", pvtLiquid );
+  writeTableToFile( "testThermalEstimatorProdWell_pvtgas.txt", pvtGas );
   ::testing::InitGoogleTest( &argc, argv );
   g_commandLineOptions = *geos::basicSetup( argc, argv );
   int const result = RUN_ALL_TESTS();
   geos::basicCleanup();
-  removeFile( "co2flash.txt" );
-  removeFile( "pvtliquid.txt" );
-  removeFile( "pvtgas.txt" );
+  removeFile( "testThermalEstimatorProdWell_co2flash.txt" );
+  removeFile( "testThermalEstimatorProdWell_pvtliquid.txt" );
+  removeFile( "testThermalEstimatorProdWell_pvtgas.txt" );
 
   return result;
 }

--- a/src/coreComponents/integrationTests/wellsTests/testThermalInjWell.cpp
+++ b/src/coreComponents/integrationTests/wellsTests/testThermalInjWell.cpp
@@ -216,8 +216,8 @@ char const * xmlInput =
       phaseNames="{ gas, water }"
       componentNames="{ co2, water }"
       componentMolarWeight="{ 44e-3, 18e-3 }"
-      phasePVTParaFiles="{  pvtgas.txt,  pvtliquid.txt }"
-      flashModelParaFile="co2flash.txt">
+      phasePVTParaFiles="{  testThermalInjWell_pvtgas.txt,  testThermalInjWell_pvtliquid.txt }"
+      flashModelParaFile="testThermalInjWell_co2flash.txt">
     </CO2BrinePhillipsThermalFluid>
     <BrooksCoreyRelativePermeability
       name="relperm"
@@ -877,16 +877,16 @@ TEST_F( CompositionalMultiphaseReservoirSolverTest, jacobianNumericalCheck_Flux 
 #endif
 int main( int argc, char * * argv )
 {
-  writeTableToFile( "co2flash.txt", co2flash );
-  writeTableToFile( "pvtliquid.txt", pvtLiquid );
-  writeTableToFile( "pvtgas.txt", pvtGas );
+  writeTableToFile( "testThermalInjWell_co2flash.txt", co2flash );
+  writeTableToFile( "testThermalInjWell_pvtliquid.txt", pvtLiquid );
+  writeTableToFile( "testThermalInjWell_pvtgas.txt", pvtGas );
   ::testing::InitGoogleTest( &argc, argv );
   g_commandLineOptions = *geos::basicSetup( argc, argv );
   int const result = RUN_ALL_TESTS();
   geos::basicCleanup();
-  removeFile( "co2flash.txt" );
-  removeFile( "pvtliquid.txt" );
-  removeFile( "pvtgas.txt" );
+  removeFile( "testThermalInjWell_co2flash.txt" );
+  removeFile( "testThermalInjWell_pvtliquid.txt" );
+  removeFile( "testThermalInjWell_pvtgas.txt" );
 
   return result;
 }

--- a/src/coreComponents/integrationTests/wellsTests/testThermalProdWell.cpp
+++ b/src/coreComponents/integrationTests/wellsTests/testThermalProdWell.cpp
@@ -216,8 +216,8 @@ char const * xmlInput =
       phaseNames="{ gas, water }"
       componentNames="{ co2, water }"
       componentMolarWeight="{ 44e-3, 18e-3 }"
-      phasePVTParaFiles="{  pvtgas.txt,  pvtliquid.txt }"
-      flashModelParaFile="co2flash.txt">
+      phasePVTParaFiles="{  testThermalProdWell_pvtgas.txt,  testThermalProdWell_pvtliquid.txt }"
+      flashModelParaFile="testThermalProdWell_co2flash.txt">
     </CO2BrinePhillipsThermalFluid>
     <BrooksCoreyRelativePermeability
       name="relperm"
@@ -867,16 +867,16 @@ TEST_F( CompositionalMultiphaseReservoirSolverTest, jacobianNumericalCheck_Flux 
 #endif
 int main( int argc, char * * argv )
 {
-  writeTableToFile( "co2flash.txt", co2flash );
-  writeTableToFile( "pvtliquid.txt", pvtLiquid );
-  writeTableToFile( "pvtgas.txt", pvtGas );
+  writeTableToFile( "testThermalProdWell_co2flash.txt", co2flash );
+  writeTableToFile( "testThermalProdWell_pvtliquid.txt", pvtLiquid );
+  writeTableToFile( "testThermalProdWell_pvtgas.txt", pvtGas );
   ::testing::InitGoogleTest( &argc, argv );
   g_commandLineOptions = *geos::basicSetup( argc, argv );
   int const result = RUN_ALL_TESTS();
   geos::basicCleanup();
-  removeFile( "co2flash.txt" );
-  removeFile( "pvtliquid.txt" );
-  removeFile( "pvtgas.txt" );
+  removeFile( "testThermalProdWell_co2flash.txt" );
+  removeFile( "testThermalProdWell_pvtliquid.txt" );
+  removeFile( "testThermalProdWell_pvtgas.txt" );
 
   return result;
 }

--- a/src/coreComponents/integrationTests/wellsTests/testThermalReservoirCompositionalMultiphaseMSWells.cpp
+++ b/src/coreComponents/integrationTests/wellsTests/testThermalReservoirCompositionalMultiphaseMSWells.cpp
@@ -229,8 +229,8 @@ char const * xmlInput =
       phaseNames="{ gas, water }"
       componentNames="{ co2, water }"
       componentMolarWeight="{ 44e-3, 18e-3 }"
-      phasePVTParaFiles="{ pvtgas.txt, pvtliquid.txt }"
-      flashModelParaFile="co2flash.txt"/>
+      phasePVTParaFiles="{ testThermalReservoirCompositionalMultiphaseMSWells_pvtgas.txt, testThermalReservoirCompositionalMultiphaseMSWells_pvtliquid.txt }"
+      flashModelParaFile="testThermalReservoirCompositionalMultiphaseMSWells_co2flash.txt"/>
 
     <BrooksCoreyRelativePermeability
       name="relperm"
@@ -873,16 +873,16 @@ TEST_F( CompositionalMultiphaseReservoirSolverTest, jacobianNumericalCheck_Press
 #endif
 int main( int argc, char * * argv )
 {
-  writeTableToFile( "co2flash.txt", co2flash );
-  writeTableToFile( "pvtliquid.txt", pvtLiquid );
-  writeTableToFile( "pvtgas.txt", pvtGas );
+  writeTableToFile( "testThermalReservoirCompositionalMultiphaseMSWells_co2flash.txt", co2flash );
+  writeTableToFile( "testThermalReservoirCompositionalMultiphaseMSWells_pvtliquid.txt", pvtLiquid );
+  writeTableToFile( "testThermalReservoirCompositionalMultiphaseMSWells_pvtgas.txt", pvtGas );
   ::testing::InitGoogleTest( &argc, argv );
   g_commandLineOptions = *geos::basicSetup( argc, argv );
   int const result = RUN_ALL_TESTS();
   geos::basicCleanup();
-  removeFile( "co2flash.txt" );
-  removeFile( "pvtliquid.txt" );
-  removeFile( "pvtgas.txt" );
+  removeFile( "testThermalReservoirCompositionalMultiphaseMSWells_co2flash.txt" );
+  removeFile( "testThermalReservoirCompositionalMultiphaseMSWells_pvtliquid.txt" );
+  removeFile( "testThermalReservoirCompositionalMultiphaseMSWells_pvtgas.txt" );
 
   return result;
 }

--- a/src/coreComponents/integrationTests/wellsTests/testThermalReservoirCompositionalMultiphaseSSWells.cpp
+++ b/src/coreComponents/integrationTests/wellsTests/testThermalReservoirCompositionalMultiphaseSSWells.cpp
@@ -230,8 +230,8 @@ char const * xmlInput =
       phaseNames="{ gas, water }"
       componentNames="{ co2, water }"
       componentMolarWeight="{ 44e-3, 18e-3 }"
-      phasePVTParaFiles="{ pvtgas.txt, pvtliquid.txt }"
-      flashModelParaFile="co2flash.txt"/>
+      phasePVTParaFiles="{ testThermalReservoirCompositionalMultiphaseSSWells_pvtgas.txt, testThermalReservoirCompositionalMultiphaseSSWells_pvtliquid.txt }"
+      flashModelParaFile="testThermalReservoirCompositionalMultiphaseSSWells_co2flash.txt"/>
 
     <BrooksCoreyRelativePermeability
       name="relperm"
@@ -847,16 +847,16 @@ TEST_F( CompositionalMultiphaseReservoirSolverTest, jacobianNumericalCheck_Press
 #endif
 int main( int argc, char * * argv )
 {
-  writeTableToFile( "co2flash.txt", co2flash );
-  writeTableToFile( "pvtliquid.txt", pvtLiquid );
-  writeTableToFile( "pvtgas.txt", pvtGas );
+  writeTableToFile( "testThermalReservoirCompositionalMultiphaseSSWells_co2flash.txt", co2flash );
+  writeTableToFile( "testThermalReservoirCompositionalMultiphaseSSWells_pvtliquid.txt", pvtLiquid );
+  writeTableToFile( "testThermalReservoirCompositionalMultiphaseSSWells_pvtgas.txt", pvtGas );
   ::testing::InitGoogleTest( &argc, argv );
   g_commandLineOptions = *geos::basicSetup( argc, argv );
   int const result = RUN_ALL_TESTS();
   geos::basicCleanup();
-  removeFile( "co2flash.txt" );
-  removeFile( "pvtliquid.txt" );
-  removeFile( "pvtgas.txt" );
+  removeFile( "testThermalReservoirCompositionalMultiphaseSSWells_co2flash.txt" );
+  removeFile( "testThermalReservoirCompositionalMultiphaseSSWells_pvtliquid.txt" );
+  removeFile( "testThermalReservoirCompositionalMultiphaseSSWells_pvtgas.txt" );
 
   return result;
 }

--- a/src/docs/sphinx/developerGuide/Contributing/UnitTests.rst
+++ b/src/docs/sphinx/developerGuide/Contributing/UnitTests.rst
@@ -38,3 +38,22 @@ Often times it makes sense to write a unit test that is meant to be run with mul
                  NUM_MPI_TASKS ${NUMBER_OF_MPI_TASKS} )
 
 With this addition ``make test`` or calling ``ctest`` directly will run ``testWithMPI`` via something analogous to ``mpirun -n NUMBER_OF_MPI_TASKS testWithMPI``.
+
+Parallel CTest Execution
+------------------------
+Generated build-system test targets run CTest in parallel by default. GEOS sets
+``CMAKE_CTEST_ARGUMENTS`` to pass ``--parallel`` to CTest unless the host-config
+or CMake command line defines ``CMAKE_CTEST_ARGUMENTS`` explicitly. CTest chooses
+the default parallel level and uses the ``PROCESSORS`` property from
+``NUM_MPI_TASKS`` tests when scheduling MPI tests with serial tests.
+
+The default can be changed when configuring GEOS:
+
+::
+
+  -DGEOS_CTEST_PARALLEL_LEVEL=OFF
+  -DGEOS_CTEST_PARALLEL_LEVEL=8
+
+``OFF`` keeps the generated ``test`` and ``build_test`` targets serial. A
+nonnegative integer is passed as ``ctest --parallel <N>``. Developers can still
+call ``ctest -j <N>`` directly from the build directory for one-off runs.


### PR DESCRIPTION
GEOS ATS starts each integrated test through an independent Open MPI
launcher. For serial tests, each launcher applied its default binding
policy independently and selected the first available core. As a result,
many concurrent one-rank tests could all be pinned to the same core on
the streak2-32core runner despite ATS accounting for 32 available slots.

Verify that the integrated-test launcher is Open MPI and disable its
hwloc binding policy before invoking geos_ats.sh. This leaves each rank
unbound within the container's available CPU set so the Linux scheduler
can use all available cores. Enable Open MPI binding reports so the
effective placement remains visible in retained ATS logs.

Also:

- validate that NPROC is a positive integer;
- use NPROC for the ATS per-node and maximum process capacities;
- authorize root execution through the Open MPI environment variables;
- set OMP_NUM_THREADS=1 to prevent each parallel test from creating an
  additional OpenMP thread pool;
- run CI unit tests with CTest parallel scheduling.

Add GEOS_CTEST_PARALLEL_LEVEL to control parallel CTest execution:

- AUTO, the default, lets CTest determine the parallel worker count;
- OFF disables parallel scheduling;
- a nonnegative integer passes an explicit worker count to CTest.

Preserve an explicitly supplied CMAKE_CTEST_ARGUMENTS value and use the
resulting arguments for both the generated build_test target and CI test
execution.

Set the CTest PROCESSORS property from NUM_MPI_TASKS so parallel CTest
accounts for the full rank count of MPI tests instead of treating every
test as a single scheduling slot.

Parallel execution exposed tests that created and removed identically
named PVT table files from shared working directories. Give the affected
constitutive and wells test executables unique scratch filenames, and
give the BlackOil fixture a unique temporary directory. Include the
newer thermal-estimator well tests, which have the same shared-file
behavior but were not present in the original EarthFlowAI change.

This removes Open MPI's forced first-core binding for independent ATS
launchers. It intentionally does not provide exclusive core allocation;
the operating system remains responsible for scheduling unbound ranks
within the runner's available CPU set.

**stats:
on rocky gcc13 (cpu), unit tests went from `397 s` to `71 s`
integratedTests go from `43m` missing some tests, to `18m` with all tests re-enabled.** 